### PR TITLE
Fail hint requests on non-exercises

### DIFF
--- a/source/vscode/src/gh-copilot/learningTools.ts
+++ b/source/vscode/src/gh-copilot/learningTools.ts
@@ -221,6 +221,23 @@ export class LearningTools {
     await this.ensureInitialized();
     return this.invoke(() => {
       const r = this.service.getHintContext("chat");
+      // The serialized state attempt to identify the actually active cell,
+      // whereas the hint state is solely based on activity-level progress,
+      // so the two can get out of sync.  Since they should agree when the
+      // user is on an exercise cell and since this tool only makes sense
+      // on exercise cells, report failure to copilot if they disagree.
+      const selectedState = this.serializeState();
+      const hintLocation = r.state.position.location;
+      const selectedLocation = selectedState.position.location;
+      if (
+        hintLocation.courseId !== selectedLocation.courseId ||
+        hintLocation.unitId !== selectedLocation.unitId ||
+        hintLocation.activityId !== selectedLocation.activityId
+      ) {
+        throw new CopilotToolError(
+          "The active cell doesn't appear to be an exercise and only exercise cells have associated hints",
+        );
+      }
       return { result: r.result };
     });
   }

--- a/source/vscode/src/gh-copilot/learningTools.ts
+++ b/source/vscode/src/gh-copilot/learningTools.ts
@@ -221,7 +221,7 @@ export class LearningTools {
     await this.ensureInitialized();
     return this.invoke(() => {
       const r = this.service.getHintContext("chat");
-      // The serialized state attempt to identify the actually active cell,
+      // The serialized state attempts to identify the actually active cell,
       // whereas the hint state is solely based on activity-level progress,
       // so the two can get out of sync.  Since they should agree when the
       // user is on an exercise cell and since this tool only makes sense


### PR DESCRIPTION
There's already a check for this, but it's based on the progress state, rather than the selection state.  Check the selection state as well.  This is pretty tricky to hit in practice: you need the progress state to be an exercise and the selection state to be something else when you explicitly ask copilot for a hint (since there won't be a button).