### PR TITLE
Fix try-except block in qiskit sample

### DIFF
--- a/samples/python_interop/qiskit.ipynb
+++ b/samples/python_interop/qiskit.ipynb
@@ -275,9 +275,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "from qsharp.interop.qiskit import QasmError\n",
+        "\n",
         "try:\n",
         "    backend.qir(qc, target_profile=TargetProfile.Base)\n",
-        "except QSharpError as e:\n",
+        "except QasmError as e:\n",
         "    print(e)"
       ]
     },


### PR DESCRIPTION
The qiskit sample notebook was handling a `QasmError` as a `QSharpError` in a try-except block. This PR fixes that.