### PR TITLE
Support emission of locally constant arrays with dynamic contents

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -5773,6 +5773,332 @@ fn operand_continue_in_controlled_call_skips_consumer_and_following_statement_in
 }
 
 #[test]
+fn array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed_emits_locally_constant_array()
+ {
+    let source = indoc::indoc! {r#"
+        namespace Test {
+            function ValueAt(arr : Int[], idx : Int) : Int {
+                arr[idx]
+            }
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                let arr = [if M(q) == One { 1 } else { 0 }, if M(q) == One { 1 } else { 0 }];
+                ValueAt(arr, if M(q) == One { 1 } else { 0 })
+            }
+        }
+    "#};
+
+    let qir = compile_source_to_qir(source, Profile::Adaptive.into());
+    expect![[r#"
+        @0 = internal constant [4 x i8] c"0_i\00"
+
+        define i64 @ENTRYPOINT__main() #0 {
+        block_0:
+          %var_2 = alloca i64
+          %var_5 = alloca i64
+          %var_8 = alloca i64
+          %var_9 = alloca [2 x i64]
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          %var_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+          br i1 %var_0, label %block_1, label %block_2
+        block_1:
+          store i64 1, ptr %var_2
+          br label %block_3
+        block_2:
+          store i64 0, ptr %var_2
+          br label %block_3
+        block_3:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+          %var_3 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+          br i1 %var_3, label %block_4, label %block_5
+        block_4:
+          store i64 1, ptr %var_5
+          br label %block_6
+        block_5:
+          store i64 0, ptr %var_5
+          br label %block_6
+        block_6:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
+          %var_6 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+          br i1 %var_6, label %block_7, label %block_8
+        block_7:
+          store i64 1, ptr %var_8
+          br label %block_9
+        block_8:
+          store i64 0, ptr %var_8
+          br label %block_9
+        block_9:
+          %var_14 = load i64, ptr %var_2
+          %var_15 = load i64, ptr %var_5
+          %var_9_0 = getelementptr [2 x i64], ptr %var_9, i64 0, i64 0
+          store i64 %var_14, ptr %var_9_0
+          %var_9_1 = getelementptr [2 x i64], ptr %var_9, i64 0, i64 1
+          store i64 %var_15, ptr %var_9_1
+          %var_17 = load i64, ptr %var_8
+          %var_10 = getelementptr i64, ptr %var_9, i64 %var_17
+          %var_18 = load i64, ptr %var_10
+          call void @__quantum__rt__int_record_output(i64 %var_18, ptr @0)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__initialize(ptr)
+
+        declare void @__quantum__qis__m__body(ptr, ptr) #1
+
+        declare i1 @__quantum__rt__read_result(ptr)
+
+        declare void @__quantum__rt__int_record_output(i64, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="3" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+        !8 = !{i32 1, !"ir_functions", i1 true}
+    "#]].assert_eq(&qir);
+}
+
+#[test]
+fn array_with_dynamic_contents_passed_as_argument_with_static_index_does_not_emit_locally_constant_array()
+ {
+    let source = indoc::indoc! {r#"
+        namespace Test {
+            function ValueAt(arr : Int[], idx : Int) : Int {
+                arr[idx]
+            }
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                let arr = [if M(q) == One { 1 } else { 0 }, if M(q) == One { 1 } else { 0 }];
+                ValueAt(arr, 0)
+            }
+        }
+    "#};
+
+    let qir = compile_source_to_qir(source, Profile::Adaptive.into());
+    expect![[r#"
+        @0 = internal constant [4 x i8] c"0_i\00"
+
+        define i64 @ENTRYPOINT__main() #0 {
+        block_0:
+          %var_2 = alloca i64
+          %var_5 = alloca i64
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          %var_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+          br i1 %var_0, label %block_1, label %block_2
+        block_1:
+          store i64 1, ptr %var_2
+          br label %block_3
+        block_2:
+          store i64 0, ptr %var_2
+          br label %block_3
+        block_3:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+          %var_3 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+          br i1 %var_3, label %block_4, label %block_5
+        block_4:
+          store i64 1, ptr %var_5
+          br label %block_6
+        block_5:
+          store i64 0, ptr %var_5
+          br label %block_6
+        block_6:
+          %var_8 = load i64, ptr %var_2
+          call void @__quantum__rt__int_record_output(i64 %var_8, ptr @0)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__initialize(ptr)
+
+        declare void @__quantum__qis__m__body(ptr, ptr) #1
+
+        declare i1 @__quantum__rt__read_result(ptr)
+
+        declare void @__quantum__rt__int_record_output(i64, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="2" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+        !8 = !{i32 1, !"ir_functions", i1 true}
+    "#]].assert_eq(&qir);
+}
+
+#[test]
+fn nested_array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed_emits_multiple_locally_constant_array()
+ {
+    let source = indoc::indoc! {r#"
+        namespace Test {
+            function ValueAt(arr : Int[][], idx : Int) : Int[] {
+                [arr[0][idx], arr[1][idx]]
+            }
+            @EntryPoint()
+            operation Main() : Int[] {
+                use q = Qubit();
+                let arr = [[if M(q) == One { 1 } else { 0 }, if M(q) == One { 1 } else { 0 }],
+                    [if M(q) == One { 1 } else { 0 }, if M(q) == One { 1 } else { 0 }, if M(q) == One { 1 } else { 0 }]];
+                ValueAt(arr, if M(q) == One { 1 } else { 0 })
+            }
+        }
+    "#};
+
+    let qir = compile_source_to_qir(source, Profile::Adaptive.into());
+    expect![[r#"
+        @0 = internal constant [4 x i8] c"0_a\00"
+        @1 = internal constant [6 x i8] c"1_a0i\00"
+        @2 = internal constant [6 x i8] c"2_a1i\00"
+
+        define i64 @ENTRYPOINT__main() #0 {
+        block_0:
+          %var_2 = alloca i64
+          %var_5 = alloca i64
+          %var_8 = alloca i64
+          %var_11 = alloca i64
+          %var_14 = alloca i64
+          %var_17 = alloca i64
+          %var_18 = alloca [2 x i64]
+          %var_19 = alloca [3 x i64]
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          %var_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+          br i1 %var_0, label %block_1, label %block_2
+        block_1:
+          store i64 1, ptr %var_2
+          br label %block_3
+        block_2:
+          store i64 0, ptr %var_2
+          br label %block_3
+        block_3:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+          %var_3 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+          br i1 %var_3, label %block_4, label %block_5
+        block_4:
+          store i64 1, ptr %var_5
+          br label %block_6
+        block_5:
+          store i64 0, ptr %var_5
+          br label %block_6
+        block_6:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
+          %var_6 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+          br i1 %var_6, label %block_7, label %block_8
+        block_7:
+          store i64 1, ptr %var_8
+          br label %block_9
+        block_8:
+          store i64 0, ptr %var_8
+          br label %block_9
+        block_9:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 3 to ptr))
+          %var_9 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 3 to ptr))
+          br i1 %var_9, label %block_10, label %block_11
+        block_10:
+          store i64 1, ptr %var_11
+          br label %block_12
+        block_11:
+          store i64 0, ptr %var_11
+          br label %block_12
+        block_12:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 4 to ptr))
+          %var_12 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 4 to ptr))
+          br i1 %var_12, label %block_13, label %block_14
+        block_13:
+          store i64 1, ptr %var_14
+          br label %block_15
+        block_14:
+          store i64 0, ptr %var_14
+          br label %block_15
+        block_15:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 5 to ptr))
+          %var_15 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 5 to ptr))
+          br i1 %var_15, label %block_16, label %block_17
+        block_16:
+          store i64 1, ptr %var_17
+          br label %block_18
+        block_17:
+          store i64 0, ptr %var_17
+          br label %block_18
+        block_18:
+          %var_28 = load i64, ptr %var_2
+          %var_29 = load i64, ptr %var_5
+          %var_18_0 = getelementptr [2 x i64], ptr %var_18, i64 0, i64 0
+          store i64 %var_28, ptr %var_18_0
+          %var_18_1 = getelementptr [2 x i64], ptr %var_18, i64 0, i64 1
+          store i64 %var_29, ptr %var_18_1
+          %var_31 = load i64, ptr %var_8
+          %var_32 = load i64, ptr %var_11
+          %var_33 = load i64, ptr %var_14
+          %var_19_0 = getelementptr [3 x i64], ptr %var_19, i64 0, i64 0
+          store i64 %var_31, ptr %var_19_0
+          %var_19_1 = getelementptr [3 x i64], ptr %var_19, i64 0, i64 1
+          store i64 %var_32, ptr %var_19_1
+          %var_19_2 = getelementptr [3 x i64], ptr %var_19, i64 0, i64 2
+          store i64 %var_33, ptr %var_19_2
+          %var_35 = load i64, ptr %var_17
+          %var_20 = getelementptr i64, ptr %var_18, i64 %var_35
+          %var_36 = load i64, ptr %var_20
+          %var_21 = getelementptr i64, ptr %var_19, i64 %var_35
+          %var_37 = load i64, ptr %var_21
+          call void @__quantum__rt__array_record_output(i64 2, ptr @0)
+          call void @__quantum__rt__int_record_output(i64 %var_36, ptr @1)
+          call void @__quantum__rt__int_record_output(i64 %var_37, ptr @2)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__initialize(ptr)
+
+        declare void @__quantum__qis__m__body(ptr, ptr) #1
+
+        declare i1 @__quantum__rt__read_result(ptr)
+
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+
+        declare void @__quantum__rt__int_record_output(i64, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="6" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+        !8 = !{i32 1, !"ir_functions", i1 true}
+    "#]].assert_eq(&qir);
+}
+
+#[test]
 fn foreign_table_lookup_callable_generates_qir() {
     let source = indoc::indoc! {r#"
         operation Invoke() : Unit {

--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -5779,10 +5779,7 @@ fn foreign_table_lookup_callable_generates_qir() {
             use address = Qubit[1];
             use output = Qubit[1];
             Std.TableLookup.Select([[false], [true]], address, output);
-
-            // Adjoint of Select does not work until support for static sized, dynamic content arrays is added.
-            // See related issue: https://github.com/microsoft/qdk/issues/3388
-            // Adjoint Std.TableLookup.Select([[false], [true]], address, output);
+            Adjoint Std.TableLookup.Select([[false], [true]], address, output);
         }
     "#};
     for profile in [Profile::AdaptiveRI, Profile::AdaptiveRIF, Profile::Adaptive] {

--- a/source/compiler/qsc_circuit/src/rir_to_circuit.rs
+++ b/source/compiler/qsc_circuit/src/rir_to_circuit.rs
@@ -423,6 +423,7 @@ fn process_variables(
             store_expr_in_variable(&mut state.variables, *variable, expr)?;
         }
         instruction @ (Instruction::Store(..)
+        | Instruction::StoreArray(..)
         | Instruction::BitwiseNot(..)
         | Instruction::Alloca(..)
         | Instruction::Load(..)

--- a/source/compiler/qsc_codegen/src/qir/v1.rs
+++ b/source/compiler/qsc_codegen/src/qir/v1.rs
@@ -221,7 +221,9 @@ impl ToQir<String> for rir::Instruction {
             rir::Instruction::Srem(lhs, rhs, variable) => {
                 binop_to_qir("srem", lhs, rhs, *variable, program)
             }
-            rir::Instruction::Store(_, _) => unimplemented!("store should be removed by pass"),
+            rir::Instruction::Store(_, _) | rir::Instruction::StoreArray(_, _) => {
+                unimplemented!("store should be removed by pass")
+            }
             rir::Instruction::Sub(lhs, rhs, variable) => {
                 binop_to_qir("sub", lhs, rhs, *variable, program)
             }

--- a/source/compiler/qsc_codegen/src/qir/v2.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2.rs
@@ -308,6 +308,7 @@ fn store_array_to_qir(
     let var_ty = get_variable_ty(variable);
     let mut qir = String::new();
     let var_str = ToQir::<String>::to_qir(&variable.variable_id, program);
+    let final_operand_idx = operands.len() - 1;
     for (i, operand) in operands.iter().enumerate() {
         let temp_var = format!("{var_str}_{i}");
         writeln!(
@@ -321,6 +322,9 @@ fn store_array_to_qir(
             ToQir::<String>::to_qir(operand, program)
         )
         .expect("writing to string should succeed");
+        if i != final_operand_idx {
+            writeln!(qir).expect("writing to string should succeed");
+        }
     }
     qir
 }

--- a/source/compiler/qsc_codegen/src/qir/v2.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2.rs
@@ -228,6 +228,9 @@ impl ToQir<String> for rir::Instruction {
             rir::Instruction::Store(operand, variable) => {
                 store_to_qir(*operand, *variable, program)
             }
+            rir::Instruction::StoreArray(operands, variable) => {
+                store_array_to_qir(operands, *variable, program)
+            }
             rir::Instruction::Sub(lhs, rhs, variable) => {
                 binop_to_qir("sub", lhs, rhs, *variable, program)
             }
@@ -289,6 +292,37 @@ fn store_to_qir(operand: rir::Operand, variable: rir::Variable, program: &rir::P
         get_value_as_str(&operand, program),
         ToQir::<String>::to_qir(&variable.variable_id, program)
     )
+}
+
+fn store_array_to_qir(
+    operands: &[rir::Operand],
+    variable: rir::Variable,
+    program: &rir::Program,
+) -> String {
+    // Since SSA variables cannot be used in array literals, we cannot store the whole
+    // array into the alloca'ed space in one instruction. Instead, iterate through the array
+    // and create temporary variables for each memory location via getelementptr, then store
+    // the corresponding value into the array.
+    // This expands the single `StoreArray` instruction into 2N instructions, where N is the
+    // number of elements in the array.
+    let var_ty = get_variable_ty(variable);
+    let mut qir = String::new();
+    let var_str = ToQir::<String>::to_qir(&variable.variable_id, program);
+    for (i, operand) in operands.iter().enumerate() {
+        let temp_var = format!("{var_str}_{i}");
+        writeln!(
+            qir,
+            "  {temp_var} = getelementptr {var_ty}, ptr {var_str}, i64 0, i64 {i}"
+        )
+        .expect("writing to string should succeed");
+        write!(
+            qir,
+            "  store {}, ptr {temp_var}",
+            ToQir::<String>::to_qir(operand, program)
+        )
+        .expect("writing to string should succeed");
+    }
+    qir
 }
 
 fn load_to_qir(var_from: rir::Variable, var_to: rir::Variable, program: &rir::Program) -> String {

--- a/source/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/source/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -10,7 +10,7 @@ use qsc_fir::fir::{LocalItemId, LocalVarId, PackageId};
 use qsc_rca::{ComputeKind, RuntimeFeatureFlags, ValueKind};
 use qsc_rir::rir::{BlockId, Literal, VariableId};
 use rustc_hash::FxHashMap;
-use std::collections::hash_map::Entry;
+use std::{collections::hash_map::Entry, rc::Rc};
 
 use crate::{ScopeDbgContext, is_static_value};
 
@@ -24,7 +24,7 @@ pub struct EvaluationContext {
 impl EvaluationContext {
     /// Creates a new evaluation context.
     pub fn new(package_id: PackageId, initial_block: BlockId) -> Self {
-        let entry_callable_scope = Scope::new(package_id, None, Vec::new(), None);
+        let entry_callable_scope = Scope::new(package_id, None, Vec::new(), None, Vec::new());
         Self {
             active_blocks: vec![BlockNode {
                 id: initial_block,
@@ -118,6 +118,9 @@ pub struct Scope {
     active_block_count: usize,
     /// Debug context, used for generating debug metadata.
     pub(crate) dbg_context: ScopeDbgContext,
+    /// Any locally constant arrays associated with this scope, along with the variable ID
+    /// they are assigned (which happens after the scope is created).
+    pub(crate) arrays: Vec<(Rc<Vec<Value>>, Option<VariableId>)>,
 }
 
 impl Scope {
@@ -127,6 +130,7 @@ impl Scope {
         callable: Option<(LocalItemId, FunctorApp)>,
         args: Vec<Arg>,
         ctls_arg: Option<Arg>,
+        arrays: Vec<Rc<Vec<Value>>>,
     ) -> Self {
         // Create the environment for the classical evaluator.
         // A default classical evaluator environment is created with one scope. However, we need to push an additional
@@ -184,6 +188,7 @@ impl Scope {
             hybrid_vars,
             static_vars: FxHashMap::default(),
             dbg_context: ScopeDbgContext::default(),
+            arrays: arrays.into_iter().map(|array| (array, None)).collect(),
         }
     }
 

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -59,7 +59,7 @@ pub use qsc_rir::{
     },
 };
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::{collections::hash_map::Entry, rc::Rc, result::Result};
+use std::{collections::hash_map::Entry, mem::take, rc::Rc, result::Result};
 use thiserror::Error;
 
 /// Partially evaluates a program with the specified entry expression.
@@ -215,6 +215,10 @@ struct PartialEvaluator<'a> {
     config: PartialEvalConfig,
     dbg_context: DbgContext,
 }
+
+// The resolved arguments of a callable invocation, including the resolved argument values, the optional
+// resolved control qubits, and any array arguments with dynamic content of type `Value::Var`.
+type ResolvedArguments = (Vec<Arg>, Option<Arg>, Vec<Rc<Vec<Value>>>);
 
 #[derive(Clone, Copy)]
 pub struct PartialEvalConfig {
@@ -1592,7 +1596,7 @@ impl<'a> PartialEvaluator<'a> {
             );
             None
         };
-        let (args, ctls_arg) = self.resolve_args(
+        let (args, ctls_arg, arrays) = self.resolve_args(
             (store_item_id.package, callable_decl.input).into(),
             args_value.clone(),
             Some(args_span),
@@ -1649,6 +1653,7 @@ impl<'a> PartialEvaluator<'a> {
             Some((store_item_id.item, functor_app)),
             args,
             ctls_arg,
+            arrays,
         );
 
         self.check_unresolved_call_capabilities(call_expr_id, callee_expr_id, &call_scope)?;
@@ -1788,7 +1793,7 @@ impl<'a> PartialEvaluator<'a> {
             panic!("global call to intrinsic function not supported");
         };
 
-        let (args, ctls_arg) = self.resolve_args(
+        let (args, ctls_arg, arrays) = self.resolve_args(
             (store_item_id.package, callable_decl.input).into(),
             args,
             None,
@@ -1800,6 +1805,7 @@ impl<'a> PartialEvaluator<'a> {
             Some((store_item_id.item, FunctorApp::default())),
             args,
             ctls_arg,
+            arrays,
         );
 
         // We generate instructions differently depending on whether we are calling an intrinsic or a specialization
@@ -2017,7 +2023,7 @@ impl<'a> PartialEvaluator<'a> {
         let callable_id = self.get_or_insert_callable(callable);
 
         // Resolve the call arguments, create the call instruction and insert it to the current block.
-        let (args, ctls_arg) = self
+        let (args, ctls_arg, _) = self
             .resolve_args(
                 (store_item_id.package, callable_decl.input).into(),
                 args_value,
@@ -2070,6 +2076,39 @@ impl<'a> PartialEvaluator<'a> {
         spec_decl: &SpecDecl,
     ) -> Result<Value, Error> {
         self.eval_context.push_scope(call_scope);
+
+        // Some arguments may include arrays with dynamic content, which we want to allow later instructions to index into.
+        // To support this, we treat these as locally constant arrays and emit an RIR instruction to store their contents into a new
+        // variable. Later instructions can then refer to this argument array based on it's Rc pointer and emit index instructions
+        // with dynamic indices into that array. We know this is safe for arrays passed as arguments because they are read-only
+        // by definition.
+        let mut local_constant_arrays = take(&mut self.eval_context.get_current_scope_mut().arrays);
+        for (array, var_id) in &mut local_constant_arrays {
+            let new_var_id = self.resource_manager.next_var();
+            *var_id = Some(new_var_id);
+            let operands = array
+                .iter()
+                .map(|value| self.map_eval_value_to_rir_operand(value))
+                .collect::<Vec<_>>();
+            let rir::Ty::Prim(elem_ty) = operands
+                .first()
+                .expect("array should have at least one element")
+                .get_type()
+            else {
+                panic!("array element type should be a primitive type");
+            };
+            self.get_current_rir_block_mut()
+                .0
+                .push(Instruction::StoreArray(
+                    operands,
+                    rir::Variable {
+                        variable_id: new_var_id,
+                        ty: rir::Ty::Array(array.len(), elem_ty),
+                    },
+                ));
+        }
+        self.eval_context.get_current_scope_mut().arrays = local_constant_arrays;
+
         let block_value = self.try_eval_block(spec_decl.block)?.into_value();
         let popped_scope = self.eval_context.pop_scope();
         assert!(
@@ -2414,6 +2453,7 @@ impl<'a> PartialEvaluator<'a> {
             Some((store_item_id.item, functor_app)),
             body_args,
             None,
+            Vec::new(),
         );
         self.eval_context.push_block_node(BlockNode {
             id: body_block_id,
@@ -3757,7 +3797,7 @@ impl<'a> PartialEvaluator<'a> {
         args_span: Option<PackageSpan>,
         ctls: Option<(StorePatId, u8)>,
         fixed_args: Option<Rc<[Value]>>,
-    ) -> Result<(Vec<Arg>, Option<Arg>), Error> {
+    ) -> Result<ResolvedArguments, Error> {
         let mut value = value;
         let ctls_arg = if let Some((ctls_pat_id, ctls_count)) = ctls {
             let mut ctls = vec![];
@@ -3800,15 +3840,23 @@ impl<'a> PartialEvaluator<'a> {
         };
 
         let pat = self.package_store.get_pat(store_pat_id);
-        let args = match &pat.kind {
-            PatKind::Discard => vec![Arg::Discard(value)],
+        let (args, arrays) = match &pat.kind {
+            PatKind::Discard => (vec![Arg::Discard(value)], Vec::new()),
             PatKind::Bind(ident) => {
+                let arrays = if let Value::Array(array) = &value {
+                    // If the value is an array, recursively check if any of the contents are variables, which would
+                    // make the array a dynamic content array, and add them to the list of tracked arrays
+                    // that we want to emit store instructions for.
+                    get_arrays_with_dynamic_content(array)
+                } else {
+                    Vec::new()
+                };
                 let variable = Variable {
                     name: ident.name.clone(),
                     value,
                     span: ident.span,
                 };
-                vec![Arg::Var(ident.id, variable)]
+                (vec![Arg::Var(ident.id, variable)], arrays)
             }
             PatKind::Tuple(pats) => {
                 let values = value.unwrap_tuple();
@@ -3818,10 +3866,11 @@ impl<'a> PartialEvaluator<'a> {
                     "pattern tuple and value tuple have different arity"
                 );
                 let mut args = Vec::new();
+                let mut arrays = Vec::new();
                 let pat_value_tuples = pats.iter().zip(values.to_vec());
                 for (pat_id, value) in pat_value_tuples {
                     // At this point we should no longer have control qubits so pass None.
-                    let (mut element_args, None) = self
+                    let (mut element_args, None, mut elem_arrays) = self
                         .resolve_args(
                             (store_pat_id.package, *pat_id).into(),
                             value,
@@ -3834,11 +3883,12 @@ impl<'a> PartialEvaluator<'a> {
                         panic!("no control qubits are expected");
                     };
                     args.append(&mut element_args);
+                    arrays.append(&mut elem_arrays);
                 }
-                args
+                (args, arrays)
             }
         };
-        Ok((args, ctls_arg))
+        Ok((args, ctls_arg, arrays))
     }
 
     fn try_eval_block(&mut self, block_id: BlockId) -> Result<EvalControlFlow, Error> {
@@ -4654,22 +4704,59 @@ impl<'a> PartialEvaluator<'a> {
         array_package_span: PackageSpan,
         array_elem_ty: &Ty,
     ) -> Result<Value, Error> {
-        let array_literal = convert_to_array_literal(array, array_package_span, array_elem_ty)?;
-        let array_elem_ty = array_literal.ty;
-
-        let const_array_id = if let Some(idx) = self
-            .program
-            .array_literals
+        let (array_operand, array_elem_ty) = if let Some((_, var_id)) = self
+            .eval_context
+            .get_current_scope()
+            .arrays
             .iter()
-            .position(|a| a == &array_literal)
+            .find(|(stored_array, _)| Rc::ptr_eq(stored_array, array))
         {
-            idx
+            // The array being indexed matches one of the dynamic content arrays tracked as a locally constant argument
+            // to the current scope. This means we can emit an index instruction pointed at the variable created on entry
+            // to the current scope.
+            let Some(var_id) = var_id else {
+                panic!("array variable ID not found in current scope");
+            };
+            let Ok(rir::Ty::Prim(elem_rir_prim_ty)) = map_fir_type_to_rir_type(array_elem_ty)
+            else {
+                return Err(Error::Unexpected(
+                    "array with non-primitive RIR type".to_string(),
+                    array_package_span,
+                ));
+            };
+            (
+                Operand::Variable(rir::Variable {
+                    variable_id: *var_id,
+                    ty: rir::Ty::Array(array.len(), elem_rir_prim_ty),
+                }),
+                elem_rir_prim_ty,
+            )
         } else {
-            let idx = self.program.array_literals.len();
-            self.program.array_literals.push(array_literal);
-            idx
-        };
+            // The array being indexed is not one tracked by the scope, so try to convert it into a static array literal
+            // that will be stored in the global section of the program. If it matches an existing array literal, we can
+            // reuse that identifier, otherwise a new one is generated and stored into the program.
+            // The index instruction will then be emitted to index into that array literal.
+            let array_literal = convert_to_array_literal(array, array_package_span, array_elem_ty)?;
+            let array_elem_ty = array_literal.ty;
 
+            let const_array_id = if let Some(idx) = self
+                .program
+                .array_literals
+                .iter()
+                .position(|a| a == &array_literal)
+            {
+                idx
+            } else {
+                let idx = self.program.array_literals.len();
+                self.program.array_literals.push(array_literal);
+                idx
+            };
+
+            (
+                Operand::Literal(Literal::Array(const_array_id)),
+                array_elem_ty,
+            )
+        };
         let variable_id = self.resource_manager.next_var();
         let rir_variable = rir::Variable {
             variable_id,
@@ -4677,7 +4764,7 @@ impl<'a> PartialEvaluator<'a> {
         };
 
         self.get_current_rir_block_mut().0.push(Instruction::Index(
-            Operand::Literal(Literal::Array(const_array_id)),
+            array_operand,
             Operand::Variable(map_eval_var_to_rir_var(var)),
             rir_variable,
         ));
@@ -5131,4 +5218,24 @@ fn convert_to_array_literal(
         contents: elem_literals,
         ty: elem_rir_prim_ty,
     })
+}
+
+/// Recursively traverse the given array to collect any arrays with dynamic contents (arrays that contain RIR variables),
+/// including the given array itself, and collect any into a flat vector. This allows them to be tracked as locally
+/// constant arrays used as arguments to the current scope.
+fn get_arrays_with_dynamic_content(array: &Rc<Vec<Value>>) -> Vec<Rc<Vec<Value>>> {
+    let mut arrays_with_dynamic_content = Vec::new();
+    for elem in array.iter() {
+        match elem {
+            Value::Array(inner) => {
+                arrays_with_dynamic_content.append(&mut get_arrays_with_dynamic_content(inner));
+            }
+            Value::Var(_) => {
+                arrays_with_dynamic_content.push(Rc::clone(array));
+                break;
+            }
+            _ => {}
+        }
+    }
+    arrays_with_dynamic_content
 }

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -182,12 +182,12 @@ impl<'a> Analyzer<'a> {
 
         let mut default_value_kind = ValueKind::Constant;
         // If we are within a dynamic scope, the compute kind of the assign index expression must be variable and an additional
-        // runtime feature is used to mark the array itself as dynamically sized.
+        // runtime feature is used to mark the array itself as dynamic.
         if !application_instance.active_dynamic_scopes.is_empty() {
             default_value_kind = ValueKind::Variable;
             replacement_value_compute_kind =
                 replacement_value_compute_kind.aggregate(ComputeKind::Dynamic {
-                    runtime_features: RuntimeFeatureFlags::UseOfDynamicallySizedArray,
+                    runtime_features: RuntimeFeatureFlags::UseOfDynamicArray,
                     value_kind: ValueKind::Constant,
                 });
         }
@@ -829,8 +829,10 @@ impl<'a> Analyzer<'a> {
 
         // If the index expression is variable, the value kind of the expression is at least dynamic (possibly variable)
         // and an additional runtime feature is used.
-        if let ComputeKind::Dynamic { value_kind, .. } = &index_expr_compute_kind
-            && *value_kind == ValueKind::Variable
+        if let ComputeKind::Dynamic {
+            value_kind: ValueKind::Variable,
+            ..
+        } = &index_expr_compute_kind
         {
             let mut dynamic_runtime_features = RuntimeFeatureFlags::UseOfDynamicIndex;
 

--- a/source/compiler/qsc_rca/src/tests/arrays.rs
+++ b/source/compiler/qsc_rca/src/tests/arrays.rs
@@ -375,7 +375,7 @@ fn check_rca_for_mutable_array_assign_index_in_dynamic_context() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -400,7 +400,7 @@ fn check_rca_for_mutable_array_assign_index_dynamic_content_in_dynamic_context()
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicArray | QubitAllocation)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -425,7 +425,7 @@ fn check_rca_for_mutable_array_assign_index_dynamic_nested_array_content_in_dyna
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicArray | QubitAllocation)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rir/src/passes/insert_alloca_load.rs
+++ b/source/compiler/qsc_rir/src/passes/insert_alloca_load.rs
@@ -89,6 +89,27 @@ fn add_alloca_load_to_block(
                 *next_var_id = next_var_id.successor();
                 continue;
             }
+            Instruction::StoreArray(operands, var) => {
+                vars_to_alloca.insert(var.variable_id, *var);
+                let new_operands = operands
+                    .iter()
+                    .map(|operand| {
+                        map_or_load_operand(
+                            operand,
+                            &mut var_map,
+                            &mut block.0,
+                            next_var_id,
+                            should_load_operand(operand, vars_to_alloca),
+                        )
+                    })
+                    .collect();
+                block.0.push(Instruction::StoreArray(new_operands, *var));
+                // Drop the cached load for this variable so a later read in this
+                // block reloads the freshly stored value instead of a stale one.
+                var_map.remove(&var.variable_id);
+                *next_var_id = next_var_id.successor();
+                continue;
+            }
 
             // Replace any arguments with the new values of stored variables.
             Instruction::Call(_, args, _, _) => {

--- a/source/compiler/qsc_rir/src/passes/prune_unneeded_stores.rs
+++ b/source/compiler/qsc_rir/src/passes/prune_unneeded_stores.rs
@@ -99,6 +99,7 @@ fn process_callable(program: &mut Program, callable_id: CallableId) {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn check_var_usage(
     program: &mut Program,
     block_id: crate::rir::BlockId,
@@ -112,6 +113,14 @@ fn check_var_usage(
             Instruction::Store(operand, variable) => {
                 if let crate::rir::Operand::Variable(var) = operand {
                     used_vars.insert(var.variable_id);
+                }
+                stored_vars.insert(variable.variable_id);
+            }
+            Instruction::StoreArray(operands, variable) => {
+                for operand in operands {
+                    if let crate::rir::Operand::Variable(var) = operand {
+                        used_vars.insert(var.variable_id);
+                    }
                 }
                 stored_vars.insert(variable.variable_id);
             }

--- a/source/compiler/qsc_rir/src/passes/ssa_check.rs
+++ b/source/compiler/qsc_rir/src/passes/ssa_check.rs
@@ -252,7 +252,10 @@ fn get_variable_uses(program: &Program) -> IndexMap<VariableId, Vec<(BlockId, us
                     panic!("Unexpected Store at {block_id:?}, instruction {idx}")
                 }
 
-                Instruction::Alloca(..) | Instruction::Load(..) | Instruction::Index(..) => {
+                Instruction::StoreArray(..)
+                | Instruction::Alloca(..)
+                | Instruction::Load(..)
+                | Instruction::Index(..) => {
                     panic!("Unexpected advanced instruction at {block_id:?}, instruction {idx}")
                 }
             }

--- a/source/compiler/qsc_rir/src/passes/type_check.rs
+++ b/source/compiler/qsc_rir/src/passes/type_check.rs
@@ -81,6 +81,24 @@ fn check_instr_types(program: &Program, instr: &Instruction) {
             assert_eq!(index.get_type(), Ty::Prim(Prim::Integer));
         }
 
+        Instruction::StoreArray(operands, var) => {
+            let Ty::Array(size, elem_ty) = &var.ty else {
+                panic!("expected variable to be of array type");
+            };
+            assert_eq!(
+                operands.len(),
+                *size,
+                "expected number of operands to match array size"
+            );
+            for opr in operands {
+                assert_eq!(
+                    opr.get_type(),
+                    Ty::Prim(*elem_ty),
+                    "expected operand type to match array element type"
+                );
+            }
+        }
+
         Instruction::Convert(_, _)
         | Instruction::Jump(_)
         | Instruction::Alloca(..)

--- a/source/compiler/qsc_rir/src/rir.rs
+++ b/source/compiler/qsc_rir/src/rir.rs
@@ -376,6 +376,7 @@ impl Display for FcmpConditionCode {
 #[derive(Clone, Debug)]
 pub enum Instruction {
     Store(Operand, Variable),
+    StoreArray(Vec<Operand>, Variable),
     Call(
         CallableId,
         Vec<Operand>,
@@ -432,6 +433,9 @@ impl Display for Instruction {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self {
             Self::Store(value, variable) => write_unary_instruction(f, "Store", value, *variable)?,
+            Self::StoreArray(value, variable) => {
+                write_store_array_instruction(f, value, *variable)?;
+            }
             Self::Jump(block_id) => write!(f, "Jump({})", block_id.0)?,
             Self::Call(callable_id, args, variable, metadata) => {
                 write_call(f, *callable_id, args, *variable, metadata.as_deref())?;
@@ -784,6 +788,23 @@ impl PartialEq for ArrayLiteral {
     fn eq(&self, other: &Self) -> bool {
         self.ty == other.ty && self.contents == other.contents
     }
+}
+
+fn write_store_array_instruction(
+    f: &mut Formatter,
+    value: &[Operand],
+    variable: Variable,
+) -> fmt::Result {
+    let mut indent = set_indentation(indented(f), 0);
+    write!(indent, "{variable} = StoreArray [")?;
+    for (index, operand) in value.iter().enumerate() {
+        write!(indent, "{operand}")?;
+        if index != value.len() - 1 {
+            write!(indent, ", ")?;
+        }
+    }
+    write!(indent, "]")?;
+    Ok(())
 }
 
 fn write_binary_instruction(

--- a/source/compiler/qsc_rir/src/utils.rs
+++ b/source/compiler/qsc_rir/src/utils.rs
@@ -110,6 +110,7 @@ pub fn get_variable_assignments(program: &Program) -> IndexMap<VariableId, (Bloc
                     assignments.insert(var.variable_id, (block_id, idx));
                 }
                 Instruction::Store(_, var)
+                | Instruction::StoreArray(_, var)
                 | Instruction::Alloca(var)
                 | Instruction::Load(_, var)
                 | Instruction::Index(_, _, var) => {
@@ -152,6 +153,18 @@ pub(crate) fn map_variable_use_in_block(
                     // this operand corresponds to at this point in the block. This makes the new variable respect a point-in-time
                     // copy of the operand.
                     var_map.insert(var.variable_id, operand.mapped(var_map));
+                    continue;
+                }
+            }
+            Instruction::StoreArray(operand, var) => {
+                if var_stor_to_keep.contains(&var.variable_id) {
+                    // Only keep stores to variables that are in the set to keep.
+                    *operand = operand
+                        .iter()
+                        .map(|op| op.mapped(var_map))
+                        .collect::<Vec<_>>();
+                } else {
+                    // Otherwise drop the store array by continuing the loop.
                     continue;
                 }
             }


### PR DESCRIPTION
This change adds additional handling in partial eval for arrays on entry to a new scope during function calls. Specificaly, any arguments that are arrays are recursively checked for contents that are `Value::Var` which indicates that the contents of the array are dynamic at runtime. However, since Q# callable arguments are read-only, these arrays can be treated as "locally constant" and emitted as stored values on scope entry. This then allows later instructions that might need to refer to those arrays (for now, just index instructions) to use those stored values in the same manner that globally constant arrays are used from the data section of the program. Since the existing RIR passes are already capable of eliminating unused store instructions, these stored arrays only persist into the final emitted program when they are actually needed for program functionality. Notably, this unblocks the emission of `Adjoint Std.TableLookup.Select` callable when using the `Adaptive` profile.