### PR TITLE
Fix learning notebook tree navigation

### DIFF
--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -606,7 +606,9 @@ export class LearningService {
     }
     const { activity } = this.findCurrentActivity();
     // For python-notebook courses the activity ID is the cell ID.
-    return activity.type === "exercise" ? activity.id : undefined;
+    return activity.type === "exercise" || activity.type === "code-cell"
+      ? activity.id
+      : undefined;
   }
 
   /** Enumerate all available courses. */
@@ -1054,10 +1056,7 @@ export class LearningService {
     action: "navigate" | "run" | "check" | "hint" | "solution" | "reset",
     source: TelemetrySource,
   ): void {
-    const activityType =
-      this.findCurrentActivity().activity.type === "exercise"
-        ? "exercise"
-        : "lesson";
+    const activityType = this.findCurrentActivity().activity.type;
     sendTelemetryEvent(
       EventType.LearningActivityAction,
       { action, activityType, source },

--- a/source/vscode/src/telemetry.ts
+++ b/source/vscode/src/telemetry.ts
@@ -344,7 +344,7 @@ type EventTypes = {
   [EventType.LearningActivityAction]: {
     properties: {
       action: "navigate" | "run" | "check" | "hint" | "solution" | "reset";
-      activityType: "lesson" | "exercise";
+      activityType: "lesson" | "exercise" | "code-cell";
       source: "panel" | "chat" | "tree" | "notebook";
     };
     measurements: Empty;


### PR DESCRIPTION
It was only working for type `exercise`, but I introduced type `code-cell` at the last minute and it should work for those too.