### PR TITLE
Use dependencies on local libraries in library tests

### DIFF
--- a/build.py
+++ b/build.py
@@ -444,7 +444,7 @@ def run_python_integration_tests(cwd, interpreter):
         cwd,
         os.path.join(root_dir, "library", "arithmetic", "test"),
     ]
-    command_args = [interpreter, "-m", "pytest", *paths]
+    command_args = [interpreter, "-m", "pytest", *paths, "-s"]
     subprocess.run(command_args, check=True, text=True, cwd=cwd)
 
 

--- a/build.py
+++ b/build.py
@@ -444,7 +444,7 @@ def run_python_integration_tests(cwd, interpreter):
         cwd,
         os.path.join(root_dir, "library", "arithmetic", "test"),
     ]
-    command_args = [interpreter, "-m", "pytest", *paths, "-s"]
+    command_args = [interpreter, "-m", "pytest", *paths]
     subprocess.run(command_args, check=True, text=True, cwd=cwd)
 
 

--- a/source/qdk_package/tests-integration/test_libraries.py
+++ b/source/qdk_package/tests-integration/test_libraries.py
@@ -1,3 +1,5 @@
+import json
+import os
 from pathlib import Path
 
 import pytest
@@ -5,7 +7,43 @@ from qdk import Context
 from qdk.test_utils import run_tests
 
 # Directory with all Q# libraries.
-_LIB_DIR = str(Path(__file__).resolve().parents[3] / "library")
+_LIB_PATH = Path(__file__).resolve().parents[3] / "library"
+
+
+def patch_dependencies(manifest_path: Path) -> None:
+    """Patches dependencies in given Q# manifest to depend on local version of QDK 
+    libraries instead of the ones on GitHub.
+
+    Applies only to libraries in microsoft/qdk/library.
+    """
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    updated = False
+
+    for dependency in manifest.get("dependencies", {}).values():
+        github = dependency.get("github")
+        if not isinstance(github, dict):
+            continue
+
+        owner = github.get("owner")
+        repo = github.get("repo")
+        library_path = github.get("path")
+        if (
+            isinstance(owner, str)
+            and owner.lower() == "microsoft"
+            and isinstance(repo, str)
+            and repo.lower() == "qdk"
+            and isinstance(library_path, str)
+        ):
+            library_name = Path(library_path).name
+            dependency.clear()
+            dependency["path"] = str(_LIB_PATH / library_name)
+            updated = True
+            print(f"AAAA patched dep {library_name} in {manifest_path}")
+
+    if updated:
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
 
 
 @pytest.mark.parametrize(
@@ -20,12 +58,14 @@ _LIB_DIR = str(Path(__file__).resolve().parents[3] / "library")
     ],
 )
 def test_library(library_name: str):
-    run_tests(context=Context(project_root=f"{_LIB_DIR}/{library_name}"))
+    if os.environ.get("CI") is not None:
+        patch_dependencies(_LIB_PATH / library_name / "qsharp.json")
+    run_tests(context=Context(project_root=f"{_LIB_PATH}/{library_name}"))
 
 
 # Use this test case for library development.
 # Run with:
 # pytest source/qdk_package/tests-integration/test_libraries.py::test_single -s
 def test_single():
-    ctx = Context(project_root=f"{_LIB_DIR}/table_lookup")
+    ctx = Context(project_root=f"{_LIB_PATH}/table_lookup")
     run_tests(context=ctx, verbose=3, regex="TestLookupMatchesStd")

--- a/source/qdk_package/tests-integration/test_libraries.py
+++ b/source/qdk_package/tests-integration/test_libraries.py
@@ -11,10 +11,8 @@ _LIB_PATH = Path(__file__).resolve().parents[3] / "library"
 
 
 def patch_dependencies(manifest_path: Path) -> None:
-    """Patches dependencies in given Q# manifest to depend on local version of QDK 
+    """Patches dependencies in given Q# manifest to depend on local version of QDK
     libraries instead of the ones on GitHub.
-
-    Applies only to libraries in microsoft/qdk/library.
     """
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     updated = False

--- a/source/qdk_package/tests-integration/test_libraries.py
+++ b/source/qdk_package/tests-integration/test_libraries.py
@@ -38,7 +38,6 @@ def patch_dependencies(manifest_path: Path) -> None:
             dependency.clear()
             dependency["path"] = str(_LIB_PATH / library_name)
             updated = True
-            print(f"AAAA patched dep {library_name} in {manifest_path}")
 
     if updated:
         manifest_path.write_text(


### PR DESCRIPTION
* Patches `qsharp.json` to depend on local library (via `path`) rather than on the same library on GitHub (via `github`).
* This fixes integration test failure that we get after updating dependencies to next version but before creating a tag for that version.
* Other benefits:
  * We don't need to make requests to GitHub while running integration tests (these requests sometimes fail).
  * We now test all libraries with latest version of their dependencies, so if there is a change that breaks integration between 2 libraries, we will discover it immediately and not after next release.
* We can't statically update libraries to depend on local paths because (1) these paths depend on environment, (2) this will make libraries unusable if user downloads the library separately, as dependencies would become invalid.