### PR TITLE
Enable user friendly angles in circuits

### DIFF
--- a/source/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/source/compiler/qsc/src/interpret/circuit_tests.rs
@@ -181,6 +181,47 @@ fn circuit_static(code: &str) -> Circuit {
     )
 }
 
+/// Compiles an OpenQASM program and renders its circuit, mirroring the path the
+/// editor and Python surfaces take for a `.qasm` file.
+fn openqasm_circuit(source: &str) -> String {
+    let capabilities = Profile::Unrestricted.into();
+    let crate::openqasm::CompileRawQasmResult(store, package_id, dependencies, sig, errors, _) =
+        crate::openqasm::parse_and_compile_raw_qasm(
+            source,
+            "test.qasm",
+            Option::<&mut crate::openqasm::io::InMemorySourceResolver>::None,
+            PackageType::Exe,
+        );
+    assert!(errors.is_empty(), "OpenQASM compilation failed: {errors:?}");
+
+    let entry_expr = sig
+        .expect("signature should be present")
+        .create_entry_expr_from_params(String::new());
+
+    let mut interpreter = Interpreter::with_package_store(
+        false,
+        store,
+        package_id,
+        capabilities,
+        LanguageFeatures::default(),
+        &dependencies,
+    )
+    .expect("interpreter creation should succeed");
+
+    interpreter
+        .circuit(
+            CircuitEntryPoint::EntryExpr(entry_expr),
+            CircuitGenerationMethod::ClassicalEval,
+            TracerConfig {
+                group_by_scope: false,
+                source_locations: false,
+                ..default_test_tracer_config()
+            },
+        )
+        .expect("circuit generation should succeed")
+        .to_string()
+}
+
 fn circuit_err(
     code: &str,
     entry: CircuitEntryPoint,
@@ -430,7 +471,52 @@ fn rotation_gate() {
     );
 
     expect![[r#"
-        q_0@test.qs:4:20 ─ Rx(1.5708)@test.qs:5:20 ─
+        q_0@test.qs:4:20 ─ Rx(π / 2)@test.qs:5:20 ──
+    "#]]
+    .assert_eq(&circ);
+}
+
+#[test]
+fn rotation_gate_angles_that_are_not_multiples_of_pi_stay_decimal() {
+    let circ = circuit_without_groups(
+        r"
+            namespace Test {
+                @EntryPoint()
+                operation Main() : Unit {
+                    use q = Qubit();
+                    Rx(0.5, q);
+                    Rz(-1.2345, q);
+                }
+            }
+        ",
+        CircuitEntryPoint::EntryPoint,
+    );
+
+    expect![[r#"
+        q_0@test.qs:4:20 ─ Rx(0.5000)@test.qs:5:20 ── Rz(-1.2345)@test.qs:6:20 ──
+    "#]]
+    .assert_eq(&circ);
+}
+
+#[test]
+fn openqasm_rotation_gate_angles_render_symbolically() {
+    let circ = openqasm_circuit(
+        r#"
+OPENQASM 3.0;
+include "stdgates.inc";
+qubit[4] q;
+rz(pi / 4) q[0];
+rx(2 * pi / 3) q[1];
+ry(pi) q[2];
+rz(0.5) q[3];
+"#,
+    );
+
+    expect![[r#"
+        q_0    ──── Rz(π / 4) ────
+        q_1    ── Rx(2 * π / 3) ──
+        q_2    ────── Ry(π) ──────
+        q_3    ─── Rz(0.5000) ────
     "#]]
     .assert_eq(&circ);
 }
@@ -1901,12 +1987,12 @@ fn grouped_scopes_match_for_apply_operation_power_ca_lambda() {
         [1] Main:
             q_0    ──────── U[2] ────────────────────────────────────────────────────────────────────
                               ┆
-            q_1    ── H ─── U[2] ──────── H ─────── Rz(-0.7854) ─── X ─── Rz(0.7854) ──── X ─────────
+            q_1    ── H ─── U[2] ──────── H ─────── Rz(-π / 4) ──── X ──── Rz(π / 4) ──── X ─────────
                               ┆                                     │                     │
-            q_2    ── H ─── U[2] ─── Rz(-0.7854) ────────────────── ● ─────────────────── ● ──── H ──
+            q_2    ── H ─── U[2] ─── Rz(-π / 4) ─────────────────── ● ─────────────────── ● ──── H ──
 
         [2] U:
-            q_0    ─ Rz(0.5236) ──── X ─── Rz(-0.5236) ─── X ─── Rz(0.5236) ──── X ─── Rz(-0.5236) ─── X ─── Rz(0.5236) ──── X ─── Rz(-0.5236) ─── X ──
+            q_0    ── Rz(π / 6) ──── X ─── Rz(-π / 6) ──── X ──── Rz(π / 6) ──── X ─── Rz(-π / 6) ──── X ──── Rz(π / 6) ──── X ─── Rz(-π / 6) ──── X ──
             q_1    ───────────────── ● ─────────────────── ● ─────────────────── ● ─────────────────── ● ────────────────────┼─────────────────────┼───
             q_2    ───────────────────────────────────────────────────────────────────────────────────────────────────────── ● ─────────────────── ● ──
     "#]]

--- a/source/compiler/qsc_circuit/src/angle_format.rs
+++ b/source/compiler/qsc_circuit/src/angle_format.rs
@@ -49,7 +49,7 @@ pub(crate) fn format_angle(value: f64) -> String {
     if multiple >= 1.0 - RATIO_EPS && (multiple - multiple.round()).abs() < RATIO_EPS {
         let count = multiple.round();
         // A single turn reads better unqualified than as "1 * π".
-        return if count == 1.0 {
+        return if (count - 1.0).abs() < RATIO_EPS {
             format!("{sign}π")
         } else {
             format!("{sign}{count:.0} * π")

--- a/source/compiler/qsc_circuit/src/angle_format.rs
+++ b/source/compiler/qsc_circuit/src/angle_format.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod tests;
+
+use std::f64::consts::PI;
+
+/// Tolerance in radians for matching an angle against a candidate fraction of π.
+const RADIAN_EPS: f64 = 1e-9;
+
+/// Tolerance on the dimensionless ratio `angle / π` used by the whole-multiple rule.
+/// Numerically equal to `RADIAN_EPS`, but it bounds a ratio rather than an angle, so
+/// that rule's effective angular tolerance is this value times π.
+const RATIO_EPS: f64 = 1e-9;
+
+/// Largest numerator and denominator considered for a reduced fraction of π.
+const MAX_FRAC: u32 = 64;
+
+/// Largest denominator considered for a simple `π / d` fraction.
+const MAX_PI_FRAC: u32 = 128;
+
+/// Formats a gate angle for display, preferring a symbolic multiple or fraction
+/// of π and otherwise falling back to four decimal places.
+///
+/// Emitted symbolic forms always use explicit operators (`2 * π / 3`, never
+/// `2π/3`) so they remain valid input to the circuit editor's angle expression
+/// parser and to circuit-to-Q# generation.
+pub(crate) fn format_angle(value: f64) -> String {
+    // NaN and the infinities have no symbolic form, and every test below would
+    // silently misbehave on them.
+    if !value.is_finite() {
+        return format_decimal(value);
+    }
+
+    let magnitude = value.abs();
+    // Collapse anything within tolerance of zero to a bare `0`, before `sign`
+    // below can turn a tiny negative into a signed zero.
+    if magnitude < RADIAN_EPS {
+        return "0".to_string();
+    }
+
+    let sign = if value < 0.0 { "-" } else { "" };
+
+    // Whole multiples of π. The first test rejects a magnitude below π: its ratio
+    // rounds to zero, which would pass the second test and print "0 * π". The
+    // second test is the actual rule, that the ratio is an integer within tolerance.
+    let multiple = magnitude / PI;
+    if multiple >= 1.0 - RATIO_EPS && (multiple - multiple.round()).abs() < RATIO_EPS {
+        let count = multiple.round();
+        // A single turn reads better unqualified than as "1 * π".
+        return if (count - 1.0).abs() < RATIO_EPS {
+            format!("{sign}π")
+        } else {
+            format!("{sign}{count:.0} * π")
+        };
+    }
+
+    // The largest fraction the rules below can produce is 15π/2, so this bound is
+    // conservative; past it only a decimal is possible.
+    if magnitude >= f64::from(MAX_FRAC) * PI {
+        return format_decimal(value);
+    }
+
+    // Simple fractions `π / d`, which allow a larger denominator than the
+    // general reduced fraction below. The three tests are, in order: reject a
+    // magnitude past 2π, whose reciprocal rounds to zero and must not be divided
+    // by; apply the readability ceiling; and confirm the rounded denominator
+    // really does reproduce the value, since rounding alone only gets close.
+    let denominator = (PI / magnitude).round();
+    if denominator >= 1.0
+        && denominator <= f64::from(MAX_PI_FRAC)
+        && (magnitude - PI / denominator).abs() < RADIAN_EPS
+    {
+        return format!("{sign}π / {denominator:.0}");
+    }
+
+    // Reduced fractions `n * π / d`. Numerator 1 and denominator 1 are already
+    // covered above.
+    for d in 2..=MAX_FRAC {
+        // Fractions at this denominator are spaced far wider than the tolerance,
+        // so only the nearest numerator can match.
+        let candidate = (magnitude * f64::from(d) / PI).round();
+        // Below two is a unit fraction, handled above; above the ceiling is out of
+        // range. This also drops the zero candidate a small angle produces.
+        if !(2.0..=f64::from(MAX_FRAC)).contains(&candidate) {
+            continue;
+        }
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // bounded above
+        let n = candidate as u32;
+        // Keep the printed fraction in lowest terms.
+        if gcd(n, d) != 1 {
+            continue;
+        }
+        // Rounding only found the closest candidate; confirm it is the value.
+        if (magnitude - f64::from(n) * PI / f64::from(d)).abs() < RADIAN_EPS {
+            return format!("{sign}{n} * π / {d}");
+        }
+    }
+
+    format_decimal(value)
+}
+
+fn format_decimal(value: f64) -> String {
+    format!("{value:.4}")
+}
+
+fn gcd(mut a: u32, mut b: u32) -> u32 {
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}

--- a/source/compiler/qsc_circuit/src/angle_format.rs
+++ b/source/compiler/qsc_circuit/src/angle_format.rs
@@ -49,7 +49,7 @@ pub(crate) fn format_angle(value: f64) -> String {
     if multiple >= 1.0 - RATIO_EPS && (multiple - multiple.round()).abs() < RATIO_EPS {
         let count = multiple.round();
         // A single turn reads better unqualified than as "1 * π".
-        return if (count - 1.0).abs() < RATIO_EPS {
+        return if count == 1.0 {
             format!("{sign}π")
         } else {
             format!("{sign}{count:.0} * π")

--- a/source/compiler/qsc_circuit/src/angle_format/tests.rs
+++ b/source/compiler/qsc_circuit/src/angle_format/tests.rs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::*;
+
+#[test]
+fn non_finite_falls_back_to_decimal() {
+    assert_eq!(format_angle(f64::NAN), "NaN");
+    assert_eq!(format_angle(f64::INFINITY), "inf");
+    assert_eq!(format_angle(f64::NEG_INFINITY), "-inf");
+}
+
+#[test]
+fn zero_and_near_zero() {
+    assert_eq!(format_angle(0.0), "0");
+    assert_eq!(format_angle(-0.0), "0");
+    assert_eq!(format_angle(1e-12), "0");
+    assert_eq!(format_angle(-1e-12), "0");
+}
+
+#[test]
+fn magnitudes_between_eps_and_pi_eps_do_not_become_a_zero_multiple() {
+    // Without the lower bound on the whole-multiple rule these round to a
+    // multiple of zero and would emit "0 * π".
+    assert_eq!(format_angle(2e-9), "0.0000");
+    assert_eq!(format_angle(3e-9), "0.0000");
+    assert_eq!(format_angle(-2e-9), "-0.0000");
+}
+
+#[test]
+fn whole_multiples_of_pi() {
+    assert_eq!(format_angle(PI), "π");
+    assert_eq!(format_angle(-PI), "-π");
+    assert_eq!(format_angle(2.0 * PI), "2 * π");
+    assert_eq!(format_angle(3.0 * PI), "3 * π");
+    assert_eq!(format_angle(-3.0 * PI), "-3 * π");
+}
+
+#[test]
+fn whole_multiples_are_not_capped_by_the_fraction_ceiling() {
+    assert_eq!(format_angle(20.0 * PI), "20 * π");
+}
+
+#[test]
+fn simple_fractions_of_pi() {
+    assert_eq!(format_angle(PI / 2.0), "π / 2");
+    assert_eq!(format_angle(PI / 3.0), "π / 3");
+    assert_eq!(format_angle(PI / 4.0), "π / 4");
+    assert_eq!(format_angle(PI / 8.0), "π / 8");
+    assert_eq!(format_angle(PI / 99.0), "π / 99");
+}
+
+#[test]
+fn negative_values_are_signed_for_every_symbolic_rule() {
+    assert_eq!(format_angle(-PI / 4.0), "-π / 4");
+    assert_eq!(format_angle(-2.0 * PI / 3.0), "-2 * π / 3");
+    assert_eq!(format_angle(-PI / 6.0), "-π / 6");
+}
+
+#[test]
+fn reduced_fractions_of_pi() {
+    assert_eq!(format_angle(2.0 * PI / 3.0), "2 * π / 3");
+    assert_eq!(format_angle(3.0 * PI / 2.0), "3 * π / 2");
+    assert_eq!(format_angle(7.0 * PI / 8.0), "7 * π / 8");
+    assert_eq!(format_angle(15.0 * PI / 16.0), "15 * π / 16");
+}
+
+#[test]
+fn fractions_are_reported_in_lowest_terms() {
+    // 2/4 and 8/16 both reduce to 1/2, which the simple-fraction rule matches.
+    assert_eq!(format_angle(2.0 * PI / 4.0), "π / 2");
+    assert_eq!(format_angle(8.0 * PI / 16.0), "π / 2");
+    // 6/8 reduces to 3/4.
+    assert_eq!(format_angle(6.0 * PI / 8.0), "3 * π / 4");
+}
+
+#[test]
+fn denominators_beyond_the_simple_fraction_ceiling_fall_back() {
+    assert_eq!(format_angle(PI / 100.0), "0.0314");
+}
+
+#[test]
+fn magnitudes_beyond_the_fraction_ceiling_fall_back() {
+    // Not a whole multiple, and larger than any recognized fraction.
+    assert_eq!(format_angle(16.5 * PI), "51.8363");
+}
+
+#[test]
+fn values_that_are_not_related_to_pi_fall_back() {
+    assert_eq!(format_angle(0.5), "0.5000");
+    assert_eq!(format_angle(1.0), "1.0000");
+    assert_eq!(format_angle(1.2345), "1.2345");
+    assert_eq!(format_angle(-0.3), "-0.3000");
+}
+
+#[test]
+fn tolerance_boundary() {
+    // Inside the tolerance, still recognized.
+    assert_eq!(format_angle(PI / 4.0 + 1e-11), "π / 4");
+    // Outside the tolerance, reported as the decimal it actually is.
+    assert_eq!(format_angle(PI / 4.0 + 1e-6), "0.7854");
+}
+
+#[test]
+fn a_narrow_openqasm_angle_width_falls_back_rather_than_claiming_a_fraction() {
+    // An `angle[8]` holding pi/3 round-trips to this value, which is off by
+    // about 8e-3 and is genuinely not pi/3.
+    let narrow = 1.055_378_782_065_321;
+    assert_eq!(format_angle(narrow), "1.0554");
+}
+
+#[test]
+fn an_unsized_openqasm_angle_round_trip_is_still_recognized() {
+    // The 53-bit fixed-point grid reproduces these within rounding error.
+    let tau = 2.0 * PI;
+    let grid = tau / f64::from(1u32 << 31) / f64::from(1u32 << 22);
+    let quarter_turn = (PI / 4.0 / grid).round() * grid;
+    assert_eq!(format_angle(quarter_turn), "π / 4");
+    let third = (PI / 3.0 / grid).round() * grid;
+    assert_eq!(format_angle(third), "π / 3");
+}
+
+#[test]
+fn wrapped_negative_angle_reports_its_wrapped_value() {
+    // OpenQASM wraps -pi/4 into [0, tau) before the circuit sees it.
+    let wrapped = 2.0 * PI - PI / 4.0;
+    assert_eq!(format_angle(wrapped), "7 * π / 4");
+}
+
+#[test]
+fn no_emitted_form_uses_implicit_multiplication() {
+    // The angle expression parser emits no operator between a number and a
+    // following π, so a digit directly followed by π would be rejected.
+    let samples = [
+        0.0,
+        PI,
+        -PI,
+        2.0 * PI,
+        PI / 2.0,
+        -PI / 4.0,
+        2.0 * PI / 3.0,
+        -15.0 * PI / 16.0,
+        0.5,
+    ];
+    for value in samples {
+        let formatted = format_angle(value);
+        let chars: Vec<char> = formatted.chars().collect();
+        for pair in chars.windows(2) {
+            assert!(
+                !(pair[0].is_ascii_digit() && pair[1] == 'π'),
+                "implicit multiplication in {formatted}"
+            );
+        }
+    }
+}
+
+#[test]
+fn emitted_forms_contain_no_parentheses() {
+    // Every symbolic form is a flat expression; the reciprocal form that would
+    // have needed grouping is deliberately not recognized.
+    for value in [PI, PI / 4.0, 2.0 * PI / 3.0, 3.0 * PI / 2.0] {
+        assert!(!format_angle(value).contains(['(', ')']));
+    }
+}

--- a/source/compiler/qsc_circuit/src/angle_format/tests.rs
+++ b/source/compiler/qsc_circuit/src/angle_format/tests.rs
@@ -76,13 +76,13 @@ fn fractions_are_reported_in_lowest_terms() {
 
 #[test]
 fn denominators_beyond_the_simple_fraction_ceiling_fall_back() {
-    assert_eq!(format_angle(PI / 100.0), "0.0314");
+    assert_eq!(format_angle(PI / 129.0), "0.0244");
 }
 
 #[test]
 fn magnitudes_beyond_the_fraction_ceiling_fall_back() {
     // Not a whole multiple, and larger than any recognized fraction.
-    assert_eq!(format_angle(16.5 * PI), "51.8363");
+    assert_eq!(format_angle(64.5 * PI), "202.6327");
 }
 
 #[test]

--- a/source/compiler/qsc_circuit/src/angle_format/tests.rs
+++ b/source/compiler/qsc_circuit/src/angle_format/tests.rs
@@ -96,9 +96,9 @@ fn values_that_are_not_related_to_pi_fall_back() {
 #[test]
 fn tolerance_boundary() {
     // Inside the tolerance, still recognized.
-    assert_eq!(format_angle(PI / 4.0 + 1e-11), "π / 4");
+    assert_eq!(format_angle(PI / 4.0 + RADIAN_EPS / 100.0), "π / 4");
     // Outside the tolerance, reported as the decimal it actually is.
-    assert_eq!(format_angle(PI / 4.0 + 1e-6), "0.7854");
+    assert_eq!(format_angle(PI / 4.0 + RADIAN_EPS * 1_000.0), "0.7854");
 }
 
 #[test]

--- a/source/compiler/qsc_circuit/src/builder.rs
+++ b/source/compiler/qsc_circuit/src/builder.rs
@@ -5,6 +5,7 @@
 pub(crate) mod tests;
 
 use crate::{
+    angle_format::format_angle,
     circuit::{
         Circuit, ComponentColumn, Ket, Measurement, Metadata, Operation, Qubit, Register,
         SourceLocation, Unitary, operation_list_to_grid,
@@ -73,7 +74,7 @@ impl Tracer for CircuitTracer {
         theta: Option<f64>,
     ) {
         let called_at = LogicalStack::from_evaluator_trace(stack);
-        let display_args: Vec<String> = theta.map(|p| format!("{p:.4}")).into_iter().collect();
+        let display_args: Vec<String> = theta.map(format_angle).into_iter().collect();
         let controls = if self.config.prune_classical_qubits {
             // Any controls that are known to be classically one can be removed, so this
             // will return the updated controls list.

--- a/source/compiler/qsc_circuit/src/circuit_to_qsharp/tests.rs
+++ b/source/compiler/qsc_circuit/src/circuit_to_qsharp/tests.rs
@@ -286,6 +286,72 @@ fn circuit_with_rz_gate() {
 }
 
 #[test]
+fn circuit_with_symbolic_angle_args() {
+    // The forms emitted by `angle_format::format_angle`. Bare integers pick up a
+    // trailing dot, and the π binding is injected once for the whole body.
+    check(
+        r#"
+{
+  "componentGrid": [
+    {
+      "components": [
+        { "kind": "unitary", "gate": "Rz", "targets": [{ "qubit": 0 }], "args": ["0"] }
+      ]
+    },
+    {
+      "components": [
+        { "kind": "unitary", "gate": "Rz", "targets": [{ "qubit": 0 }], "args": ["π"] }
+      ]
+    },
+    {
+      "components": [
+        { "kind": "unitary", "gate": "Rz", "targets": [{ "qubit": 0 }], "args": ["3 * π"] }
+      ]
+    },
+    {
+      "components": [
+        { "kind": "unitary", "gate": "Rz", "targets": [{ "qubit": 0 }], "args": ["π / 4"] }
+      ]
+    },
+    {
+      "components": [
+        { "kind": "unitary", "gate": "Rz", "targets": [{ "qubit": 0 }], "args": ["2 * π / 3"] }
+      ]
+    },
+    {
+      "components": [
+        { "kind": "unitary", "gate": "Rz", "targets": [{ "qubit": 0 }], "args": ["-π / 4"] }
+      ]
+    },
+    {
+      "components": [
+        { "kind": "unitary", "gate": "Rz", "targets": [{ "qubit": 0 }], "args": ["0.7854"] }
+      ]
+    }
+  ],
+  "qubits": [{ "id": 0 }]
+}"#,
+        &expect![[r#"
+            /// Expects a qubit register of at least 1 qubits.
+            operation Test(qs : Qubit[]) : Unit is Ctl + Adj {
+                if Length(qs) < 1 {
+                    fail "Invalid number of qubits. Operation Test expects a qubit register of at least 1 qubits.";
+                }
+                let π = Std.Math.PI();
+                Rz(0., qs[0]);
+                Rz(π, qs[0]);
+                Rz(3. * π, qs[0]);
+                Rz(π / 4., qs[0]);
+                Rz(2. * π / 3., qs[0]);
+                Rz(-π / 4., qs[0]);
+                Rz(0.7854, qs[0]);
+            }
+
+        "#]],
+    );
+}
+
+#[test]
 fn circuit_with_controlled_gate_multiple_args() {
     check(
         r#"

--- a/source/compiler/qsc_circuit/src/lib.rs
+++ b/source/compiler/qsc_circuit/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod angle_format;
 mod builder;
 mod circuit;
 pub mod operations;

--- a/source/compiler/qsc_circuit/src/rir_to_circuit.rs
+++ b/source/compiler/qsc_circuit/src/rir_to_circuit.rs
@@ -19,6 +19,7 @@ use std::{iter::Peekable, mem::take};
 
 use crate::{
     Circuit, Error, TracerConfig,
+    angle_format::format_angle,
     builder::{
         CallableId, GateInputs, LogicalStack, LogicalStackEntry, LogicalStackEntryLocation, LoopId,
         OperationListBuilder, OperationReceiver, PackageOffset, Scope, ScopeStack, SourceLookup,
@@ -1325,6 +1326,10 @@ fn callable_spec<'a>(
 
     let gate_spec = known_gate_spec(&callable.name);
 
+    // Only a known gate's argument is guaranteed to be a rotation angle; a custom callable's
+    // double operand is classified the same way but can be any value.
+    let is_known_gate = gate_spec.is_some();
+
     let gate_spec = if let Some(gate_spec) = gate_spec {
         gate_spec
     } else {
@@ -1422,7 +1427,11 @@ fn callable_spec<'a>(
                 },
                 Literal::Double(d) => match operand_type {
                     OperandType::Arg => {
-                        args.push(format!("{d:.4}"));
+                        if is_known_gate {
+                            args.push(format_angle(*d));
+                        } else {
+                            args.push(format!("{d:.4}"));
+                        }
                     }
                     _ => {
                         return Err(Error::UnsupportedFeature(

--- a/source/npm/qsharp/test/circuit-editor/angleExpression.test.mjs
+++ b/source/npm/qsharp/test/circuit-editor/angleExpression.test.mjs
@@ -15,6 +15,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  evaluateAngleExpression,
   isValidAngleExpression,
   normalizeAngleExpression,
 } from "../../dist/ux/circuit-vis/angleExpression.js";
@@ -156,6 +157,57 @@ test("isValidAngleExpression: adjacent factors without an operator are invalid",
   // is added later, this test should be updated to expect `true`.)
   assert.equal(isValidAngleExpression("2π"), false);
   assert.equal(isValidAngleExpression("π2"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Generated circuit args
+// ---------------------------------------------------------------------------
+
+test("isValidAngleExpression: every form the circuit generator emits is valid", () => {
+  // Circuit generation renders a rotation angle symbolically when it is a clean multiple or
+  // fraction of π, and falls back to four decimals otherwise. Those strings land in the
+  // operation's `args` and flow straight back into the Edit Argument prompt, so the validator has
+  // to accept all of them. Keep this list in sync with the emitted forms; the explicit `*` in
+  // "2 * π / 3" is load-bearing, since the implicit-multiplication test above shows "2π" would be
+  // rejected.
+  const emitted = [
+    "0",
+    "π",
+    "-π",
+    "3 * π",
+    "-3 * π",
+    "π / 4",
+    "-π / 4",
+    "π / 99",
+    "2 * π / 3",
+    "-15 * π / 16",
+    "0.7854",
+    "-0.3000",
+  ];
+  for (const expr of emitted) {
+    assert.equal(isValidAngleExpression(expr), true, `rejected ${expr}`);
+  }
+});
+
+test("evaluateAngleExpression: generated symbolic args evaluate to their angle", () => {
+  // The state-visualization worker evaluates `args[0]` through this same helper, so a symbolic
+  // arg has to produce the angle it stands for.
+  const cases = [
+    ["0", 0],
+    ["π", Math.PI],
+    ["-π", -Math.PI],
+    ["3 * π", 3 * Math.PI],
+    ["π / 4", Math.PI / 4],
+    ["-π / 4", -Math.PI / 4],
+    ["2 * π / 3", (2 * Math.PI) / 3],
+  ];
+  for (const [expr, expected] of cases) {
+    const actual = evaluateAngleExpression(expr);
+    assert.ok(
+      actual !== undefined && Math.abs(actual - expected) < 1e-12,
+      `${expr} evaluated to ${actual}, expected ${expected}`,
+    );
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/source/npm/qsharp/test/circuit-editor/angleExpression.test.mjs
+++ b/source/npm/qsharp/test/circuit-editor/angleExpression.test.mjs
@@ -20,6 +20,9 @@ import {
   normalizeAngleExpression,
 } from "../../dist/ux/circuit-vis/angleExpression.js";
 
+// JavaScript floating-point comparison tolerance, independent of the circuit formatter thresholds.
+const EVALUATION_EPS = 1e-12;
+
 // ---------------------------------------------------------------------------
 // isValidAngleExpression — positive cases
 // ---------------------------------------------------------------------------
@@ -204,7 +207,7 @@ test("evaluateAngleExpression: generated symbolic args evaluate to their angle",
   for (const [expr, expected] of cases) {
     const actual = evaluateAngleExpression(expr);
     assert.ok(
-      actual !== undefined && Math.abs(actual - expected) < 1e-12,
+      actual !== undefined && Math.abs(actual - expected) < EVALUATION_EPS,
       `${expr} evaluated to ${actual}, expected ${expected}`,
     );
   }

--- a/source/npm/qsharp/test/circuits-cases/symbolic-angles.qs
+++ b/source/npm/qsharp/test/circuits-cases/symbolic-angles.qs
@@ -1,0 +1,9 @@
+operation Main() : Result[] {
+    use (q1, q2) = (Qubit(), Qubit());
+    H(q1);
+    Rz(Std.Math.PI() / 4.0, q1);
+    Rx(2.0 * Std.Math.PI() / 3.0, q2);
+    Ry(-Std.Math.PI() / 2.0, q2);
+    Rz(0.4321, q1);
+    MResetEachZ([q1, q2])
+}

--- a/source/npm/qsharp/test/circuits-cases/symbolic-angles.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/symbolic-angles.qs.snapshot.html
@@ -1,0 +1,1532 @@
+<!DOCTYPE html>
+<html
+  xmlns="http://www.w3.org/1999/xhtml"
+  style="--minToolboxHeight: 150px; --minGateWidth: 40px; --gateHeight: 40px"
+>
+  <head>
+    <link rel="stylesheet" href="../../ux/qsharp-ux.css" />
+    <link rel="stylesheet" href="../../ux/qsharp-circuit.css" />
+  </head>
+  <body>
+    <div><h2>circuit-static-collapsed</h2></div>
+    <div id="circuit-static-collapsed" class="qs-circuit">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="qviz"
+        width="423"
+        height="308"
+        viewBox="0 0 423 308"
+      >
+        <g class="qubit-input-states">
+          <text
+            font-size="16"
+            x="20"
+            y="92"
+            text-anchor="start"
+            dominant-baseline="middle"
+            data-wire="0"
+            class="qs-maintext qs-qubit-label"
+          >
+            |
+            <tspan class="qs-mathtext">ψ</tspan>
+            <tspan baseline-shift="sub" font-size="65%">0</tspan>
+            ⟩
+          </text>
+          <text
+            font-size="16"
+            x="20"
+            y="196"
+            text-anchor="start"
+            dominant-baseline="middle"
+            data-wire="1"
+            class="qs-maintext qs-qubit-label"
+          >
+            |
+            <tspan class="qs-mathtext">ψ</tspan>
+            <tspan baseline-shift="sub" font-size="65%">1</tspan>
+            ⟩
+          </text>
+        </g>
+        <g class="wires">
+          <line x1="40" x2="423" y1="92" y2="92" class="qubit-wire" />
+          <line x1="40" x2="423" y1="196" y2="196" class="qubit-wire" />
+          <g>
+            <line
+              x1="324"
+              x2="324"
+              y1="92"
+              y2="143"
+              class="register-classical"
+            />
+            <line
+              x1="322"
+              x2="322"
+              y1="92"
+              y2="145"
+              class="register-classical"
+            />
+            <line
+              x1="324"
+              x2="423"
+              y1="143"
+              y2="143"
+              class="register-classical"
+            />
+            <line
+              x1="322"
+              x2="423"
+              y1="145"
+              y2="145"
+              class="register-classical"
+            />
+          </g>
+          <g>
+            <line
+              x1="264"
+              x2="264"
+              y1="196"
+              y2="247"
+              class="register-classical"
+            />
+            <line
+              x1="262"
+              x2="262"
+              y1="196"
+              y2="249"
+              class="register-classical"
+            />
+            <line
+              x1="264"
+              x2="423"
+              y1="247"
+              y2="247"
+              class="register-classical"
+            />
+            <line
+              x1="262"
+              x2="423"
+              y1="249"
+              y2="249"
+              class="register-classical"
+            />
+          </g>
+        </g>
+        <g>
+          <g class="gate" data-location="0,0" data-expanded="true">
+            <rect
+              class="gate-unitary"
+              x="80"
+              y="46"
+              width="325"
+              height="232"
+              fill-opacity="0"
+              stroke-dasharray="8, 8"
+            />
+            <g>
+              <g class="gate" data-location="0,0-0,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:3:5 H(q1);</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="104"
+                        y="72"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="40"
+                      />
+                      <text font-size="14" x="124" y="92" class="qs-maintext">
+                        <tspan class="qs-mathtext">H</tspan>
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-0,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:5:5 Rx(2.0 * Std.Math.PI() / 3.0, q2);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="90"
+                        y="176"
+                        width="68"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="68"
+                      />
+                      <text font-size="14" x="124" y="189" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rx</tspan>
+                      </text>
+                      <text font-size="12" x="124" y="204" class="arg-button">
+                        2 *
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 3
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-1,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:4:5 Rz(Std.Math.PI() / 4.0, q1);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="173"
+                        y="72"
+                        width="47"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="47"
+                      />
+                      <text font-size="14" x="196.5" y="85" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rz</tspan>
+                      </text>
+                      <text font-size="12" x="196.5" y="100" class="arg-button">
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 4
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-1,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:6:5 Ry(-Std.Math.PI() / 2.0, q2);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="170"
+                        y="176"
+                        width="53"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="53"
+                      />
+                      <text
+                        font-size="14"
+                        x="196.5"
+                        y="189"
+                        class="qs-maintext"
+                      >
+                        <tspan class="qs-mathtext">Ry</tspan>
+                      </text>
+                      <text font-size="12" x="196.5" y="204" class="arg-button">
+                        -
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 2
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-2,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:7:5 Rz(0.4321, q1);</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="235"
+                        y="72"
+                        width="56"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="56"
+                      />
+                      <text font-size="14" x="263" y="85" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rz</tspan>
+                      </text>
+                      <text font-size="12" x="263" y="100" class="arg-button">
+                        0.4321
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-2,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <rect
+                      class="gate-measure"
+                      x="243"
+                      y="176"
+                      width="40"
+                      height="40"
+                      data-wire-ys="[196]"
+                      data-width="40"
+                    />
+                    <path
+                      class="arc-measure"
+                      d="M 278 198 A 15 12 0 0 0 248 198"
+                      style="pointer-events: none"
+                    />
+                    <line
+                      x1="263"
+                      x2="275"
+                      y1="204"
+                      y2="184"
+                      class="qs-line-measure"
+                      style="pointer-events: none"
+                    />
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-3,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <rect
+                      class="gate-measure"
+                      x="303"
+                      y="72"
+                      width="40"
+                      height="40"
+                      data-wire-ys="[92]"
+                      data-width="40"
+                    />
+                    <path
+                      class="arc-measure"
+                      d="M 338 94 A 15 12 0 0 0 308 94"
+                      style="pointer-events: none"
+                    />
+                    <line
+                      x1="323"
+                      x2="335"
+                      y1="100"
+                      y2="80"
+                      class="qs-line-measure"
+                      style="pointer-events: none"
+                    />
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-3,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-ket"
+                        x="303"
+                        y="176"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="40"
+                      />
+                      <text
+                        font-size="14"
+                        x="323"
+                        y="196"
+                        class="qs-maintext ket-text"
+                      >
+                        |0⟩
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-4,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-ket"
+                        x="355"
+                        y="72"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="40"
+                      />
+                      <text
+                        font-size="14"
+                        x="375"
+                        y="92"
+                        class="qs-maintext ket-text"
+                      >
+                        |0⟩
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+            </g>
+            <text
+              font-size="14"
+              x="90"
+              y="61"
+              class="qs-maintext qs-group-label"
+            >
+              <tspan class="qs-mathtext">Main</tspan>
+            </text>
+            <g class="gate-control gate-collapse">
+              <circle cx="82" cy="48" r="10" />
+              <path d="M75,48 h14" />
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+    <div><h2>circuit-static-expanded</h2></div>
+    <div id="circuit-static-expanded" class="qs-circuit">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="qviz"
+        width="423"
+        height="308"
+        viewBox="0 0 423 308"
+      >
+        <g class="qubit-input-states">
+          <text
+            font-size="16"
+            x="20"
+            y="92"
+            text-anchor="start"
+            dominant-baseline="middle"
+            data-wire="0"
+            class="qs-maintext qs-qubit-label"
+          >
+            |
+            <tspan class="qs-mathtext">ψ</tspan>
+            <tspan baseline-shift="sub" font-size="65%">0</tspan>
+            ⟩
+          </text>
+          <text
+            font-size="16"
+            x="20"
+            y="196"
+            text-anchor="start"
+            dominant-baseline="middle"
+            data-wire="1"
+            class="qs-maintext qs-qubit-label"
+          >
+            |
+            <tspan class="qs-mathtext">ψ</tspan>
+            <tspan baseline-shift="sub" font-size="65%">1</tspan>
+            ⟩
+          </text>
+        </g>
+        <g class="wires">
+          <line x1="40" x2="423" y1="92" y2="92" class="qubit-wire" />
+          <line x1="40" x2="423" y1="196" y2="196" class="qubit-wire" />
+          <g>
+            <line
+              x1="324"
+              x2="324"
+              y1="92"
+              y2="143"
+              class="register-classical"
+            />
+            <line
+              x1="322"
+              x2="322"
+              y1="92"
+              y2="145"
+              class="register-classical"
+            />
+            <line
+              x1="324"
+              x2="423"
+              y1="143"
+              y2="143"
+              class="register-classical"
+            />
+            <line
+              x1="322"
+              x2="423"
+              y1="145"
+              y2="145"
+              class="register-classical"
+            />
+          </g>
+          <g>
+            <line
+              x1="264"
+              x2="264"
+              y1="196"
+              y2="247"
+              class="register-classical"
+            />
+            <line
+              x1="262"
+              x2="262"
+              y1="196"
+              y2="249"
+              class="register-classical"
+            />
+            <line
+              x1="264"
+              x2="423"
+              y1="247"
+              y2="247"
+              class="register-classical"
+            />
+            <line
+              x1="262"
+              x2="423"
+              y1="249"
+              y2="249"
+              class="register-classical"
+            />
+          </g>
+        </g>
+        <g>
+          <g class="gate" data-location="0,0" data-expanded="true">
+            <rect
+              class="gate-unitary"
+              x="80"
+              y="46"
+              width="325"
+              height="232"
+              fill-opacity="0"
+              stroke-dasharray="8, 8"
+            />
+            <g>
+              <g class="gate" data-location="0,0-0,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:3:5 H(q1);</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="104"
+                        y="72"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="40"
+                      />
+                      <text font-size="14" x="124" y="92" class="qs-maintext">
+                        <tspan class="qs-mathtext">H</tspan>
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-0,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:5:5 Rx(2.0 * Std.Math.PI() / 3.0, q2);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="90"
+                        y="176"
+                        width="68"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="68"
+                      />
+                      <text font-size="14" x="124" y="189" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rx</tspan>
+                      </text>
+                      <text font-size="12" x="124" y="204" class="arg-button">
+                        2 *
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 3
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-1,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:4:5 Rz(Std.Math.PI() / 4.0, q1);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="173"
+                        y="72"
+                        width="47"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="47"
+                      />
+                      <text font-size="14" x="196.5" y="85" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rz</tspan>
+                      </text>
+                      <text font-size="12" x="196.5" y="100" class="arg-button">
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 4
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-1,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:6:5 Ry(-Std.Math.PI() / 2.0, q2);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="170"
+                        y="176"
+                        width="53"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="53"
+                      />
+                      <text
+                        font-size="14"
+                        x="196.5"
+                        y="189"
+                        class="qs-maintext"
+                      >
+                        <tspan class="qs-mathtext">Ry</tspan>
+                      </text>
+                      <text font-size="12" x="196.5" y="204" class="arg-button">
+                        -
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 2
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-2,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:7:5 Rz(0.4321, q1);</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="235"
+                        y="72"
+                        width="56"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="56"
+                      />
+                      <text font-size="14" x="263" y="85" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rz</tspan>
+                      </text>
+                      <text font-size="12" x="263" y="100" class="arg-button">
+                        0.4321
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-2,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <rect
+                      class="gate-measure"
+                      x="243"
+                      y="176"
+                      width="40"
+                      height="40"
+                      data-wire-ys="[196]"
+                      data-width="40"
+                    />
+                    <path
+                      class="arc-measure"
+                      d="M 278 198 A 15 12 0 0 0 248 198"
+                      style="pointer-events: none"
+                    />
+                    <line
+                      x1="263"
+                      x2="275"
+                      y1="204"
+                      y2="184"
+                      class="qs-line-measure"
+                      style="pointer-events: none"
+                    />
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-3,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <rect
+                      class="gate-measure"
+                      x="303"
+                      y="72"
+                      width="40"
+                      height="40"
+                      data-wire-ys="[92]"
+                      data-width="40"
+                    />
+                    <path
+                      class="arc-measure"
+                      d="M 338 94 A 15 12 0 0 0 308 94"
+                      style="pointer-events: none"
+                    />
+                    <line
+                      x1="323"
+                      x2="335"
+                      y1="100"
+                      y2="80"
+                      class="qs-line-measure"
+                      style="pointer-events: none"
+                    />
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-3,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-ket"
+                        x="303"
+                        y="176"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="40"
+                      />
+                      <text
+                        font-size="14"
+                        x="323"
+                        y="196"
+                        class="qs-maintext ket-text"
+                      >
+                        |0⟩
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-4,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-ket"
+                        x="355"
+                        y="72"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="40"
+                      />
+                      <text
+                        font-size="14"
+                        x="375"
+                        y="92"
+                        class="qs-maintext ket-text"
+                      >
+                        |0⟩
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+            </g>
+            <text
+              font-size="14"
+              x="90"
+              y="61"
+              class="qs-maintext qs-group-label"
+            >
+              <tspan class="qs-mathtext">Main</tspan>
+            </text>
+            <g class="gate-control gate-collapse">
+              <circle cx="82" cy="48" r="10" />
+              <path d="M75,48 h14" />
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+    <div><h2>circuit-eval-collapsed</h2></div>
+    <div id="circuit-eval-collapsed" class="qs-circuit">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="qviz"
+        width="423"
+        height="308"
+        viewBox="0 0 423 308"
+      >
+        <g class="qubit-input-states">
+          <a href="#" class="qs-circuit-source-link">
+            <title>
+              symbolic-angles.qs:2:21 use (q1, q2) = (Qubit(), Qubit());
+            </title>
+            <text
+              font-size="16"
+              x="20"
+              y="92"
+              text-anchor="start"
+              dominant-baseline="middle"
+              data-wire="0"
+              class="qs-maintext qs-qubit-label"
+            >
+              |
+              <tspan class="qs-mathtext">ψ</tspan>
+              <tspan baseline-shift="sub" font-size="65%">0</tspan>
+              ⟩
+            </text>
+          </a>
+          <a href="#" class="qs-circuit-source-link">
+            <title>
+              symbolic-angles.qs:2:30 use (q1, q2) = (Qubit(), Qubit());
+            </title>
+            <text
+              font-size="16"
+              x="20"
+              y="196"
+              text-anchor="start"
+              dominant-baseline="middle"
+              data-wire="1"
+              class="qs-maintext qs-qubit-label"
+            >
+              |
+              <tspan class="qs-mathtext">ψ</tspan>
+              <tspan baseline-shift="sub" font-size="65%">1</tspan>
+              ⟩
+            </text>
+          </a>
+        </g>
+        <g class="wires">
+          <line x1="40" x2="423" y1="92" y2="92" class="qubit-wire" />
+          <line x1="40" x2="423" y1="196" y2="196" class="qubit-wire" />
+          <g>
+            <line
+              x1="324"
+              x2="324"
+              y1="92"
+              y2="143"
+              class="register-classical"
+            />
+            <line
+              x1="322"
+              x2="322"
+              y1="92"
+              y2="145"
+              class="register-classical"
+            />
+            <line
+              x1="324"
+              x2="423"
+              y1="143"
+              y2="143"
+              class="register-classical"
+            />
+            <line
+              x1="322"
+              x2="423"
+              y1="145"
+              y2="145"
+              class="register-classical"
+            />
+          </g>
+          <g>
+            <line
+              x1="264"
+              x2="264"
+              y1="196"
+              y2="247"
+              class="register-classical"
+            />
+            <line
+              x1="262"
+              x2="262"
+              y1="196"
+              y2="249"
+              class="register-classical"
+            />
+            <line
+              x1="264"
+              x2="423"
+              y1="247"
+              y2="247"
+              class="register-classical"
+            />
+            <line
+              x1="262"
+              x2="423"
+              y1="249"
+              y2="249"
+              class="register-classical"
+            />
+          </g>
+        </g>
+        <g>
+          <g class="gate" data-location="0,0" data-expanded="true">
+            <rect
+              class="gate-unitary"
+              x="80"
+              y="46"
+              width="325"
+              height="232"
+              fill-opacity="0"
+              stroke-dasharray="8, 8"
+            />
+            <g>
+              <g class="gate" data-location="0,0-0,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:3:5 H(q1);</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="104"
+                        y="72"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="40"
+                      />
+                      <text font-size="14" x="124" y="92" class="qs-maintext">
+                        <tspan class="qs-mathtext">H</tspan>
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-0,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:5:5 Rx(2.0 * Std.Math.PI() / 3.0, q2);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="90"
+                        y="176"
+                        width="68"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="68"
+                      />
+                      <text font-size="14" x="124" y="189" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rx</tspan>
+                      </text>
+                      <text font-size="12" x="124" y="204" class="arg-button">
+                        2 *
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 3
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-1,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:4:5 Rz(Std.Math.PI() / 4.0, q1);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="173"
+                        y="72"
+                        width="47"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="47"
+                      />
+                      <text font-size="14" x="196.5" y="85" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rz</tspan>
+                      </text>
+                      <text font-size="12" x="196.5" y="100" class="arg-button">
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 4
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-1,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:6:5 Ry(-Std.Math.PI() / 2.0, q2);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="170"
+                        y="176"
+                        width="53"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="53"
+                      />
+                      <text
+                        font-size="14"
+                        x="196.5"
+                        y="189"
+                        class="qs-maintext"
+                      >
+                        <tspan class="qs-mathtext">Ry</tspan>
+                      </text>
+                      <text font-size="12" x="196.5" y="204" class="arg-button">
+                        -
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 2
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-2,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:7:5 Rz(0.4321, q1);</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="235"
+                        y="72"
+                        width="56"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="56"
+                      />
+                      <text font-size="14" x="263" y="85" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rz</tspan>
+                      </text>
+                      <text font-size="12" x="263" y="100" class="arg-button">
+                        0.4321
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-2,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <rect
+                      class="gate-measure"
+                      x="243"
+                      y="176"
+                      width="40"
+                      height="40"
+                      data-wire-ys="[196]"
+                      data-width="40"
+                    />
+                    <path
+                      class="arc-measure"
+                      d="M 278 198 A 15 12 0 0 0 248 198"
+                      style="pointer-events: none"
+                    />
+                    <line
+                      x1="263"
+                      x2="275"
+                      y1="204"
+                      y2="184"
+                      class="qs-line-measure"
+                      style="pointer-events: none"
+                    />
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-3,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <rect
+                      class="gate-measure"
+                      x="303"
+                      y="72"
+                      width="40"
+                      height="40"
+                      data-wire-ys="[92]"
+                      data-width="40"
+                    />
+                    <path
+                      class="arc-measure"
+                      d="M 338 94 A 15 12 0 0 0 308 94"
+                      style="pointer-events: none"
+                    />
+                    <line
+                      x1="323"
+                      x2="335"
+                      y1="100"
+                      y2="80"
+                      class="qs-line-measure"
+                      style="pointer-events: none"
+                    />
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-3,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-ket"
+                        x="303"
+                        y="176"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="40"
+                      />
+                      <text
+                        font-size="14"
+                        x="323"
+                        y="196"
+                        class="qs-maintext ket-text"
+                      >
+                        |0⟩
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-4,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-ket"
+                        x="355"
+                        y="72"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="40"
+                      />
+                      <text
+                        font-size="14"
+                        x="375"
+                        y="92"
+                        class="qs-maintext ket-text"
+                      >
+                        |0⟩
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+            </g>
+            <text
+              font-size="14"
+              x="90"
+              y="61"
+              class="qs-maintext qs-group-label"
+            >
+              <tspan class="qs-mathtext">Main</tspan>
+            </text>
+            <g class="gate-control gate-collapse">
+              <circle cx="82" cy="48" r="10" />
+              <path d="M75,48 h14" />
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+    <div><h2>circuit-eval-expanded</h2></div>
+    <div id="circuit-eval-expanded" class="qs-circuit">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="qviz"
+        width="423"
+        height="308"
+        viewBox="0 0 423 308"
+      >
+        <g class="qubit-input-states">
+          <a href="#" class="qs-circuit-source-link">
+            <title>
+              symbolic-angles.qs:2:21 use (q1, q2) = (Qubit(), Qubit());
+            </title>
+            <text
+              font-size="16"
+              x="20"
+              y="92"
+              text-anchor="start"
+              dominant-baseline="middle"
+              data-wire="0"
+              class="qs-maintext qs-qubit-label"
+            >
+              |
+              <tspan class="qs-mathtext">ψ</tspan>
+              <tspan baseline-shift="sub" font-size="65%">0</tspan>
+              ⟩
+            </text>
+          </a>
+          <a href="#" class="qs-circuit-source-link">
+            <title>
+              symbolic-angles.qs:2:30 use (q1, q2) = (Qubit(), Qubit());
+            </title>
+            <text
+              font-size="16"
+              x="20"
+              y="196"
+              text-anchor="start"
+              dominant-baseline="middle"
+              data-wire="1"
+              class="qs-maintext qs-qubit-label"
+            >
+              |
+              <tspan class="qs-mathtext">ψ</tspan>
+              <tspan baseline-shift="sub" font-size="65%">1</tspan>
+              ⟩
+            </text>
+          </a>
+        </g>
+        <g class="wires">
+          <line x1="40" x2="423" y1="92" y2="92" class="qubit-wire" />
+          <line x1="40" x2="423" y1="196" y2="196" class="qubit-wire" />
+          <g>
+            <line
+              x1="324"
+              x2="324"
+              y1="92"
+              y2="143"
+              class="register-classical"
+            />
+            <line
+              x1="322"
+              x2="322"
+              y1="92"
+              y2="145"
+              class="register-classical"
+            />
+            <line
+              x1="324"
+              x2="423"
+              y1="143"
+              y2="143"
+              class="register-classical"
+            />
+            <line
+              x1="322"
+              x2="423"
+              y1="145"
+              y2="145"
+              class="register-classical"
+            />
+          </g>
+          <g>
+            <line
+              x1="264"
+              x2="264"
+              y1="196"
+              y2="247"
+              class="register-classical"
+            />
+            <line
+              x1="262"
+              x2="262"
+              y1="196"
+              y2="249"
+              class="register-classical"
+            />
+            <line
+              x1="264"
+              x2="423"
+              y1="247"
+              y2="247"
+              class="register-classical"
+            />
+            <line
+              x1="262"
+              x2="423"
+              y1="249"
+              y2="249"
+              class="register-classical"
+            />
+          </g>
+        </g>
+        <g>
+          <g class="gate" data-location="0,0" data-expanded="true">
+            <rect
+              class="gate-unitary"
+              x="80"
+              y="46"
+              width="325"
+              height="232"
+              fill-opacity="0"
+              stroke-dasharray="8, 8"
+            />
+            <g>
+              <g class="gate" data-location="0,0-0,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:3:5 H(q1);</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="104"
+                        y="72"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="40"
+                      />
+                      <text font-size="14" x="124" y="92" class="qs-maintext">
+                        <tspan class="qs-mathtext">H</tspan>
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-0,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:5:5 Rx(2.0 * Std.Math.PI() / 3.0, q2);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="90"
+                        y="176"
+                        width="68"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="68"
+                      />
+                      <text font-size="14" x="124" y="189" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rx</tspan>
+                      </text>
+                      <text font-size="12" x="124" y="204" class="arg-button">
+                        2 *
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 3
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-1,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:4:5 Rz(Std.Math.PI() / 4.0, q1);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="173"
+                        y="72"
+                        width="47"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="47"
+                      />
+                      <text font-size="14" x="196.5" y="85" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rz</tspan>
+                      </text>
+                      <text font-size="12" x="196.5" y="100" class="arg-button">
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 4
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-1,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>
+                    symbolic-angles.qs:6:5 Ry(-Std.Math.PI() / 2.0, q2);
+                  </title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="170"
+                        y="176"
+                        width="53"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="53"
+                      />
+                      <text
+                        font-size="14"
+                        x="196.5"
+                        y="189"
+                        class="qs-maintext"
+                      >
+                        <tspan class="qs-mathtext">Ry</tspan>
+                      </text>
+                      <text font-size="12" x="196.5" y="204" class="arg-button">
+                        -
+                        <tspan class="qs-mathtext">π</tspan>
+                        / 2
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-2,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:7:5 Rz(0.4321, q1);</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-unitary"
+                        x="235"
+                        y="72"
+                        width="56"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="56"
+                      />
+                      <text font-size="14" x="263" y="85" class="qs-maintext">
+                        <tspan class="qs-mathtext">Rz</tspan>
+                      </text>
+                      <text font-size="12" x="263" y="100" class="arg-button">
+                        0.4321
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-2,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <rect
+                      class="gate-measure"
+                      x="243"
+                      y="176"
+                      width="40"
+                      height="40"
+                      data-wire-ys="[196]"
+                      data-width="40"
+                    />
+                    <path
+                      class="arc-measure"
+                      d="M 278 198 A 15 12 0 0 0 248 198"
+                      style="pointer-events: none"
+                    />
+                    <line
+                      x1="263"
+                      x2="275"
+                      y1="204"
+                      y2="184"
+                      class="qs-line-measure"
+                      style="pointer-events: none"
+                    />
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-3,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <rect
+                      class="gate-measure"
+                      x="303"
+                      y="72"
+                      width="40"
+                      height="40"
+                      data-wire-ys="[92]"
+                      data-width="40"
+                    />
+                    <path
+                      class="arc-measure"
+                      d="M 338 94 A 15 12 0 0 0 308 94"
+                      style="pointer-events: none"
+                    />
+                    <line
+                      x1="323"
+                      x2="335"
+                      y1="100"
+                      y2="80"
+                      class="qs-line-measure"
+                      style="pointer-events: none"
+                    />
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-3,1">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-ket"
+                        x="303"
+                        y="176"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[196]"
+                        data-width="40"
+                      />
+                      <text
+                        font-size="14"
+                        x="323"
+                        y="196"
+                        class="qs-maintext ket-text"
+                      >
+                        |0⟩
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+              <g class="gate" data-location="0,0-4,0">
+                <a href="#" class="qs-circuit-source-link">
+                  <title>symbolic-angles.qs:8:5 MResetEachZ([q1, q2])</title>
+                  <g>
+                    <g>
+                      <rect
+                        class="gate-ket"
+                        x="355"
+                        y="72"
+                        width="40"
+                        height="40"
+                        data-wire-ys="[92]"
+                        data-width="40"
+                      />
+                      <text
+                        font-size="14"
+                        x="375"
+                        y="92"
+                        class="qs-maintext ket-text"
+                      >
+                        |0⟩
+                      </text>
+                    </g>
+                  </g>
+                </a>
+              </g>
+            </g>
+            <text
+              font-size="14"
+              x="90"
+              y="61"
+              class="qs-maintext qs-group-label"
+            >
+              <tspan class="qs-mathtext">Main</tspan>
+            </text>
+            <g class="gate-control gate-collapse">
+              <circle cx="82" cy="48" r="10" />
+              <path d="M75,48 h14" />
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </body>
+</html>

--- a/source/samples_test/src/tests/algorithms.rs
+++ b/source/samples_test/src/tests/algorithms.rs
@@ -65,7 +65,7 @@ pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_DEBUG: Expect = expect![[r#"
     Computed value = 1.0, true value = 0.995974293995239
     (16, 4)"#]];
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_CIRCUIT: Expect =
-    expect!["generated circuit of length 120400"];
+    expect!["generated circuit of length 122966"];
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 139362"];
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect =
@@ -107,7 +107,7 @@ pub const HIDDENSHIFTNISQ_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated Q
 pub const HIDDENSHIFTNISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 8448"];
 pub const PHASEESTIMATION_EXPECT: Expect = expect!["1.0799224746714913"];
 pub const PHASEESTIMATION_EXPECT_DEBUG: Expect = expect!["1.0799224746714913"];
-pub const PHASEESTIMATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 248107"];
+pub const PHASEESTIMATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 249358"];
 pub const PHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 95778"];
 pub const PHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 15701"];
@@ -186,7 +186,7 @@ pub const SIMPLEPHASEESTIMATION_EXPECT: Expect = expect![[r#"[Zero, Zero, Zero, 
 pub const SIMPLEPHASEESTIMATION_EXPECT_DEBUG: Expect =
     expect![[r#"[Zero, Zero, Zero, One, Zero, One]"#]];
 pub const SIMPLEPHASEESTIMATION_EXPECT_CIRCUIT: Expect =
-    expect!["generated circuit of length 87076"];
+    expect!["generated circuit of length 87885"];
 pub const SIMPLEPHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 39770"];
 pub const SIMPLEPHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect =
@@ -286,7 +286,7 @@ pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of 
 pub const THREEQUBITREPETITIONCODE_EXPECT: Expect = expect!["(true, 0)"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_DEBUG: Expect = expect!["(true, 0)"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_CIRCUIT: Expect =
-    expect!["generated circuit of length 51203"];
+    expect!["generated circuit of length 51383"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18122"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_QIR_ADAPTIVE: Expect =


### PR DESCRIPTION
This adds friendly angle rendering to circuits in both the circuit editor and the generated circuits view.

For the VS Code changelog on the next release:

```markdown
### Symbolic angles in circuit diagrams

Circuit diagrams now label a rotation with the angle you recognize instead of a decimal. A gate written as `rz(pi / 4) q;` in OpenQASM, or `Rz(Std.Math.PI() / 4.0, q)` in Q#, is drawn as `Rz(π / 4)` rather than `Rz(0.7854)`.

```qasm
OPENQASM 3.0;
include "stdgates.inc";
qubit[2] q;
rz(pi / 4) q[0];
rx(2 * pi / 3) q[1];
```

```text
q_0    ──── Rz(π / 4) ────
q_1    ── Rx(2 * π / 3) ──
```

This applies everywhere a circuit is shown: the circuit view, the text diagram, Python output, and the circuit JSON. An angle that is not a whole multiple or a simple fraction of π keeps the four-decimal form it has always had, so `rz(0.5) q;` is still drawn as `Rz(0.5000)`. Angles are recognized from their computed value, so a rotation built at run time is labeled too. Note that OpenQASM reduces an angle modulo 2π before the circuit is drawn, so `rz(-pi/4) q;` appears as `Rz(7 * π / 4)`.

If you read circuit JSON programmatically, note that a gate's `args` entry is an angle expression rather than always a decimal number, so code that converts it straight to a float needs to handle forms such as `π / 4`.
```