### PR TITLE
Fix vendored file checks and Windows OpenQASM paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,17 @@ env:
   RUST_TOOLCHAIN_COMPONENTS: rustfmt clippy
 
 jobs:
+  vendor-sync:
+    name: Check vendored files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Check vendored file provenance
+        run: python source/qdk_openqasm/vendor-sync/check_vendor_sync.py
+
   format:
     name: Format
     runs-on: ubuntu-latest
@@ -213,6 +224,7 @@ jobs:
     name: Status Check
     needs:
       [
+        vendor-sync,
         format,
         clippy,
         web-check,

--- a/build.py
+++ b/build.py
@@ -329,20 +329,24 @@ if npm_install_needed:
     step_end()
 
 if args.check:
-    # step_start("Checking vendored file provenance")
-    # # Stdlib only, so it runs on the ambient interpreter without a venv.
-    # subprocess.run(
-    #     [
-    #         sys.executable,
-    #         os.path.join(
-    #             root_dir, "source", "qdk_openqasm", "vendor-sync", "check_vendor_sync.py"
-    #         ),
-    #     ],
-    #     check=True,
-    #     text=True,
-    #     cwd=root_dir,
-    # )
-    # step_end()
+    step_start("Checking vendored file provenance")
+    # Stdlib only, so it runs on the ambient interpreter without a venv.
+    subprocess.run(
+        [
+            sys.executable,
+            os.path.join(
+                root_dir,
+                "source",
+                "qdk_openqasm",
+                "vendor-sync",
+                "check_vendor_sync.py",
+            ),
+        ],
+        check=True,
+        text=True,
+        cwd=root_dir,
+    )
+    step_end()
 
     step_start("Running eslint and prettier checks")
     try:

--- a/source/qdk_openqasm/src/parser.rs
+++ b/source/qdk_openqasm/src/parser.rs
@@ -413,6 +413,12 @@ fn resolve_path(base: &Path, path: &Path) -> miette::Result<PathBuf> {
     Ok(normalized)
 }
 
+/// Converts a platform-native path into a logical source resolver path.
+/// Logical paths always use forward slashes so resolver keys are portable.
+fn logical_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
 /// Parse a QASM file and return the parse result using the provided resolver.
 /// Returns `Err` if the resolver cannot resolve the file.
 /// Returns `Ok` otherwise. Any parse errors will be included in the result.
@@ -434,7 +440,7 @@ where
         let target_path = Path::new(path.as_ref());
 
         match resolve_path(parent_dir, target_path) {
-            Ok(resolved_path) => Arc::from(resolved_path.display().to_string()),
+            Ok(resolved_path) => Arc::from(logical_path(&resolved_path)),
             Err(_) => path.clone(),
         }
     } else {

--- a/source/qdk_openqasm/src/parser/tests.rs
+++ b/source/qdk_openqasm/src/parser/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use crate::io::InMemorySourceResolver;
 use crate::io::SourceResolver;
@@ -10,7 +10,7 @@ use crate::tests::assert_panics_with;
 
 use super::ast::StmtKind;
 use super::parse_source;
-use super::{ParseResult, SourceStatus};
+use super::{ParseResult, SourceStatus, logical_path};
 use miette::Report;
 
 use super::prim::FinalSep;
@@ -401,6 +401,14 @@ include "uri.inc";"#;
             .resolve("https://example.test/uri.inc")
             .map(|file| file.id),
         Some(files[2].id)
+    );
+}
+
+#[test]
+fn logical_paths_use_forward_slashes() {
+    assert_eq!(
+        logical_path(Path::new(r"root\nested\file.inc")),
+        "root/nested/file.inc"
     );
 }
 

