### PR TITLE
[OpenQASM]: Properly detect zero step in const ranges

### DIFF
--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -4589,8 +4589,8 @@ impl Lowerer {
         // The spec says that the step cannot be zero, so we push an error in that case.
         // <https://openqasm.com/language/types.html#register-concatenation-and-slicing>
         if let Some(Some(step)) = &step {
-            if let semantic::ExprKind::Lit(semantic::LiteralKind::Int(val)) = &*step.kind {
-                if *val == 0 {
+            if let Some(semantic::LiteralKind::Int(val)) = step.get_const_value() {
+                if val == 0 {
                     self.push_semantic_error(SemanticErrorKind::ZeroStepInRange(range.span));
                     return None;
                 }

--- a/source/compiler/qsc_qasm/src/semantic/types/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/types/tests.rs
@@ -39,6 +39,23 @@ fn sliced_type_has_right_dimensions() {
 }
 
 #[test]
+fn zero_sized_slice_has_right_dimensions() {
+    let source = "
+        array[bool, 5, 1, 2] arr_1;
+        array[bool, 3, 1, 2] arr_2 = arr_1[1:3];
+    ";
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        mutable arr_1 = [[[false, false]], [[false, false]], [[false, false]], [[false, false]], [[false, false]]];
+        mutable arr_2 = arr_1[1..3];
+    "#]],
+    );
+}
+
+#[test]
 fn bigint_output_is_initially_zero_l() {
     let source = "
         input uint[128] input_var;

--- a/source/compiler/qsc_qasm/src/semantic/types/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/types/tests.rs
@@ -39,23 +39,6 @@ fn sliced_type_has_right_dimensions() {
 }
 
 #[test]
-fn zero_sized_slice_has_right_dimensions() {
-    let source = "
-        array[bool, 5, 1, 2] arr_1;
-        array[bool, 3, 1, 2] arr_2 = arr_1[1:3];
-    ";
-
-    check_qasm_to_qsharp(
-        source,
-        &expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        mutable arr_1 = [[[false, false]], [[false, false]], [[false, false]], [[false, false]], [[false, false]]];
-        mutable arr_2 = arr_1[1..3];
-    "#]],
-    );
-}
-
-#[test]
 fn bigint_output_is_initially_zero_l() {
     let source = "
         input uint[128] input_var;

--- a/source/compiler/qsc_qasm/src/tests/expression/indexed.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/indexed.rs
@@ -442,3 +442,26 @@ fn positive_index_out_of_bounds_errors() {
         "#]],
     );
 }
+
+#[test]
+fn const_zero_step_errors() {
+    let source = r#"
+        const bit[4] a = "1010";
+        const bit b = a[:"0":];
+    "#;
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.ZeroStepInRange
+
+              x range step cannot be zero
+               ,-[Test.qasm:3:25]
+             2 |         const bit[4] a = "1010";
+             3 |         const bit b = a[:"0":];
+               :                         ^^^^^
+             4 |     
+               `----
+        "#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/source/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -171,3 +171,12 @@ fn fuzz_2669() {
     let source = "gphase(1E1000);";
     compile_qasm_best_effort(source);
 }
+
+/// We weren't detecting that the step of a range was zero if it was
+/// something other than a literal int. For example, a literal zero
+/// bitstring wasn't been detected.
+#[test]
+fn fuzz_2702() {
+    let source = r#""0"[0:"0":0]"#;
+    compile_qasm_best_effort(source);
+}


### PR DESCRIPTION
We were trying to detect if a step in a const range was zero by manually inspecting the `step` expression before being const evaluated. This only works if the `step` expr is the `0` literal, but it won't work if it is a const-expression evaluating to zero. This PR changes that logic to check the `step` value after being const-evaluated.

Fixes #2702