### PR TITLE
Fix calculated compute properties for callables invoked from `parallel` exprs

### DIFF
--- a/source/compiler/qsc/benches/rca.rs
+++ b/source/compiler/qsc/benches/rca.rs
@@ -104,8 +104,7 @@ impl CompilationContext {
 
         // Clear the compute properties of the open package.
         let open_package_id = map_hir_package_to_fir(self.compiler.package_id());
-        let package_compute_properties = compute_properties.get_mut(open_package_id);
-        package_compute_properties.clear();
+        compute_properties.clear_package(open_package_id);
 
         // Analyze the open package without re-analyzing the other packages.
         let analyzer = Analyzer::init_with_compute_properties(

--- a/source/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/source/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -24,7 +24,8 @@ pub struct EvaluationContext {
 impl EvaluationContext {
     /// Creates a new evaluation context.
     pub fn new(package_id: PackageId, initial_block: BlockId) -> Self {
-        let entry_callable_scope = Scope::new(package_id, None, Vec::new(), None, Vec::new());
+        let entry_callable_scope =
+            Scope::new(package_id, None, Vec::new(), None, false, Vec::new());
         Self {
             active_blocks: vec![BlockNode {
                 id: initial_block,
@@ -108,6 +109,8 @@ pub struct Scope {
     pub callable: Option<(LocalItemId, FunctorApp)>,
     /// The compute kind of the arguments passed to the callable.
     pub args_compute_kind: Vec<ComputeKind>,
+    /// Whether the callable is being invoked from inside a parallel expression.
+    pub in_parallel: bool,
     /// The classical environment of the callable, which holds values corresponding to local variables.
     pub env: Env,
     /// Map that holds the values of local variables.
@@ -130,6 +133,7 @@ impl Scope {
         callable: Option<(LocalItemId, FunctorApp)>,
         args: Vec<Arg>,
         ctls_arg: Option<Arg>,
+        in_parallel: bool,
         arrays: Vec<Rc<Vec<Value>>>,
     ) -> Self {
         // Create the environment for the classical evaluator.
@@ -183,6 +187,7 @@ impl Scope {
             package_id,
             callable,
             args_compute_kind,
+            in_parallel,
             env,
             active_block_count: 1,
             hybrid_vars,

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -1668,6 +1668,7 @@ impl<'a> PartialEvaluator<'a> {
             Some((store_item_id.item, functor_app)),
             args,
             ctls_arg,
+            self.in_parallel_expr(),
             arrays,
         );
 
@@ -1820,6 +1821,7 @@ impl<'a> PartialEvaluator<'a> {
             Some((store_item_id.item, FunctorApp::default())),
             args,
             ctls_arg,
+            false,
             arrays,
         );
 
@@ -2224,8 +2226,9 @@ impl<'a> PartialEvaluator<'a> {
         store_item_id: StoreItemId,
         functor_app: FunctorApp,
     ) -> bool {
-        let ItemComputeProperties::Callable(callable_compute_properties) =
-            self.compute_properties.get_item(store_item_id)
+        let ItemComputeProperties::Callable(callable_compute_properties) = self
+            .compute_properties
+            .get_item(store_item_id, self.in_parallel_scope())
         else {
             return false;
         };
@@ -2456,6 +2459,7 @@ impl<'a> PartialEvaluator<'a> {
             Some((store_item_id.item, functor_app)),
             body_args,
             None,
+            false,
             Vec::new(),
         );
         self.eval_context.push_block_node(BlockNode {
@@ -3503,7 +3507,9 @@ impl<'a> PartialEvaluator<'a> {
     fn get_expr_compute_kind(&self, expr_id: ExprId) -> ComputeKind {
         let current_package_id = self.get_current_package_id();
         let store_expr_id = StoreExprId::from((current_package_id, expr_id));
-        let expr_generator_set = self.compute_properties.get_expr(store_expr_id);
+        let expr_generator_set = self
+            .compute_properties
+            .get_expr(store_expr_id, self.in_parallel_scope());
         let callable_scope = self.eval_context.get_current_scope();
         expr_generator_set.generate_application_compute_kind(&callable_scope.args_compute_kind)
     }
@@ -3512,7 +3518,7 @@ impl<'a> PartialEvaluator<'a> {
         let current_package_id = self.get_current_package_id();
         let store_expr_id = StoreExprId::from((current_package_id, expr_id));
         self.compute_properties
-            .is_unresolved_callee_expr(store_expr_id)
+            .is_unresolved_callee_expr(store_expr_id, self.in_parallel_scope())
     }
 
     fn get_call_compute_kind(&self, callable_scope: &Scope) -> ComputeKind {
@@ -3523,8 +3529,9 @@ impl<'a> PartialEvaluator<'a> {
                 .expect("callable should be present")
                 .0,
         ));
-        let ItemComputeProperties::Callable(callable_compute_properties) =
-            self.compute_properties.get_item(store_item_id)
+        let ItemComputeProperties::Callable(callable_compute_properties) = self
+            .compute_properties
+            .get_item(store_item_id, self.in_parallel_scope())
         else {
             panic!("item compute properties not found");
         };
@@ -4873,6 +4880,10 @@ impl<'a> PartialEvaluator<'a> {
 
     fn in_parallel_expr(&self) -> bool {
         self.resource_manager.is_delaying_release()
+    }
+
+    fn in_parallel_scope(&self) -> bool {
+        self.eval_context.get_current_scope().in_parallel
     }
 }
 

--- a/source/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck.rs
@@ -63,7 +63,7 @@ pub fn run_rca_pass(
     let compute_properties = analyzer.analyze_all();
     let fir_package = fir_store.get(package_id);
 
-    let package_compute_properties = compute_properties.get(package_id);
+    let package_compute_properties = compute_properties.get(package_id, false);
     let mut errors = check_supported_capabilities(
         fir_package,
         package_compute_properties,

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -139,7 +139,7 @@ impl CompilationContext {
     fn get_package_compute_properties_tuple(&self) -> (&Package, &PackageComputeProperties) {
         (
             self.fir_store.get(self.package_id),
-            self.compute_properties.get(self.package_id),
+            self.compute_properties.get(self.package_id, false),
         )
     }
 }

--- a/source/compiler/qsc_passes/src/lib.rs
+++ b/source/compiler/qsc_passes/src/lib.rs
@@ -316,7 +316,7 @@ pub fn run_rca_for_callable(
     capabilities: TargetCapabilityFlags,
 ) -> Vec<Error> {
     let package = fir_store.get(callable.package);
-    let package_compute_properties = compute_properties.get(callable.package);
+    let package_compute_properties = compute_properties.get(callable.package, false);
     let capabilities_errors = check_supported_capabilities_for_callable(
         package,
         package_compute_properties,

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -448,7 +448,9 @@ impl<'a> Analyzer<'a> {
         // Analyze the specialization to determine its application generator set.
         let callee_id = GlobalSpecId::from((callee.item, callee.functor_app.functor_set_value()));
         self.analyze_spec(callee_id, callable_decl);
-        let application_generator_set = self.package_store_compute_properties.get_spec(callee_id);
+        let application_generator_set = self
+            .package_store_compute_properties
+            .get_spec(callee_id, self.in_parallel_expr);
 
         // We need to split controls and specialization input arguments so we can derive the correct callable
         // application.
@@ -1359,7 +1361,7 @@ impl<'a> Analyzer<'a> {
             GlobalSpecId::from((current_item_context.id, FunctorSetValue::Empty));
         if self
             .package_store_compute_properties
-            .find_specialization(body_specialization_id)
+            .find_specialization(body_specialization_id, self.in_parallel_expr)
             .is_some()
         {
             return;
@@ -1377,8 +1379,11 @@ impl<'a> Analyzer<'a> {
         };
 
         // Insert the generator set in the entry corresponding to the body specialization of the callable.
-        self.package_store_compute_properties
-            .insert_spec(body_specialization_id, application_generator_set);
+        self.package_store_compute_properties.insert_spec(
+            body_specialization_id,
+            application_generator_set,
+            self.in_parallel_expr,
+        );
     }
 
     fn analyze_item(&mut self, item_id: StoreItemId, item: &'a Item) {
@@ -1433,7 +1438,9 @@ impl<'a> Analyzer<'a> {
         assert!(top_level_context.package_id == package_id);
 
         // Save the analysis of the top-level elements to the corresponding package compute properties.
-        let package_compute_properties = self.package_store_compute_properties.get_mut(package_id);
+        let package_compute_properties = self
+            .package_store_compute_properties
+            .get_mut(package_id, self.in_parallel_expr);
         top_level_context
             .builder
             .save_to_package_compute_properties(package_compute_properties, None);
@@ -1447,7 +1454,7 @@ impl<'a> Analyzer<'a> {
         // 2. Performance (avoids redundant analysis of already-complete specs)
         if self
             .package_store_compute_properties
-            .find_specialization(id)
+            .find_specialization(id, self.in_parallel_expr)
             .is_some()
         {
             return;
@@ -1455,8 +1462,6 @@ impl<'a> Analyzer<'a> {
 
         // Push the context of the callable the specialization belongs to.
         self.push_item_context(id.callable);
-        let previous_in_parallel = self.in_parallel_expr;
-        self.in_parallel_expr = false;
         let package = self.package_store.get(id.callable.package);
         let input_params = package.derive_callable_input_params(callable_decl);
         let current_callable_context = self.get_current_item_context_mut();
@@ -1498,7 +1503,6 @@ impl<'a> Analyzer<'a> {
         // Since we are done analyzing the specialization, pop the active item context.
         let popped_item_id = self.pop_item_context();
         assert!(popped_item_id == id.callable);
-        self.in_parallel_expr = previous_in_parallel;
     }
 
     fn analyze_spec_decl(&mut self, decl: &'a SpecDecl, functor_set_value: FunctorSetValue) {
@@ -1507,7 +1511,7 @@ impl<'a> Analyzer<'a> {
         let global_spec_id = GlobalSpecId::from((current_item_context.id, functor_set_value));
         if self
             .package_store_compute_properties
-            .find_specialization(global_spec_id)
+            .find_specialization(global_spec_id, self.in_parallel_expr)
             .is_some()
         {
             return;
@@ -1522,13 +1526,18 @@ impl<'a> Analyzer<'a> {
         assert!(spec_context.functor_set_value == functor_set_value);
 
         // Save the analysis to the corresponding package compute properties.
-        let package_compute_properties = self.package_store_compute_properties.get_mut(package_id);
+        let package_compute_properties = self
+            .package_store_compute_properties
+            .get_mut(package_id, self.in_parallel_expr);
         let application_generator_set = spec_context
             .builder
             .save_to_package_compute_properties(package_compute_properties, Some(decl.block))
             .expect("applications generator set should be some");
-        self.package_store_compute_properties
-            .insert_spec(global_spec_id, application_generator_set);
+        self.package_store_compute_properties.insert_spec(
+            global_spec_id,
+            application_generator_set,
+            self.in_parallel_expr,
+        );
     }
 
     fn bind_compute_kind_to_ident(
@@ -1765,7 +1774,7 @@ impl<'a> Analyzer<'a> {
         for (stmt_id, _stmt) in &package.stmts {
             if self
                 .package_store_compute_properties
-                .find_stmt((package_id, stmt_id).into())
+                .find_stmt((package_id, stmt_id).into(), self.in_parallel_expr)
                 .is_none()
             {
                 unanalyzed_stmts.push(stmt_id);
@@ -1936,6 +1945,7 @@ impl<'a> Analyzer<'a> {
             self.package_store_compute_properties.insert_stmt(
                 (self.get_current_package_id(), stmt_id).into(),
                 default_generator_set.clone(),
+                self.in_parallel_expr,
             );
         }
     }
@@ -2208,9 +2218,10 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
             ItemKind::Ty(_, _) => {
                 // Items that are not callables do not have compute properties by themselves so we just record them as
                 // such in the package store compute properties data structure.
-                self.package_store_compute_properties.insert_item(
+                self.package_store_compute_properties.insert_ty_item(
                     current_item_context.id,
                     InternalItemComputeProperties::NonCallable,
+                    self.in_parallel_expr,
                 );
             }
         }

--- a/source/compiler/qsc_rca/src/invariants.rs
+++ b/source/compiler/qsc_rca/src/invariants.rs
@@ -35,21 +35,21 @@ pub(crate) fn assert_arity_consistency(
 ) {
     for (package_id, package) in store {
         let ownership = collect_ownership(package_id, package);
-        let package_props = props.get(package_id);
-
-        for (block_id, generator) in package_props.blocks.iter() {
-            check_entry(
-                package_id,
-                ElementKey::Block(block_id),
-                generator,
-                &ownership,
-            );
-        }
-        for (stmt_id, generator) in package_props.stmts.iter() {
-            check_entry(package_id, ElementKey::Stmt(stmt_id), generator, &ownership);
-        }
-        for (expr_id, generator) in package_props.exprs.iter() {
-            check_entry(package_id, ElementKey::Expr(expr_id), generator, &ownership);
+        for package_props in [props.get(package_id, false), props.get(package_id, true)] {
+            for (block_id, generator) in package_props.blocks.iter() {
+                check_entry(
+                    package_id,
+                    ElementKey::Block(block_id),
+                    generator,
+                    &ownership,
+                );
+            }
+            for (stmt_id, generator) in package_props.stmts.iter() {
+                check_entry(package_id, ElementKey::Stmt(stmt_id), generator, &ownership);
+            }
+            for (expr_id, generator) in package_props.exprs.iter() {
+                check_entry(package_id, ElementKey::Expr(expr_id), generator, &ownership);
+            }
         }
     }
 }

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -21,10 +21,7 @@ mod scaffolding;
 use bitflags::bitflags;
 use indenter::indented;
 use qsc_data_structures::display::core::set_indentation;
-use qsc_data_structures::{
-    index_map::{IndexMap, Iter},
-    target::TargetCapabilityFlags,
-};
+use qsc_data_structures::{index_map::IndexMap, target::TargetCapabilityFlags};
 use qsc_fir::{
     fir::{
         BlockId, ExprId, LocalItemId, PackageId, StmtId, StoreBlockId, StoreExprId, StoreItemId,
@@ -44,109 +41,106 @@ pub use crate::analyzer::Analyzer;
 /// A trait to look for the compute properties of elements in a package store.
 pub trait ComputePropertiesLookup {
     /// Searches for the application generator set of a block with the specified ID.
-    fn find_block(&self, id: StoreBlockId) -> Option<&ApplicationGeneratorSet>;
+    fn find_block(&self, id: StoreBlockId, parallel: bool) -> Option<&ApplicationGeneratorSet>;
     /// Searches for the application generator set of an expression with the specified ID.
-    fn find_expr(&self, id: StoreExprId) -> Option<&ApplicationGeneratorSet>;
+    fn find_expr(&self, id: StoreExprId, parallel: bool) -> Option<&ApplicationGeneratorSet>;
     /// Searches for the compute properties of an item with the specified ID.
-    fn find_item(&self, id: StoreItemId) -> Option<&ItemComputeProperties>;
+    fn find_item(&self, id: StoreItemId, parallel: bool) -> Option<&ItemComputeProperties>;
     /// Searches for the application generator set of a statement with the specified ID.
-    fn find_stmt(&self, id: StoreStmtId) -> Option<&ApplicationGeneratorSet>;
+    fn find_stmt(&self, id: StoreStmtId, parallel: bool) -> Option<&ApplicationGeneratorSet>;
     /// Gets the application generator set of a block.
-    fn get_block(&self, id: StoreBlockId) -> &ApplicationGeneratorSet;
+    fn get_block(&self, id: StoreBlockId, parallel: bool) -> &ApplicationGeneratorSet;
     /// Gets the application generator set of an expression.
-    fn get_expr(&self, id: StoreExprId) -> &ApplicationGeneratorSet;
+    fn get_expr(&self, id: StoreExprId, parallel: bool) -> &ApplicationGeneratorSet;
     /// Gets the compute properties of an item.
-    fn get_item(&self, id: StoreItemId) -> &ItemComputeProperties;
+    fn get_item(&self, id: StoreItemId, parallel: bool) -> &ItemComputeProperties;
     /// Gets the application generator set of a statement.
-    fn get_stmt(&self, id: StoreStmtId) -> &ApplicationGeneratorSet;
+    fn get_stmt(&self, id: StoreStmtId, parallel: bool) -> &ApplicationGeneratorSet;
 }
 
 /// The compute properties of a package store.
 #[derive(Clone, Debug, Default)]
-pub struct PackageStoreComputeProperties(IndexMap<PackageId, PackageComputeProperties>);
+pub struct PackageStoreComputeProperties {
+    // The compute properties for each package in the store, keyed by package ID.
+    props: IndexMap<PackageId, PackageComputeProperties>,
+    // The alternative compute properties for each package if the callables are invoked
+    // from within a parallel expression, keyed by package ID.
+    parallel_props: IndexMap<PackageId, PackageComputeProperties>,
+}
 
 impl ComputePropertiesLookup for PackageStoreComputeProperties {
-    fn find_block(&self, id: StoreBlockId) -> Option<&ApplicationGeneratorSet> {
-        self.get(id.package).blocks.get(id.block)
+    fn find_block(&self, id: StoreBlockId, parallel: bool) -> Option<&ApplicationGeneratorSet> {
+        self.get(id.package, parallel).blocks.get(id.block)
     }
 
-    fn find_expr(&self, id: StoreExprId) -> Option<&ApplicationGeneratorSet> {
-        self.get(id.package).exprs.get(id.expr)
+    fn find_expr(&self, id: StoreExprId, parallel: bool) -> Option<&ApplicationGeneratorSet> {
+        self.get(id.package, parallel).exprs.get(id.expr)
     }
 
-    fn find_item(&self, id: StoreItemId) -> Option<&ItemComputeProperties> {
-        self.get(id.package).items.get(id.item)
+    fn find_item(&self, id: StoreItemId, parallel: bool) -> Option<&ItemComputeProperties> {
+        self.get(id.package, parallel).items.get(id.item)
     }
 
-    fn find_stmt(&self, id: StoreStmtId) -> Option<&ApplicationGeneratorSet> {
-        self.get(id.package).stmts.get(id.stmt)
+    fn find_stmt(&self, id: StoreStmtId, parallel: bool) -> Option<&ApplicationGeneratorSet> {
+        self.get(id.package, parallel).stmts.get(id.stmt)
     }
 
-    fn get_block(&self, id: StoreBlockId) -> &ApplicationGeneratorSet {
-        self.find_block(id)
+    fn get_block(&self, id: StoreBlockId, parallel: bool) -> &ApplicationGeneratorSet {
+        self.find_block(id, parallel)
             .expect("block compute properties not found")
     }
 
-    fn get_expr(&self, id: StoreExprId) -> &ApplicationGeneratorSet {
-        self.find_expr(id)
+    fn get_expr(&self, id: StoreExprId, parallel: bool) -> &ApplicationGeneratorSet {
+        self.find_expr(id, parallel)
             .expect("expression compute properties not found")
     }
 
-    fn get_item(&self, id: StoreItemId) -> &ItemComputeProperties {
-        self.find_item(id)
+    fn get_item(&self, id: StoreItemId, parallel: bool) -> &ItemComputeProperties {
+        self.find_item(id, parallel)
             .expect("item compute properties not found")
     }
 
-    fn get_stmt(&self, id: StoreStmtId) -> &ApplicationGeneratorSet {
-        self.find_stmt(id)
+    fn get_stmt(&self, id: StoreStmtId, parallel: bool) -> &ApplicationGeneratorSet {
+        self.find_stmt(id, parallel)
             .expect("statement compute properties not found")
-    }
-}
-
-impl<'a> IntoIterator for &'a PackageStoreComputeProperties {
-    type IntoIter = qsc_data_structures::index_map::Iter<'a, PackageId, PackageComputeProperties>;
-    type Item = (PackageId, &'a PackageComputeProperties);
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
     }
 }
 
 impl PackageStoreComputeProperties {
     #[must_use]
-    pub fn get(&self, id: PackageId) -> &PackageComputeProperties {
-        self.0.get(id).expect("package should exist")
+    pub fn get(&self, id: PackageId, parallel: bool) -> &PackageComputeProperties {
+        if parallel {
+            self.parallel_props.get(id).expect("package should exist")
+        } else {
+            self.props.get(id).expect("package should exist")
+        }
     }
 
     #[must_use]
-    pub fn get_mut(&mut self, id: PackageId) -> &mut PackageComputeProperties {
-        self.0.get_mut(id).expect("package should exist")
+    pub fn get_mut(&mut self, id: PackageId, parallel: bool) -> &mut PackageComputeProperties {
+        if parallel {
+            self.parallel_props
+                .get_mut(id)
+                .expect("package should exist")
+        } else {
+            self.props.get_mut(id).expect("package should exist")
+        }
     }
 
-    pub fn insert_block(&mut self, id: StoreBlockId, value: ApplicationGeneratorSet) {
-        self.get_mut(id.package).blocks.insert(id.block, value);
-    }
-
-    pub fn insert_expr(&mut self, id: StoreExprId, value: ApplicationGeneratorSet) {
-        self.get_mut(id.package).exprs.insert(id.expr, value);
-    }
-
-    pub fn insert_item(&mut self, id: StoreItemId, value: ItemComputeProperties) {
-        self.get_mut(id.package).items.insert(id.item, value);
-    }
-
-    pub fn insert_stmt(&mut self, id: StoreStmtId, value: ApplicationGeneratorSet) {
-        self.get_mut(id.package).stmts.insert(id.stmt, value);
-    }
-
-    #[must_use]
-    pub fn iter(&self) -> Iter<'_, PackageId, PackageComputeProperties> {
-        self.0.iter()
+    pub fn clear_package(&mut self, id: PackageId) {
+        self.props
+            .get_mut(id)
+            .expect("package should exist")
+            .clear();
+        self.parallel_props
+            .get_mut(id)
+            .expect("package should exist")
+            .clear();
     }
 
     #[must_use]
-    pub fn is_unresolved_callee_expr(&self, id: StoreExprId) -> bool {
-        self.get(id.package)
+    pub fn is_unresolved_callee_expr(&self, id: StoreExprId, parallel: bool) -> bool {
+        self.get(id.package, parallel)
             .unresolved_callee_exprs
             .contains(&id.expr)
     }

--- a/source/compiler/qsc_rca/src/scaffolding.rs
+++ b/source/compiler/qsc_rca/src/scaffolding.rs
@@ -401,8 +401,12 @@ impl From<SpecializationsComputeProperties> for CallableComputeProperties {
             }
         }
 
+        // If the body is not present, this is likely a callable where only
+        // a non-body specialization is invoked in a parallel expression. We allow
+        // the body to be effectively empty by using default, since only the non-body
+        // specialization compute properties are relevant.
         CallableComputeProperties {
-            body: body.expect("body should exist"),
+            body: body.unwrap_or_default(),
             adj,
             ctl,
             ctl_adj,

--- a/source/compiler/qsc_rca/src/scaffolding.rs
+++ b/source/compiler/qsc_rca/src/scaffolding.rs
@@ -17,14 +17,18 @@ use qsc_fir::{
 
 /// Scaffolding used to build the package store compute properties.
 #[derive(Debug)]
-pub struct InternalPackageStoreComputeProperties(
-    IndexMap<PackageId, InternalPackageComputeProperties>,
-);
+pub struct InternalPackageStoreComputeProperties {
+    // The compute properties for each package in the store, keyed by package ID.
+    props: IndexMap<PackageId, InternalPackageComputeProperties>,
+    // The alternative compute properties for each package if the callables are invoked
+    // from within a parallel expression, keyed by package ID.
+    parallel_props: IndexMap<PackageId, InternalPackageComputeProperties>,
+}
 
 impl From<PackageStoreComputeProperties> for InternalPackageStoreComputeProperties {
     fn from(value: PackageStoreComputeProperties) -> Self {
         let mut scaffolding = IndexMap::<PackageId, InternalPackageComputeProperties>::default();
-        for (package_id, package_compute_properties) in value.0 {
+        for (package_id, package_compute_properties) in value.props {
             let mut items = IndexMap::<LocalItemId, InternalItemComputeProperties>::new();
             for (item_id, item_compute_properties) in package_compute_properties.items {
                 let item_scaffolding = InternalItemComputeProperties::from(item_compute_properties);
@@ -42,8 +46,31 @@ impl From<PackageStoreComputeProperties> for InternalPackageStoreComputeProperti
             };
             scaffolding.insert(package_id, package_compute_properties);
         }
+        let mut parallel_scaffolding =
+            IndexMap::<PackageId, InternalPackageComputeProperties>::default();
+        for (package_id, package_compute_properties) in value.parallel_props {
+            let mut items = IndexMap::<LocalItemId, InternalItemComputeProperties>::new();
+            for (item_id, item_compute_properties) in package_compute_properties.items {
+                let item_scaffolding = InternalItemComputeProperties::from(item_compute_properties);
+                items.insert(item_id, item_scaffolding);
+            }
+            let package_compute_properties = InternalPackageComputeProperties {
+                items,
+                blocks: package_compute_properties.blocks,
+                stmts: package_compute_properties.stmts,
+                exprs: package_compute_properties.exprs,
+                unresolved_callee_exprs: package_compute_properties
+                    .unresolved_callee_exprs
+                    .into_iter()
+                    .collect(),
+            };
+            parallel_scaffolding.insert(package_id, package_compute_properties);
+        }
 
-        Self(scaffolding)
+        Self {
+            props: scaffolding,
+            parallel_props: parallel_scaffolding,
+        }
     }
 }
 
@@ -51,7 +78,7 @@ impl From<InternalPackageStoreComputeProperties> for PackageStoreComputeProperti
     fn from(value: InternalPackageStoreComputeProperties) -> Self {
         let mut package_store_compute_properties =
             IndexMap::<PackageId, PackageComputeProperties>::default();
-        for (package_id, package_scaffolding) in value.0 {
+        for (package_id, package_scaffolding) in value.props {
             let mut items = IndexMap::<LocalItemId, ItemComputeProperties>::new();
             for (item_id, item_scaffolding) in package_scaffolding.items {
                 let item_compute_properties = ItemComputeProperties::from(item_scaffolding);
@@ -70,50 +97,79 @@ impl From<InternalPackageStoreComputeProperties> for PackageStoreComputeProperti
             };
             package_store_compute_properties.insert(package_id, package_compute_properties);
         }
-        Self(package_store_compute_properties)
+        let mut parallel_package_store_compute_properties =
+            IndexMap::<PackageId, PackageComputeProperties>::default();
+        for (package_id, package_scaffolding) in value.parallel_props {
+            let mut items = IndexMap::<LocalItemId, ItemComputeProperties>::new();
+            for (item_id, item_scaffolding) in package_scaffolding.items {
+                let item_compute_properties = ItemComputeProperties::from(item_scaffolding);
+                items.insert(item_id, item_compute_properties);
+            }
+
+            let package_compute_properties = PackageComputeProperties {
+                items,
+                blocks: package_scaffolding.blocks,
+                stmts: package_scaffolding.stmts,
+                exprs: package_scaffolding.exprs,
+                unresolved_callee_exprs: package_scaffolding
+                    .unresolved_callee_exprs
+                    .into_iter()
+                    .collect(),
+            };
+            parallel_package_store_compute_properties
+                .insert(package_id, package_compute_properties);
+        }
+        Self {
+            props: package_store_compute_properties,
+            parallel_props: parallel_package_store_compute_properties,
+        }
     }
 }
 
 impl ComputePropertiesLookup for InternalPackageStoreComputeProperties {
-    fn find_block(&self, id: StoreBlockId) -> Option<&ApplicationGeneratorSet> {
-        self.get(id.package).blocks.get(id.block)
+    fn find_block(&self, id: StoreBlockId, parallel: bool) -> Option<&ApplicationGeneratorSet> {
+        self.get(id.package, parallel).blocks.get(id.block)
     }
 
-    fn find_expr(&self, id: StoreExprId) -> Option<&ApplicationGeneratorSet> {
-        self.get(id.package).exprs.get(id.expr)
+    fn find_expr(&self, id: StoreExprId, parallel: bool) -> Option<&ApplicationGeneratorSet> {
+        self.get(id.package, parallel).exprs.get(id.expr)
     }
 
-    fn find_item(&self, _: StoreItemId) -> Option<&ItemComputeProperties> {
+    fn find_item(&self, _: StoreItemId, _: bool) -> Option<&ItemComputeProperties> {
         unimplemented!()
     }
 
-    fn find_stmt(&self, id: StoreStmtId) -> Option<&ApplicationGeneratorSet> {
-        self.get(id.package).stmts.get(id.stmt)
+    fn find_stmt(&self, id: StoreStmtId, parallel: bool) -> Option<&ApplicationGeneratorSet> {
+        self.get(id.package, parallel).stmts.get(id.stmt)
     }
 
-    fn get_block(&self, id: StoreBlockId) -> &ApplicationGeneratorSet {
-        self.find_block(id)
+    fn get_block(&self, id: StoreBlockId, parallel: bool) -> &ApplicationGeneratorSet {
+        self.find_block(id, parallel)
             .expect("block compute properties should exist")
     }
 
-    fn get_expr(&self, id: StoreExprId) -> &ApplicationGeneratorSet {
-        self.find_expr(id)
+    fn get_expr(&self, id: StoreExprId, parallel: bool) -> &ApplicationGeneratorSet {
+        self.find_expr(id, parallel)
             .expect("expression compute properties should exist")
     }
 
-    fn get_item(&self, _: StoreItemId) -> &ItemComputeProperties {
+    fn get_item(&self, _: StoreItemId, _: bool) -> &ItemComputeProperties {
         unimplemented!()
     }
 
-    fn get_stmt(&self, id: StoreStmtId) -> &ApplicationGeneratorSet {
-        self.find_stmt(id)
+    fn get_stmt(&self, id: StoreStmtId, parallel: bool) -> &ApplicationGeneratorSet {
+        self.find_stmt(id, parallel)
             .expect("statement compute properties should exist")
     }
 }
 
 impl InternalPackageStoreComputeProperties {
-    pub fn find_specialization(&self, id: GlobalSpecId) -> Option<&ApplicationGeneratorSet> {
-        self.get(id.callable.package)
+    pub(crate) fn find_specialization(
+        &self,
+        id: GlobalSpecId,
+        parallel: bool,
+    ) -> Option<&ApplicationGeneratorSet> {
+        self.get(id.callable.package, parallel)
             .items
             .get(id.callable.item)
             .and_then(|item_compute_properties| match item_compute_properties {
@@ -127,45 +183,71 @@ impl InternalPackageStoreComputeProperties {
             })
     }
 
-    pub fn get(&self, id: PackageId) -> &InternalPackageComputeProperties {
-        self.0
-            .get(id)
-            .expect("package compute properties should be present in store")
+    pub(crate) fn get(&self, id: PackageId, parallel: bool) -> &InternalPackageComputeProperties {
+        if parallel {
+            self.parallel_props
+                .get(id)
+                .expect("package compute properties should be present in store")
+        } else {
+            self.props
+                .get(id)
+                .expect("package compute properties should be present in store")
+        }
     }
 
-    pub fn get_mut(&mut self, id: PackageId) -> &mut InternalPackageComputeProperties {
-        self.0
-            .get_mut(id)
-            .expect("package compute properties should be present in store")
+    pub(crate) fn get_mut(
+        &mut self,
+        id: PackageId,
+        parallel: bool,
+    ) -> &mut InternalPackageComputeProperties {
+        if parallel {
+            self.parallel_props
+                .get_mut(id)
+                .expect("package compute properties should be present in store")
+        } else {
+            self.props
+                .get_mut(id)
+                .expect("package compute properties should be present in store")
+        }
     }
 
-    pub fn get_spec(&self, id: GlobalSpecId) -> &ApplicationGeneratorSet {
-        self.find_specialization(id)
+    pub(crate) fn get_spec(&self, id: GlobalSpecId, parallel: bool) -> &ApplicationGeneratorSet {
+        self.find_specialization(id, parallel)
             .expect("specialization should exist")
     }
 
-    pub fn init(package_store: &fir::PackageStore) -> Self {
+    pub(crate) fn init(package_store: &fir::PackageStore) -> Self {
         let mut packages = IndexMap::<PackageId, InternalPackageComputeProperties>::default();
+        let mut parallel_packages =
+            IndexMap::<PackageId, InternalPackageComputeProperties>::default();
         for (package_id, _) in package_store {
             packages.insert(package_id, InternalPackageComputeProperties::default());
+            parallel_packages.insert(package_id, InternalPackageComputeProperties::default());
         }
-        Self(packages)
+        Self {
+            props: packages,
+            parallel_props: parallel_packages,
+        }
     }
 
-    pub fn insert_block(&mut self, id: StoreBlockId, value: ApplicationGeneratorSet) {
-        self.get_mut(id.package).blocks.insert(id.block, value);
+    pub(crate) fn insert_ty_item(
+        &mut self,
+        id: StoreItemId,
+        value: InternalItemComputeProperties,
+        parallel: bool,
+    ) {
+        self.get_mut(id.package, parallel)
+            .items
+            .insert(id.item, value);
     }
 
-    pub fn insert_expr(&mut self, id: StoreExprId, value: ApplicationGeneratorSet) {
-        self.get_mut(id.package).exprs.insert(id.expr, value);
-    }
-
-    pub fn insert_item(&mut self, id: StoreItemId, value: InternalItemComputeProperties) {
-        self.get_mut(id.package).items.insert(id.item, value);
-    }
-
-    pub fn insert_spec(&mut self, id: GlobalSpecId, value: ApplicationGeneratorSet) {
-        let items = &mut self.get_mut(id.callable.package).items;
+    pub(crate) fn insert_spec(
+        &mut self,
+        id: GlobalSpecId,
+        value: ApplicationGeneratorSet,
+        parallel: bool,
+    ) {
+        let items = &mut self.get_mut(id.callable.package, parallel).items;
         if let Some(item_compute_properties) = items.get_mut(id.callable.item) {
             if let InternalItemComputeProperties::Specializations(specializations) =
                 item_compute_properties
@@ -186,8 +268,15 @@ impl InternalPackageStoreComputeProperties {
         }
     }
 
-    pub fn insert_stmt(&mut self, id: StoreStmtId, value: ApplicationGeneratorSet) {
-        self.get_mut(id.package).stmts.insert(id.stmt, value);
+    pub(crate) fn insert_stmt(
+        &mut self,
+        id: StoreStmtId,
+        value: ApplicationGeneratorSet,
+        parallel: bool,
+    ) {
+        self.get_mut(id.package, parallel)
+            .stmts
+            .insert(id.stmt, value);
     }
 }
 

--- a/source/compiler/qsc_rca/src/tests.rs
+++ b/source/compiler/qsc_rca/src/tests.rs
@@ -88,8 +88,7 @@ impl CompilationContext {
         self.compiler.update(increment);
 
         // Clear the compute properties of the package to update.
-        let package_compute_properties = self.compute_properties.get_mut(package_id);
-        package_compute_properties.clear();
+        self.compute_properties.clear_package(package_id);
         let analyzer = Analyzer::init_with_compute_properties(
             &self.fir_store,
             self.capabilities,
@@ -194,7 +193,7 @@ pub fn check_callable_compute_properties(
         .find_callable_id_by_name(callable_name)
         .expect("callable should exist");
 
-    let callable_compute_properties = package_store_compute_properties.get_item(callable_id);
+    let callable_compute_properties = package_store_compute_properties.get_item(callable_id, false);
     expect.assert_eq(&callable_compute_properties.to_string());
 }
 
@@ -203,11 +202,12 @@ pub fn check_last_statement_compute_properties(
     expect: &Expect,
 ) {
     let last_package_id = package_store_compute_properties
+        .props
         .iter()
         .map(|(package_id, _)| package_id)
         .max()
         .expect("at least one package should exist");
-    let package_compute_properties = package_store_compute_properties.get(last_package_id);
+    let package_compute_properties = package_store_compute_properties.get(last_package_id, false);
     let last_statement_id = package_compute_properties
         .stmts
         .iter()

--- a/source/compiler/qsc_rca/src/tests/invariants_strict.rs
+++ b/source/compiler/qsc_rca/src/tests/invariants_strict.rs
@@ -34,7 +34,8 @@ fn body_arity(context: &CompilationContext, callable_name: &str) -> usize {
         .fir_store
         .find_callable_id_by_name(callable_name)
         .unwrap_or_else(|| panic!("callable {callable_name} should exist"));
-    let ItemComputeProperties::Callable(props) = context.get_compute_properties().get_item(id)
+    let ItemComputeProperties::Callable(props) =
+        context.get_compute_properties().get_item(id, false)
     else {
         panic!("{callable_name} should be a callable item");
     };
@@ -269,8 +270,9 @@ fn dynamic_return_pipeline_passes_strict_invariant() {
         .fir_store
         .find_callable_id_by_name("DynReturnStrict")
         .expect("DynReturnStrict should exist after pipeline lowering");
-    let ItemComputeProperties::Callable(props) =
-        context.get_compute_properties().get_item(dyn_return_id)
+    let ItemComputeProperties::Callable(props) = context
+        .get_compute_properties()
+        .get_item(dyn_return_id, false)
     else {
         panic!("DynReturnStrict should be a callable item");
     };

--- a/source/compiler/qsc_rca/src/tests/parallel.rs
+++ b/source/compiler/qsc_rca/src/tests/parallel.rs
@@ -5,6 +5,7 @@ use super::{
     CompilationContext, check_callable_compute_properties, check_last_statement_compute_properties,
 };
 use expect_test::expect;
+use qsc_data_structures::target::Profile;
 
 #[test]
 fn check_rca_for_parallel_expr_with_static_body() {
@@ -424,6 +425,46 @@ fn check_rca_for_parallel_with_dynamic_arg_to_rotation_does_not_branch() {
                         runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | QubitAllocation)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
+                adj: <none>
+                ctl: <none>
+                ctl-adj: <none>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_callable_with_parallel_loop_invoking_stdlib_callable_with_inner_loop() {
+    let mut compilation_context = CompilationContext::new(Profile::Adaptive.into());
+    compilation_context.update(
+        r#"
+        operation ParallelJointMeasure(qs: Qubit[]) : Unit {
+            parallel for i in 0..2..Length(qs)-1 {
+                let _ = MeasureAllZ(qs[i..i+1]);
+            }
+        }
+        "#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_callable_compute_properties(
+        &compilation_context.fir_store,
+        package_store_compute_properties,
+        "ParallelJointMeasure",
+        &expect![[r#"
+            Callable: CallableComputeProperties:
+                body: ApplicationsGeneratorSet:
+                    inherent: Dynamic:
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                        value_kind: Constant
+                    dynamic_param_applications:
+                        [0]: [Parameter Type Array] ArrayParamApplication:
+                            constant_content: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                value_kind: Constant
+                            static_size: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                value_kind: Constant
+                            dynamic_size: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicPauli | UseOfDynamicRange | UseOfDynamicQubit | UseOfDynamicArray | UseOfDynamicallySizedArray | MeasurementWithinDynamicScope | UseOfDynamicIndex | LoopWithDynamicCondition | UseOfDynamicResult | QubitAllocation | UseOfDynamicBranchingInParallelExpr)
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],

--- a/source/compiler/qsc_rca/src/tests/parallel.rs
+++ b/source/compiler/qsc_rca/src/tests/parallel.rs
@@ -470,3 +470,37 @@ fn check_rca_for_callable_with_parallel_loop_invoking_stdlib_callable_with_inner
                 ctl-adj: <none>"#]],
     );
 }
+
+#[test]
+fn check_rca_for_parallel_with_only_call_to_controlled_specialization() {
+    let mut compilation_context = CompilationContext::new(Profile::Adaptive.into());
+    compilation_context.update(
+        r#"
+        operation ParallelControlled(q : Qubit) : Unit {
+            parallel Controlled X([], q);
+        }"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_callable_compute_properties(
+        &compilation_context.fir_store,
+        package_store_compute_properties,
+        "ParallelControlled",
+        &expect![[r#"
+            Callable: CallableComputeProperties:
+                body: ApplicationsGeneratorSet:
+                    inherent: Dynamic:
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                        value_kind: Constant
+                    dynamic_param_applications:
+                        [0]: [Parameter Type Element] ElementParamApplication:
+                            constant: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                value_kind: Constant
+                            variable: Dynamic:
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                value_kind: Constant
+                adj: <none>
+                ctl: <none>
+                ctl-adj: <none>"#]],
+    );
+}


### PR DESCRIPTION
This fixes a bug in how compute proerties were calculated by RCA and queried during Partial Eval when the callable being invoked is inside of a parallel expression. Since parallel expressions force inlining and unrolling, the invoked callable uses different capabilities than what would be computed by default. This avoids computing every callable twice by only inserting into a parallel data structure those specializations that are invoked from within a parallel expr. As a result, code that doesn't use parallel keeps the same behavior, but code that does parallel will compute extra, parallel-specific properties for those callables used within.