--- a/source/qdk_openqasm/src/source.rs
+++ b/source/qdk_openqasm/src/source.rs
@@ -15,7 +15,7 @@
 mod line_column;
 
 pub use crate::vendor::source::{
-    Source, SourceContents, SourceMap, SourceName, longest_common_prefix,
+    Source, SourceContents, SourceMap, SourceName, longest_common_folder_prefix,
 };
 pub use line_column::{
     Position, PositionEncoding, PositionError, Range, byte_offset, position_at, range_from_span,

--- a/source/qdk_openqasm/src/vendor/source.rs
+++ b/source/qdk_openqasm/src/vendor/source.rs
@@ -43,7 +43,7 @@ impl SourceMap {
         // Each source has a name, which is a string. The project root dir is calculated as the
         // common prefix of all of the sources.
         // Calculate the common prefix.
-        let common_prefix: String = longest_common_prefix(
+        let common_prefix: String = longest_common_folder_prefix(
             &offset_sources
                 .iter()
                 .map(|source| source.name.as_ref())
@@ -165,7 +165,7 @@ pub type SourceContents = Arc<str>;
 /// because returned slices end only after an ASCII path separator or at the end
 /// of the first source name.
 #[must_use]
-pub fn longest_common_prefix<'a>(strs: &'a [&'a str]) -> &'a str {
+pub fn longest_common_folder_prefix<'a>(strs: &'a [&'a str]) -> &'a str {
     // The fold below has nothing to disagree with a lone name, so it would hand
     // back that whole name, file component included, instead of a prefix.
     if strs.len() == 1 {

--- a/source/qdk_openqasm/src/vendor/source/tests.rs
+++ b/source/qdk_openqasm/src/vendor/source/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::{SourceMap, longest_common_prefix};
+use super::{SourceMap, longest_common_folder_prefix};
 
 #[test]
 fn longest_common_prefix_preserves_separator_behavior() {
@@ -30,7 +30,7 @@ fn longest_common_prefix_preserves_separator_behavior() {
     ];
 
     for (sources, expected) in cases {
-        assert_eq!(longest_common_prefix(sources), expected);
+        assert_eq!(longest_common_folder_prefix(sources), expected);
     }
 }
 
@@ -52,7 +52,7 @@ fn longest_common_prefix_truncates_at_the_last_separator_of_either_kind() {
     ];
 
     for (sources, expected) in cases {
-        assert_eq!(longest_common_prefix(sources), expected);
+        assert_eq!(longest_common_folder_prefix(sources), expected);
     }
 }
 
@@ -69,7 +69,7 @@ fn longest_common_prefix_handles_multibyte_boundaries() {
     ];
 
     for (sources, expected) in cases {
-        assert_eq!(longest_common_prefix(sources), expected);
+        assert_eq!(longest_common_folder_prefix(sources), expected);
     }
 }
 

--- a/source/qdk_openqasm/vendor-sync/README.md
+++ b/source/qdk_openqasm/vendor-sync/README.md
@@ -55,9 +55,9 @@ internal:
   published, because nothing here has a package to qualify a span with and the
   type would invite a meaning it does not have.
 - `qdk_openqasm::source` publishes `Source`, `SourceContents`, `SourceMap`,
-  `SourceName`, and `longest_common_prefix` from the vendored file. The rest of
-  that module is the crate's own: the `line_column` coordinate types have no
-  vendored origin and nothing here governs them.
+  `SourceName`, and `longest_common_folder_prefix` from the vendored file. The
+  rest of that module is the crate's own: the `line_column` coordinate types have
+  no vendored origin and nothing here governs them.
 - `qdk_openqasm::error::SourceSnapshotSourceCode` comes from the forked `error`
   module.
 

--- a/source/qdk_openqasm/vendor-sync/check_vendor_sync.py
+++ b/source/qdk_openqasm/vendor-sync/check_vendor_sync.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 MANIFEST = Path(__file__).resolve().parent / "manifest.json"
-REGENERATE = "source/qdk_openqasm/vendor-sync/copy_vendored.py"
+REGENERATE = "python3 source/qdk_openqasm/vendor-sync/copy_vendored.py"
 
 
 def sha256(path: Path) -> str:
@@ -79,7 +79,7 @@ def check_fork(pair: dict) -> str | None:
         f"    this file is a deliberate fork, so nothing is copied automatically: "
         f"{pair['divergence']}\n"
         "    read the origin's change, port it by hand if it applies, then re-pin "
-        "with `check_vendor_sync.py --update`"
+        "with `python3 source/qdk_openqasm/vendor-sync/check_vendor_sync.py --update`"
     )
 
 

--- a/source/qdk_openqasm/vendor-sync/copy_vendored.py
+++ b/source/qdk_openqasm/vendor-sync/copy_vendored.py
@@ -43,7 +43,7 @@ def select(pairs: list[dict], name: str | None) -> list[dict]:
             f"{name} is a fork, not a copy, so there is nothing to copy from the "
             f"origin: {pair['divergence']}\n"
             "Port the origin's change by hand, then re-pin with "
-            "`check_vendor_sync.py --update`."
+            "`python3 source/qdk_openqasm/vendor-sync/check_vendor_sync.py --update`."
         )
     return [pair]
 


### PR DESCRIPTION

- Added a dedicated PR vendor-sync CI job and re-enabled the `build.py`
- Synchronized both stale vendored source files and updated the renamed public re-export
- Corrected repair commands to include python3 and full script paths
- Normalized resolver paths to forward slashes, fixing Windows alias resolution, with regression coverage