### PR TITLE
Optimize execution graph with expression specific nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,7 +1901,7 @@ dependencies = [
  "num-traits",
  "probability",
  "qsc",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rustc-hash",
  "serde",
  "thiserror",

--- a/source/compiler/qsc_eval/src/lib.rs
+++ b/source/compiler/qsc_eval/src/lib.rs
@@ -38,9 +38,9 @@ use output::Receiver;
 use qsc_data_structures::{functors::FunctorApp, index_map::IndexMap, span::Span};
 use qsc_fir::fir::{
     self, BinOp, BlockId, CallableImpl, ConfiguredExecGraph, ExecGraph, ExecGraphConfig,
-    ExecGraphDebugNode, ExecGraphNode, Expr, ExprId, ExprKind, Field, FieldAssign, Global, Lit,
-    LocalItemId, LocalVarId, PackageId, PackageStoreLookup, ParKind, PatId, PatKind, PrimField,
-    Res, StmtId, StoreItemId, StringComponent, UnOp,
+    ExecGraphDebugNode, ExecGraphExpr, ExecGraphNode, Expr, ExprId, ExprKind, Field, FieldAssign,
+    Global, Lit, LocalItemId, LocalVarId, PackageId, PackageStoreLookup, ParKind, PatId, PatKind,
+    PrimField, Res, StmtId, StoreItemId, StringComponent, UnOp,
 };
 use qsc_fir::ty::Ty;
 pub use qsc_hir::hir::PackageSpan;
@@ -777,9 +777,9 @@ impl State {
                     self.eval_bind(env, globals, *pat);
                     continue;
                 }
-                Some(ExecGraphNode::Expr(expr)) => {
+                Some(ExecGraphNode::Expr(expr, span)) => {
                     self.idx += 1;
-                    match self.eval_expr(env, sim, globals, out, *expr) {
+                    match self.eval_expr(env, sim, globals, out, *expr, *span) {
                         Ok(()) => continue,
                         Err(e) => return self.handle_error(e),
                     }
@@ -1042,18 +1042,78 @@ impl State {
         sim: &mut TracingBackend<'_, B>,
         globals: &impl PackageStoreLookup,
         out: &mut impl Receiver,
-        expr: ExprId,
+        expr: ExecGraphExpr,
+        span: Span,
     ) -> Result<(), Error> {
-        let expr = globals.get_expr((self.package, expr).into());
-        self.current_span = expr.span;
-        match &expr.kind {
-            ExprKind::Array(arr) => self.eval_arr(arr.len()),
-            ExprKind::ArrayLit(arr) => self.eval_arr_lit(arr, globals),
-            ExprKind::ArrayRepeat(..) => self.eval_arr_repeat(expr.span)?,
-            ExprKind::Assign(lhs, _) => self.eval_assign(env, globals, *lhs)?,
-            ExprKind::AssignOp(op, lhs, rhs) => {
-                let lhs_span = globals.get_expr((self.package, *lhs).into()).span;
-                let rhs_span = globals.get_expr((self.package, *rhs).into()).span;
+        self.current_span = span;
+        // NOTE: the ordering of the match arms here and in nested matches is roughly in order of how often they are expected to be hit,
+        // with the most common cases first. This helps optimize performance for those common cases.
+        match &expr {
+            ExecGraphExpr::Expr(id) => {
+                let expr = globals.get_expr((self.package, *id).into());
+                match &expr.kind {
+                    ExprKind::Lit(lit) => {
+                        self.set_val_register(lit_to_val(lit));
+                    }
+                    ExprKind::String(components) => self.collect_string(components),
+                    ExprKind::ArrayLit(arr) => self.eval_arr_lit(arr, globals),
+                    ExprKind::Closure(args, callable) => {
+                        let closure = resolve_closure(env, self.package, span, args, *callable)?;
+                        self.set_val_register(closure);
+                    }
+                    ExprKind::AssignField(record, field, _) => {
+                        self.eval_update_field(field.clone());
+                        self.eval_assign(env, globals, *record)?;
+                    }
+                    ExprKind::Field(_, field) => self.eval_field(field.clone()),
+                    ExprKind::Struct(res, copy, fields) => self.eval_struct(res, *copy, fields),
+                    ExprKind::UpdateField(_, field, _) => {
+                        self.eval_update_field(field.clone());
+                    }
+                    ExprKind::Array(..)
+                    | ExprKind::ArrayRepeat(..)
+                    | ExprKind::Assign(..)
+                    | ExprKind::AssignOp(..)
+                    | ExprKind::AssignIndex(..)
+                    | ExprKind::BinOp(..)
+                    | ExprKind::Block(..)
+                    | ExprKind::Call(..)
+                    | ExprKind::Fail(..)
+                    | ExprKind::Hole
+                    | ExprKind::If(..)
+                    | ExprKind::Index(..)
+                    | ExprKind::Parallel(..)
+                    | ExprKind::Range(..)
+                    | ExprKind::Return(..)
+                    | ExprKind::UpdateIndex(..)
+                    | ExprKind::Tuple(..)
+                    | ExprKind::UnOp(..)
+                    | ExprKind::Var(..)
+                    | ExprKind::While(..) => {
+                        panic!("unexpected expression kind in exec graph: {:?}", expr.kind)
+                    }
+                }
+            }
+            ExecGraphExpr::Assign(lhs) => self.eval_assign(env, globals, *lhs)?,
+            ExecGraphExpr::Tuple(size) => self.eval_tup(*size),
+            ExecGraphExpr::Var(res) => {
+                self.set_val_register(resolve_binding(env, self.package, *res, span)?);
+            }
+            ExecGraphExpr::Call {
+                callee_span,
+                args_span,
+            } => self.eval_call(env, sim, globals, *callee_span, *args_span, out)?,
+            ExecGraphExpr::BinOp {
+                op,
+                lhs_span,
+                rhs_span,
+            } => self.eval_binop(*op, *lhs_span, *rhs_span)?,
+            ExecGraphExpr::AssignOp {
+                op,
+                lhs,
+                lhs_span,
+                rhs_span,
+            } => {
                 let (is_array, is_unique) =
                     is_updatable_in_place(env, globals.get_expr((self.package, *lhs).into()));
                 if is_array {
@@ -1062,86 +1122,50 @@ impl State {
                         return Ok(());
                     }
                     let rhs_val = self.take_val_register();
-                    self.eval_expr(env, sim, globals, out, *lhs)?;
+                    let ExprKind::Var(res, _) = &globals.get_expr((self.package, *lhs).into()).kind
+                    else {
+                        panic!("lhs of assign op should be a variable");
+                    };
+                    self.set_val_register(resolve_binding(env, self.package, *res, *lhs_span)?);
                     self.push_val();
                     self.set_val_register(rhs_val);
                 }
-                self.eval_binop(*op, lhs_span, rhs_span)?;
+                self.eval_binop(*op, *lhs_span, *rhs_span)?;
                 self.eval_assign(env, globals, *lhs)?;
             }
-            ExprKind::AssignField(record, field, _) => {
-                self.eval_update_field(field.clone());
-                self.eval_assign(env, globals, *record)?;
-            }
-            ExprKind::AssignIndex(lhs, mid, _) => {
-                let mid_span = globals.get_expr((self.package, *mid).into()).span;
+            ExecGraphExpr::Array(size) => self.eval_arr(*size),
+            ExecGraphExpr::UnOp(op) => self.eval_unop(*op),
+            ExecGraphExpr::Index {
+                index_span: rhs_span,
+            } => self.eval_index(*rhs_span)?,
+            ExecGraphExpr::Range {
+                has_start,
+                has_step,
+                has_end,
+            } => self.eval_range(*has_start, *has_step, *has_end),
+            ExecGraphExpr::AssignIndex { lhs, mid_span } => {
                 let (_, is_unique) =
                     is_updatable_in_place(env, globals.get_expr((self.package, *lhs).into()));
                 if is_unique {
-                    self.eval_update_index_in_place(env, globals, *lhs, mid_span)?;
+                    self.eval_update_index_in_place(env, globals, *lhs, *mid_span)?;
                     return Ok(());
                 }
                 self.push_val();
-                self.eval_expr(env, sim, globals, out, *lhs)?;
-                self.eval_update_index(mid_span)?;
+                let lhs_expr = globals.get_expr((self.package, *lhs).into());
+                let ExprKind::Var(res, _) = &lhs_expr.kind else {
+                    panic!("lhs of assign op should be a variable");
+                };
+                self.set_val_register(resolve_binding(env, self.package, *res, lhs_expr.span)?);
+                self.eval_update_index(*mid_span)?;
                 self.eval_assign(env, globals, *lhs)?;
             }
-            ExprKind::BinOp(op, lhs, rhs) => {
-                let lhs_span = globals.get_expr((self.package, *lhs).into()).span;
-                let rhs_span = globals.get_expr((self.package, *rhs).into()).span;
-                self.eval_binop(*op, lhs_span, rhs_span)?;
-            }
-            ExprKind::Block(..) => panic!("block expr should be handled by control flow"),
-            ExprKind::Call(callee_expr, args_expr) => {
-                let callable_span = globals.get_expr((self.package, *callee_expr).into()).span;
-                let args_span = globals.get_expr((self.package, *args_expr).into()).span;
-                self.eval_call(env, sim, globals, callable_span, args_span, out)?;
-            }
-            ExprKind::Closure(args, callable) => {
-                let closure = resolve_closure(env, self.package, expr.span, args, *callable)?;
-                self.set_val_register(closure);
-            }
-            ExprKind::Fail(..) => {
+            ExecGraphExpr::UpdateIndex { mid_span } => self.eval_update_index(*mid_span)?,
+            ExecGraphExpr::ArrayRepeat => self.eval_arr_repeat(span)?,
+            ExecGraphExpr::Fail => {
                 return Err(Error::UserFail(
                     self.take_val_register().unwrap_string().to_string(),
-                    self.to_global_span(expr.span),
+                    self.to_global_span(span),
                 ));
-            }
-            ExprKind::Field(_, field) => self.eval_field(field.clone()),
-            ExprKind::Hole => panic!("hole expr should be disallowed by passes"),
-            ExprKind::If(..) => {
-                panic!("if expr should be handled by control flow")
-            }
-            ExprKind::Index(_, rhs) => {
-                let rhs_span = globals.get_expr((self.package, *rhs).into()).span;
-                self.eval_index(rhs_span)?;
-            }
-            ExprKind::Lit(lit) => {
-                self.set_val_register(lit_to_val(lit));
-            }
-            ExprKind::Range(start, step, end) => {
-                self.eval_range(start.is_some(), step.is_some(), end.is_some());
-            }
-            ExprKind::Return(..) => panic!("return expr should be handled by control flow"),
-            ExprKind::Struct(res, copy, fields) => self.eval_struct(res, *copy, fields),
-            ExprKind::String(components) => self.collect_string(components),
-            ExprKind::UpdateIndex(_, mid, _) => {
-                let mid_span = globals.get_expr((self.package, *mid).into()).span;
-                self.eval_update_index(mid_span)?;
-            }
-            ExprKind::Tuple(tup) => self.eval_tup(tup.len()),
-            ExprKind::UnOp(op, _) => self.eval_unop(*op),
-            ExprKind::UpdateField(_, field, _) => {
-                self.eval_update_field(field.clone());
-            }
-            ExprKind::Var(res, _) => {
-                self.set_val_register(resolve_binding(env, self.package, *res, expr.span)?);
-            }
-            ExprKind::While(..) => {
-                panic!("while expr should be handled by control flow")
-            }
-            ExprKind::Parallel(..) => {
-                panic!("parallel expr should be handled by control flow")
             }
         }
 

--- a/source/compiler/qsc_fir/src/fir.rs
+++ b/source/compiler/qsc_fir/src/fir.rs
@@ -898,7 +898,7 @@ pub enum ExecGraphNode {
     /// A binding of a value to a variable.
     Bind(PatId),
     /// An expression to execute.
-    Expr(ExprId),
+    Expr(ExecGraphExpr, Span),
     /// An unconditional jump with to given location.
     Jump(u32),
     /// A conditional jump with to given location, where the jump is only taken if the condition is
@@ -919,6 +919,49 @@ pub enum ExecGraphNode {
     ParEnd,
     /// A node only to be executed in debug mode.
     Debug(ExecGraphDebugNode),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[allow(missing_docs)]
+pub enum ExecGraphExpr {
+    Expr(ExprId),
+    Array(usize),
+    ArrayRepeat,
+    Assign(ExprId),
+    AssignOp {
+        op: BinOp,
+        lhs: ExprId,
+        lhs_span: Span,
+        rhs_span: Span,
+    },
+    AssignIndex {
+        lhs: ExprId,
+        mid_span: Span,
+    },
+    BinOp {
+        op: BinOp,
+        lhs_span: Span,
+        rhs_span: Span,
+    },
+    Call {
+        callee_span: Span,
+        args_span: Span,
+    },
+    Fail,
+    Index {
+        index_span: Span,
+    },
+    Range {
+        has_start: bool,
+        has_step: bool,
+        has_end: bool,
+    },
+    UpdateIndex {
+        mid_span: Span,
+    },
+    Tuple(usize),
+    UnOp(UnOp),
+    Var(Res),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/source/compiler/qsc_fir_transforms/src/cloner.rs
+++ b/source/compiler/qsc_fir_transforms/src/cloner.rs
@@ -701,8 +701,47 @@ impl FirCloner {
             ExecGraphNode::Bind(pat_id) => {
                 ExecGraphNode::Bind(*self.pat_map.get(&pat_id).unwrap_or(&pat_id))
             }
-            ExecGraphNode::Expr(expr_id) => {
-                ExecGraphNode::Expr(*self.expr_map.get(&expr_id).unwrap_or(&expr_id))
+            ExecGraphNode::Expr(expr, span) => {
+                let mut expr = expr;
+                match &mut expr {
+                    qsc_fir::fir::ExecGraphExpr::Expr(expr_id)
+                    | qsc_fir::fir::ExecGraphExpr::Assign(expr_id)
+                    | qsc_fir::fir::ExecGraphExpr::AssignOp {
+                        lhs: expr_id,
+                        op: _,
+                        lhs_span: _,
+                        rhs_span: _,
+                    }
+                    | qsc_fir::fir::ExecGraphExpr::AssignIndex {
+                        lhs: expr_id,
+                        mid_span: _,
+                    } => {
+                        *expr_id = *self.expr_map.get(expr_id).unwrap_or(expr_id);
+                    }
+                    qsc_fir::fir::ExecGraphExpr::Array(_)
+                    | qsc_fir::fir::ExecGraphExpr::ArrayRepeat
+                    | qsc_fir::fir::ExecGraphExpr::BinOp {
+                        op: _,
+                        lhs_span: _,
+                        rhs_span: _,
+                    }
+                    | qsc_fir::fir::ExecGraphExpr::Call {
+                        callee_span: _,
+                        args_span: _,
+                    }
+                    | qsc_fir::fir::ExecGraphExpr::Fail
+                    | qsc_fir::fir::ExecGraphExpr::Index { index_span: _ }
+                    | qsc_fir::fir::ExecGraphExpr::Range {
+                        has_start: _,
+                        has_step: _,
+                        has_end: _,
+                    }
+                    | qsc_fir::fir::ExecGraphExpr::UpdateIndex { mid_span: _ }
+                    | qsc_fir::fir::ExecGraphExpr::Tuple(_)
+                    | qsc_fir::fir::ExecGraphExpr::UnOp(_)
+                    | qsc_fir::fir::ExecGraphExpr::Var(_) => {}
+                }
+                ExecGraphNode::Expr(expr, span)
             }
             // Jump targets are graph-relative indices, not IDs — preserve them.
             ExecGraphNode::Jump(_)

--- a/source/compiler/qsc_fir_transforms/src/exec_graph_rebuild.rs
+++ b/source/compiler/qsc_fir_transforms/src/exec_graph_rebuild.rs
@@ -33,8 +33,8 @@ mod tests;
 use std::ops::Range;
 
 use qsc_fir::fir::{
-    BinOp, BlockId, CallableImpl, ExecGraphDebugNode, ExecGraphIdx, ExecGraphNode, ExprId,
-    ExprKind, ItemKind, LocalItemId, Package, PackageId, PackageLookup, PackageStore,
+    BinOp, BlockId, CallableImpl, ExecGraphDebugNode, ExecGraphExpr, ExecGraphIdx, ExecGraphNode,
+    ExprId, ExprKind, ItemKind, LocalItemId, Package, PackageId, PackageLookup, PackageStore,
     SpecDecl as FirSpecDecl, StmtId, StmtKind, StoreItemId, StringComponent,
 };
 use qsc_fir::ty::Ty;
@@ -338,6 +338,7 @@ fn rebuild_expr(
 ) {
     let graph_start = builder.len();
     let expr = package.get_expr(expr_id);
+    let expr_span = expr.span;
     let kind = expr.kind.clone();
 
     match kind {
@@ -411,13 +412,17 @@ fn rebuild_expr(
             rebuild_expr(package, builder, lhs, ranges);
             builder.truncate(idx);
             rebuild_expr(package, builder, rhs, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Assign(lhs), expr_span));
             builder.push(ExecGraphNode::Unit);
         }
 
         ExprKind::AssignOp(op, lhs, rhs) => {
             let idx = builder.len();
-            let is_array = matches!(package.get_expr(lhs).ty, Ty::Array(..));
+            let lhs_expr = package.get_expr(lhs);
+            let lhs_ty = &lhs_expr.ty;
+            let lhs_span = lhs_expr.span;
+            let rhs_span = package.get_expr(rhs).span;
+            let is_array = matches!(lhs_ty, Ty::Array(..));
             rebuild_expr(package, builder, lhs, ranges);
 
             if is_array {
@@ -445,7 +450,15 @@ fn rebuild_expr(
                 _ => {}
             }
 
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::AssignOp {
+                    op,
+                    lhs,
+                    lhs_span,
+                    rhs_span,
+                },
+                expr_span,
+            ));
             builder.push(ExecGraphNode::Unit);
         }
 
@@ -453,7 +466,7 @@ fn rebuild_expr(
             rebuild_expr(package, builder, replace, ranges);
             builder.push(ExecGraphNode::Store);
             rebuild_expr(package, builder, container, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Expr(expr_id), expr_span));
             builder.push(ExecGraphNode::Unit);
         }
 
@@ -465,7 +478,14 @@ fn rebuild_expr(
             let idx = builder.len();
             rebuild_expr(package, builder, container, ranges);
             builder.truncate(idx);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            let index_span = package.get_expr(index).span;
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::AssignIndex {
+                    lhs: container,
+                    mid_span: index_span,
+                },
+                expr_span,
+            ));
             builder.push(ExecGraphNode::Unit);
         }
 
@@ -479,12 +499,25 @@ fn rebuild_expr(
         // `ExprKind::ArrayLit` pops after each item. This asymmetry
         // matches the evaluator's expected stack shape for the two
         // array-construction variants.
-        ExprKind::Array(items) | ExprKind::Tuple(items) => {
+        ExprKind::Array(items) => {
             for item_id in &items {
                 rebuild_expr(package, builder, *item_id, ranges);
                 builder.push(ExecGraphNode::Store);
             }
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::Array(items.len()),
+                expr_span,
+            ));
+        }
+        ExprKind::Tuple(items) => {
+            for item_id in &items {
+                rebuild_expr(package, builder, *item_id, ranges);
+                builder.push(ExecGraphNode::Store);
+            }
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::Tuple(items.len()),
+                expr_span,
+            ));
         }
 
         ExprKind::ArrayLit(items) => {
@@ -492,24 +525,33 @@ fn rebuild_expr(
                 rebuild_expr(package, builder, *item_id, ranges);
                 builder.pop();
             }
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Expr(expr_id), expr_span));
         }
 
         ExprKind::ArrayRepeat(val, size) => {
             rebuild_expr(package, builder, val, ranges);
             builder.push(ExecGraphNode::Store);
             rebuild_expr(package, builder, size, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::ArrayRepeat, expr_span));
         }
 
-        ExprKind::BinOp(_op, lhs, rhs) => {
+        ExprKind::BinOp(op, lhs, rhs) => {
             // Non-short-circuit binary op (AndL/OrL handled above).
             // Store saves the LHS value so both operands are available
             // when the Expr node evaluates the operation.
+            let lhs_span = package.get_expr(lhs).span;
+            let rhs_span = package.get_expr(rhs).span;
             rebuild_expr(package, builder, lhs, ranges);
             builder.push(ExecGraphNode::Store);
             rebuild_expr(package, builder, rhs, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::BinOp {
+                    op,
+                    lhs_span,
+                    rhs_span,
+                },
+                expr_span,
+            ));
         }
 
         ExprKind::Call(callee, arg) => {
@@ -518,21 +560,33 @@ fn rebuild_expr(
             rebuild_expr(package, builder, callee, ranges);
             builder.push(ExecGraphNode::Store);
             rebuild_expr(package, builder, arg, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            let callee_span = package.get_expr(callee).span;
+            let args_span = package.get_expr(arg).span;
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::Call {
+                    callee_span,
+                    args_span,
+                },
+                expr_span,
+            ));
         }
 
         ExprKind::Index(container, index) => {
             rebuild_expr(package, builder, container, ranges);
             builder.push(ExecGraphNode::Store);
             rebuild_expr(package, builder, index, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            let index_span = package.get_expr(index).span;
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::Index { index_span },
+                expr_span,
+            ));
         }
 
         ExprKind::UpdateField(record, _field, replace) => {
             rebuild_expr(package, builder, replace, ranges);
             builder.push(ExecGraphNode::Store);
             rebuild_expr(package, builder, record, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Expr(expr_id), expr_span));
         }
 
         ExprKind::UpdateIndex(lhs, mid, rhs) => {
@@ -541,7 +595,11 @@ fn rebuild_expr(
             rebuild_expr(package, builder, rhs, ranges);
             builder.push(ExecGraphNode::Store);
             rebuild_expr(package, builder, lhs, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            let mid_span = package.get_expr(mid).span;
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::UpdateIndex { mid_span },
+                expr_span,
+            ));
         }
 
         ExprKind::Range(start, step, end) => {
@@ -556,7 +614,14 @@ fn rebuild_expr(
             if let Some(e) = end {
                 rebuild_expr(package, builder, e, ranges);
             }
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(
+                ExecGraphExpr::Range {
+                    has_start: start.is_some(),
+                    has_step: step.is_some(),
+                    has_end: end.is_some(),
+                },
+                expr_span,
+            ));
         }
 
         ExprKind::String(components) => {
@@ -566,27 +631,29 @@ fn rebuild_expr(
                     builder.push(ExecGraphNode::Store);
                 }
             }
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Expr(expr_id), expr_span));
         }
 
-        // Simple variants (just Expr(id))
-        ExprKind::Lit(..) | ExprKind::Var(..) => {
-            builder.push(ExecGraphNode::Expr(expr_id));
+        ExprKind::Lit(..) => {
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Expr(expr_id), expr_span));
+        }
+        ExprKind::Var(res, _) => {
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Var(res), expr_span));
         }
 
         ExprKind::Fail(msg) => {
             rebuild_expr(package, builder, msg, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Fail, expr_span));
         }
 
         ExprKind::Field(container, _) => {
             rebuild_expr(package, builder, container, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::Expr(expr_id), expr_span));
         }
 
-        ExprKind::UnOp(_, operand) => {
+        ExprKind::UnOp(op, operand) => {
             rebuild_expr(package, builder, operand, ranges);
-            builder.push(ExecGraphNode::Expr(expr_id));
+            builder.push(ExecGraphNode::Expr(ExecGraphExpr::UnOp(op), expr_span));
         }
 
         ExprKind::Parallel(limit, body) => {

--- a/source/compiler/qsc_fir_transforms/src/exec_graph_rebuild/tests.rs
+++ b/source/compiler/qsc_fir_transforms/src/exec_graph_rebuild/tests.rs
@@ -13,8 +13,8 @@ use crate::test_utils::{
 use expect_test::{Expect, expect};
 use indoc::indoc;
 use qsc_fir::fir::{
-    CallableDecl, CallableImpl, ExecGraphConfig, ExecGraphDebugNode, ExecGraphNode, ExprId, Field,
-    ItemKind, LocalVarId, PackageLookup, PatId, PatKind, Res, StoreItemId,
+    CallableDecl, CallableImpl, ExecGraphConfig, ExecGraphDebugNode, ExecGraphExpr, ExecGraphNode,
+    ExprId, Field, ItemKind, LocalVarId, PackageLookup, PatId, PatKind, Res, StoreItemId,
 };
 use rustc_hash::FxHashMap;
 
@@ -51,9 +51,12 @@ fn format_callable_exec_graph(
                 .iter()
                 .enumerate()
                 .map(|(i, node)| match node {
-                    ExecGraphNode::Expr(expr_id) => {
+                    ExecGraphNode::Expr(ExecGraphExpr::Expr(expr_id), _) => {
                         let label = expr_kind_short(package, *expr_id);
                         format!("{i}: Expr({expr_id:?}) [{label}]")
+                    }
+                    ExecGraphNode::Expr(expr, _) => {
+                        format!("{i}: Expr [{expr:?}]")
                     }
                     ExecGraphNode::Debug(ExecGraphDebugNode::Stmt(stmt_id)) => {
                         let label = stmt_kind_short(package, *stmt_id);
@@ -206,10 +209,14 @@ fn format_exec_graph_nodes(
         .enumerate()
         .map(|(index, node)| match node {
             ExecGraphNode::Bind(pat_id) => format!("{index}: {}", bind_label(package, *pat_id)),
-            ExecGraphNode::Expr(expr_id) => format!(
+            ExecGraphNode::Expr(ExecGraphExpr::Expr(expr_id), _) => format!(
                 "{index}: {}",
                 semantic_expr_label(store, package, local_names, *expr_id)
             ),
+            ExecGraphNode::Expr(ExecGraphExpr::Var(Res::Item(item_id)), _) => {
+                format!("{index}: {}", item_name(store, item_id))
+            }
+            ExecGraphNode::Expr(expr, _) => format!("{index}: {expr:?}"),
             ExecGraphNode::Jump(target) => format!("{index}: Jump({target})"),
             ExecGraphNode::JumpIf(target) => format!("{index}: JumpIf({target})"),
             ExecGraphNode::JumpIfNot(target) => format!("{index}: JumpIfNot({target})"),
@@ -458,7 +465,7 @@ fn binop_add_evaluates_operands_then_expr() {
             0: Expr(ExprId(4)) [Lit(Int(1))]
             1: Store
             2: Expr(ExprId(5)) [Lit(Int(2))]
-            3: Expr(ExprId(3)) [BinOp(Add)]
+            3: Expr [BinOp { op: Add, lhs_span: Span { lo: 24, hi: 25 }, rhs_span: Span { lo: 28, hi: 29 } }]
             4: Ret"#]],
     );
 }
@@ -472,7 +479,7 @@ fn tuple_construction_emits_store_per_element() {
             1: Store
             2: Expr(ExprId(5)) [Lit(Int(2))]
             3: Store
-            4: Expr(ExprId(3)) [Tuple(len=2)]
+            4: Expr [Tuple(2)]
             5: Ret"#]],
     );
 }
@@ -503,15 +510,15 @@ fn while_loop_emits_jump_back_to_condition() {
         &expect![[r#"
             0: Expr(ExprId(3)) [Lit(Int(0))]
             1: Bind(PatId(1))
-            2: Expr(ExprId(6)) [Var]
+            2: Expr [Var(Local(LocalVarId(1)))]
             3: Store
             4: Expr(ExprId(7)) [Lit(Int(3))]
-            5: Expr(ExprId(5)) [BinOp(Lt)]
+            5: Expr [BinOp { op: Lt, lhs_span: Span { lo: 70, hi: 71 }, rhs_span: Span { lo: 74, hi: 75 } }]
             6: JumpIfNot(14)
-            7: Expr(ExprId(9)) [Var]
+            7: Expr [Var(Local(LocalVarId(1)))]
             8: Store
             9: Expr(ExprId(10)) [Lit(Int(1))]
-            10: Expr(ExprId(8)) [AssignOp(Add)]
+            10: Expr [AssignOp { op: Add, lhs: ExprId(9), lhs_span: Span { lo: 94, hi: 95 }, rhs_span: Span { lo: 99, hi: 100 } }]
             11: Unit
             12: Unit
             13: Jump(2)
@@ -539,7 +546,7 @@ fn let_binding_stores_value_then_evaluates_body() {
         &expect![[r#"
             0: Expr(ExprId(3)) [Lit(Int(42))]
             1: Bind(PatId(1))
-            2: Expr(ExprId(4)) [Var]
+            2: Expr [Var(Local(LocalVarId(1)))]
             3: Ret"#]],
     );
 }
@@ -554,12 +561,12 @@ fn tuple_eq_lowered_to_element_wise_andl_chain() {
             0: Expr(ExprId(5)) [Lit(Int(1))]
             1: Store
             2: Expr(ExprId(8)) [Lit(Int(1))]
-            3: Expr(ExprId(10)) [BinOp(Eq)]
+            3: Expr [BinOp { op: Eq, lhs_span: Span { lo: 26, hi: 27 }, rhs_span: Span { lo: 36, hi: 37 } }]
             4: JumpIfNot(9)
             5: Expr(ExprId(6)) [Lit(Int(2))]
             6: Store
             7: Expr(ExprId(9)) [Lit(Int(2))]
-            8: Expr(ExprId(11)) [BinOp(Eq)]
+            8: Expr [BinOp { op: Eq, lhs_span: Span { lo: 29, hi: 30 }, rhs_span: Span { lo: 39, hi: 40 } }]
             9: Ret"#]],
     );
 }
@@ -571,12 +578,12 @@ fn nested_blocks_flatten_to_sequential_nodes() {
         &expect![[r#"
             0: Expr(ExprId(4)) [Lit(Int(1))]
             1: Bind(PatId(2))
-            2: Expr(ExprId(6)) [Var]
+            2: Expr [Var(Local(LocalVarId(2)))]
             3: Store
             4: Expr(ExprId(7)) [Lit(Int(1))]
-            5: Expr(ExprId(5)) [BinOp(Add)]
+            5: Expr [BinOp { op: Add, lhs_span: Span { lo: 45, hi: 46 }, rhs_span: Span { lo: 49, hi: 50 } }]
             6: Bind(PatId(1))
-            7: Expr(ExprId(8)) [Var]
+            7: Expr [Var(Local(LocalVarId(1)))]
             8: Ret"#]],
     );
 }
@@ -611,7 +618,7 @@ fn fail_expression_evaluates_message_then_expr() {
         "function Main() : Unit { fail \"error\"; }",
         &expect![[r#"
             0: Expr(ExprId(4)) [String(parts=1)]
-            1: Expr(ExprId(3)) [Fail]
+            1: Expr [Fail]
             2: Unit
             3: Ret"#]],
     );
@@ -627,9 +634,9 @@ fn assign_index_emits_store_and_expr_unit() {
             2: Expr(ExprId(8)) [Lit(Int(0))]
             3: Store
             4: Expr(ExprId(9)) [Lit(Int(42))]
-            5: Expr(ExprId(7)) [AssignIndex]
+            5: Expr [AssignIndex { lhs: ExprId(10), mid_span: Span { lo: 63, hi: 64 } }]
             6: Unit
-            7: Expr(ExprId(11)) [Var]
+            7: Expr [Var(Local(LocalVarId(1)))]
             8: Ret"#]],
     );
 }
@@ -642,9 +649,9 @@ fn exec_graph_array_repeat_emits_store_pattern() {
             0: Expr(ExprId(4)) [Lit(Int(0))]
             1: Store
             2: Expr(ExprId(5)) [Lit(Int(3))]
-            3: Expr(ExprId(3)) [ArrayRepeat]
+            3: Expr [ArrayRepeat]
             4: Bind(PatId(1))
-            5: Expr(ExprId(6)) [Var]
+            5: Expr [Var(Local(LocalVarId(1)))]
             6: Ret"#]],
     );
 }
@@ -657,7 +664,7 @@ fn exec_graph_range_expression() {
             0: Expr(ExprId(4)) [Lit(Int(0))]
             1: Store
             2: Expr(ExprId(5)) [Lit(Int(10))]
-            3: Expr(ExprId(3)) [Range]
+            3: Expr [Range { has_start: true, has_step: false, has_end: true }]
             4: Ret"#]],
     );
 }
@@ -669,7 +676,7 @@ fn exec_graph_string_interpolation() {
         &expect![[r#"
             0: Expr(ExprId(3)) [Lit(Int(42))]
             1: Bind(PatId(1))
-            2: Expr(ExprId(5)) [Var]
+            2: Expr [Var(Local(LocalVarId(1)))]
             3: Store
             4: Expr(ExprId(4)) [String(parts=2)]
             5: Ret"#]],
@@ -682,7 +689,7 @@ fn exec_graph_unary_not() {
         "function Main() : Bool { not true }",
         &expect![[r#"
             0: Expr(ExprId(4)) [Lit(Bool(true))]
-            1: Expr(ExprId(3)) [UnOp(NotL)]
+            1: Expr [UnOp(NotL)]
             2: Ret"#]],
     );
 }
@@ -708,7 +715,7 @@ fn divergent_only_body_rebuilds_fail_without_trailing_value() {
         "function Main() : Int { fail \"boom\" }",
         &expect![[r#"
             0: Expr(ExprId(4)) [String(parts=1)]
-            1: Expr(ExprId(3)) [Fail]
+            1: Expr [Fail]
             2: Ret"#]],
     );
 }
@@ -732,27 +739,27 @@ fn nested_if_within_while_rebuilds_nested_control_flow() {
         &expect![[r#"
             0: Expr(ExprId(3)) [Lit(Int(0))]
             1: Bind(PatId(1))
-            2: Expr(ExprId(6)) [Var]
+            2: Expr [Var(Local(LocalVarId(1)))]
             3: Store
             4: Expr(ExprId(7)) [Lit(Int(3))]
-            5: Expr(ExprId(5)) [BinOp(Lt)]
+            5: Expr [BinOp { op: Lt, lhs_span: Span { lo: 70, hi: 71 }, rhs_span: Span { lo: 74, hi: 75 } }]
             6: JumpIfNot(26)
-            7: Expr(ExprId(10)) [Var]
+            7: Expr [Var(Local(LocalVarId(1)))]
             8: Store
             9: Expr(ExprId(11)) [Lit(Int(1))]
-            10: Expr(ExprId(9)) [BinOp(Eq)]
+            10: Expr [BinOp { op: Eq, lhs_span: Span { lo: 97, hi: 98 }, rhs_span: Span { lo: 102, hi: 103 } }]
             11: JumpIfNot(19)
-            12: Expr(ExprId(14)) [Var]
+            12: Expr [Var(Local(LocalVarId(1)))]
             13: Store
             14: Expr(ExprId(15)) [Lit(Int(10))]
-            15: Expr(ExprId(13)) [AssignOp(Add)]
+            15: Expr [AssignOp { op: Add, lhs: ExprId(14), lhs_span: Span { lo: 126, hi: 127 }, rhs_span: Span { lo: 131, hi: 133 } }]
             16: Unit
             17: Unit
             18: Jump(25)
-            19: Expr(ExprId(18)) [Var]
+            19: Expr [Var(Local(LocalVarId(1)))]
             20: Store
             21: Expr(ExprId(19)) [Lit(Int(1))]
-            22: Expr(ExprId(17)) [AssignOp(Add)]
+            22: Expr [AssignOp { op: Add, lhs: ExprId(18), lhs_span: Span { lo: 180, hi: 181 }, rhs_span: Span { lo: 185, hi: 186 } }]
             23: Unit
             24: Unit
             25: Jump(2)
@@ -771,8 +778,8 @@ fn exec_graph_callable_with_adjoint_spec_rebuilds_body_and_adj_independently() {
         &expect![[r#"
             0: H
             1: Store
-            2: Var(q)
-            3: Call
+            2: Var(Local(LocalVarId(1)))
+            3: Call { callee_span: Span { lo: 52, hi: 53 }, args_span: Span { lo: 54, hi: 55 } }
             4: Unit
             5: Ret"#]],
     );
@@ -783,8 +790,8 @@ fn exec_graph_callable_with_adjoint_spec_rebuilds_body_and_adj_independently() {
         &expect![[r#"
             0: X
             1: Store
-            2: Var(q)
-            3: Call
+            2: Var(Local(LocalVarId(1)))
+            3: Call { callee_span: Span { lo: 74, hi: 75 }, args_span: Span { lo: 76, hi: 77 } }
             4: Unit
             5: Ret"#]],
     );
@@ -806,14 +813,14 @@ fn controlled_spec_exec_graph_rebuilds_semantic_order() {
         CallableSpecKind::Ctl,
         &expect![[r#"
             0: X
-            1: Functor(Ctl)(X)
+            1: UnOp(Functor(Ctl))
             2: Store
-            3: Var(ctls)
+            3: Var(Local(LocalVarId(2)))
             4: Store
-            5: Var(q)
+            5: Var(Local(LocalVarId(1)))
             6: Store
-            7: Tuple(len=2)
-            8: Call
+            7: Tuple(2)
+            8: Call { callee_span: Span { lo: 109, hi: 121 }, args_span: Span { lo: 121, hi: 130 } }
             9: Unit
             10: Ret"#]],
     );
@@ -837,15 +844,15 @@ fn controlled_adjoint_spec_exec_graph_rebuilds_semantic_order() {
         CallableSpecKind::CtlAdj,
         &expect![[r#"
             0: S
-            1: Functor(Adj)(S)
-            2: Functor(Ctl)(Functor(Adj)(S))
+            1: UnOp(Functor(Adj))
+            2: UnOp(Functor(Ctl))
             3: Store
-            4: Var(ctls)
+            4: Var(Local(LocalVarId(3)))
             5: Store
-            6: Var(q)
+            6: Var(Local(LocalVarId(1)))
             7: Store
-            8: Tuple(len=2)
-            9: Call
+            8: Tuple(2)
+            9: Call { callee_span: Span { lo: 227, hi: 247 }, args_span: Span { lo: 247, hi: 256 } }
             10: Unit
             11: Ret"#]],
     );
@@ -859,14 +866,14 @@ fn exec_graph_entry_expression_rebuilt_correctly() {
             0: Expr(ExprId(4)) [Lit(Int(1))]
             1: Store
             2: Expr(ExprId(5)) [Lit(Int(2))]
-            3: Expr(ExprId(3)) [BinOp(Add)]
+            3: Expr [BinOp { op: Add, lhs_span: Span { lo: 32, hi: 33 }, rhs_span: Span { lo: 36, hi: 37 } }]
             4: Bind(PatId(1))
-            5: Expr(ExprId(7)) [Var]
+            5: Expr [Var(Local(LocalVarId(1)))]
             6: Store
             7: Expr(ExprId(8)) [Lit(Int(3))]
-            8: Expr(ExprId(6)) [BinOp(Mul)]
+            8: Expr [BinOp { op: Mul, lhs_span: Span { lo: 47, hi: 48 }, rhs_span: Span { lo: 51, hi: 52 } }]
             9: Bind(PatId(2))
-            10: Expr(ExprId(9)) [Var]
+            10: Expr [Var(Local(LocalVarId(2)))]
             11: Ret"#]],
     );
 }
@@ -974,7 +981,7 @@ fn external_udt_copy_update_exec_graph_rebuilds_mutated_external_spec() {
         qsc_fir::fir::ExecGraphConfig::NoDebug,
     );
     assert!(
-        graph.contains("Tuple(len=2)"),
+        graph.contains("Tuple(2)"),
         "external copy-update exec graph should include the erased update tuple:\n{graph}"
     );
     // The external library body is transformed cross-package: UDT erasure
@@ -982,7 +989,7 @@ fn external_udt_copy_update_exec_graph_rebuilds_mutated_external_spec() {
     // scalar-replaces the untouched-field projection, so the rebuilt graph
     // reads it through a decomposed local rather than a `.1` field path.
     assert!(
-        graph.contains("Var(LocalVarId"),
+        graph.contains("Var(Local(LocalVarId"),
         "external copy-update exec graph should read the untouched field through a \
          decomposed local after tuple-decompose:\n{graph}"
     );
@@ -1024,21 +1031,21 @@ fn exec_graph_rebuild_passes_post_all_invariant() {
     expect![[r#"
         0: __quantum__rt__qubit_allocate
         1: Store
-        2: Tuple(len=0)
-        3: Call
+        2: Tuple(0)
+        3: Call { callee_span: Span { lo: 73, hi: 89 }, args_span: Span { lo: 73, hi: 89 } }
         4: Bind(q)
         5: H
         6: Store
-        7: Var(LocalVarId(1))
-        8: Call
+        7: Var(Local(LocalVarId(1)))
+        8: Call { callee_span: Span { lo: 98, hi: 99 }, args_span: Span { lo: 100, hi: 101 } }
         9: Reset
         10: Store
-        11: Var(LocalVarId(1))
-        12: Call
+        11: Var(Local(LocalVarId(1)))
+        12: Call { callee_span: Span { lo: 112, hi: 117 }, args_span: Span { lo: 118, hi: 119 } }
         13: __quantum__rt__qubit_release
         14: Store
-        15: Var(LocalVarId(1))
-        16: Call
+        15: Var(Local(LocalVarId(1)))
+        16: Call { callee_span: Span { lo: 73, hi: 89 }, args_span: Span { lo: 73, hi: 89 } }
         17: Unit
         18: Ret"#]]
     .assert_eq(&graph);
@@ -1170,13 +1177,13 @@ fn parallel_without_limit_emits_par_start_and_end() {
             1: Store
             2: Expr(ExprId(5)) [Lit(Int(2))]
             3: Store
-            4: Expr(ExprId(3)) [Tuple(len=2)]
+            4: Expr [Tuple(2)]
             5: Bind(PatId(1))
             6: ParStart(Unlimited)
-            7: Expr(ExprId(13)) [Var]
+            7: Expr [Var(Local(LocalVarId(2)))]
             8: Store
-            9: Expr(ExprId(14)) [Var]
-            10: Expr(ExprId(8)) [BinOp(Add)]
+            9: Expr [Var(Local(LocalVarId(3)))]
+            10: Expr [BinOp { op: Add, lhs_span: Span { lo: 140, hi: 145 }, rhs_span: Span { lo: 148, hi: 153 } }]
             11: ParEnd
             12: Ret"#]],
     );
@@ -1200,14 +1207,14 @@ fn parallel_within_limit_emits_par_start_with_limit() {
             1: Store
             2: Expr(ExprId(5)) [Lit(Int(4))]
             3: Store
-            4: Expr(ExprId(3)) [Tuple(len=2)]
+            4: Expr [Tuple(2)]
             5: Bind(PatId(1))
-            6: Expr(ExprId(15)) [Var]
+            6: Expr [Var(Local(LocalVarId(2)))]
             7: ParStart(Limited)
-            8: Expr(ExprId(16)) [Var]
+            8: Expr [Var(Local(LocalVarId(2)))]
             9: Store
-            10: Expr(ExprId(17)) [Var]
-            11: Expr(ExprId(10)) [BinOp(Add)]
+            10: Expr [Var(Local(LocalVarId(3)))]
+            11: Expr [BinOp { op: Add, lhs_span: Span { lo: 153, hi: 158 }, rhs_span: Span { lo: 161, hi: 166 } }]
             12: ParEnd
             13: Ret"#]],
     );

--- a/source/compiler/qsc_fir_transforms/src/invariants.rs
+++ b/source/compiler/qsc_fir_transforms/src/invariants.rs
@@ -2134,6 +2134,7 @@ fn check_local_reference(
 /// # Panics
 ///
 /// Panics with a descriptive message if any invariant is violated.
+#[allow(clippy::too_many_lines)]
 fn check_configured_exec_graph(
     package: &Package,
     nodes: &[ExecGraphNode],
@@ -2176,12 +2177,45 @@ fn check_configured_exec_graph(
                 );
             }
             // Invariant B: Expr references valid ExprId.
-            ExecGraphNode::Expr(expr_id) => {
-                assert!(
+            ExecGraphNode::Expr(expr, _) => match expr {
+                qsc_fir::fir::ExecGraphExpr::Expr(expr_id)
+                | qsc_fir::fir::ExecGraphExpr::Assign(expr_id)
+                | qsc_fir::fir::ExecGraphExpr::AssignOp {
+                    lhs: expr_id,
+                    op: _,
+                    lhs_span: _,
+                    rhs_span: _,
+                }
+                | qsc_fir::fir::ExecGraphExpr::AssignIndex {
+                    lhs: expr_id,
+                    mid_span: _,
+                } => assert!(
                     package.exprs.get(*expr_id).is_some(),
                     "Exec graph for {context} ({config_label}): node {i} references nonexistent Expr {expr_id}"
-                );
-            }
+                ),
+                qsc_fir::fir::ExecGraphExpr::Array(_)
+                | qsc_fir::fir::ExecGraphExpr::ArrayRepeat
+                | qsc_fir::fir::ExecGraphExpr::BinOp {
+                    op: _,
+                    lhs_span: _,
+                    rhs_span: _,
+                }
+                | qsc_fir::fir::ExecGraphExpr::Call {
+                    callee_span: _,
+                    args_span: _,
+                }
+                | qsc_fir::fir::ExecGraphExpr::Fail
+                | qsc_fir::fir::ExecGraphExpr::Index { index_span: _ }
+                | qsc_fir::fir::ExecGraphExpr::Range {
+                    has_start: _,
+                    has_step: _,
+                    has_end: _,
+                }
+                | qsc_fir::fir::ExecGraphExpr::UpdateIndex { mid_span: _ }
+                | qsc_fir::fir::ExecGraphExpr::Tuple(_)
+                | qsc_fir::fir::ExecGraphExpr::UnOp(_)
+                | qsc_fir::fir::ExecGraphExpr::Var(_) => {}
+            },
             // Invariant C: Bind references valid PatId.
             ExecGraphNode::Bind(pat_id) => {
                 assert!(

--- a/source/compiler/qsc_lowerer/src/lib.rs
+++ b/source/compiler/qsc_lowerer/src/lib.rs
@@ -4,8 +4,8 @@
 use qsc_data_structures::index_map::IndexMap;
 use qsc_fir::assigner::Assigner;
 use qsc_fir::fir::{
-    Block, CallableImpl, ExecGraph, ExecGraphDebugNode, ExecGraphIdx, ExecGraphNode, Expr, Pat,
-    SpecImpl, Stmt,
+    Block, CallableImpl, ExecGraph, ExecGraphDebugNode, ExecGraphExpr, ExecGraphIdx, ExecGraphNode,
+    Expr, Pat, SpecImpl, Stmt,
 };
 use qsc_fir::{
     fir::{self, BlockId, ExprId, LocalItemId, PatId, StmtId},
@@ -515,32 +515,38 @@ impl Lowerer {
         let graph_start_idx = self.exec_graph.len();
         let ty = self.lower_ty(&expr.ty);
 
-        let kind = match &expr.kind {
+        let (kind, exec_expr) = match &expr.kind {
             hir::ExprKind::Array(items) => {
                 if items
                     .iter()
                     .all(|i| matches!(i.kind, hir::ExprKind::Lit(..)))
                 {
-                    fir::ExprKind::ArrayLit(
-                        items
-                            .iter()
-                            .map(|i| {
-                                let i = self.lower_expr(i);
-                                self.exec_graph.pop();
-                                i
-                            })
-                            .collect(),
+                    (
+                        fir::ExprKind::ArrayLit(
+                            items
+                                .iter()
+                                .map(|i| {
+                                    let i = self.lower_expr(i);
+                                    self.exec_graph.pop();
+                                    i
+                                })
+                                .collect(),
+                        ),
+                        None,
                     )
                 } else {
-                    fir::ExprKind::Array(
-                        items
-                            .iter()
-                            .map(|i| {
-                                let i = self.lower_expr(i);
-                                self.exec_graph.push(ExecGraphNode::Store);
-                                i
-                            })
-                            .collect(),
+                    (
+                        fir::ExprKind::Array(
+                            items
+                                .iter()
+                                .map(|i| {
+                                    let i = self.lower_expr(i);
+                                    self.exec_graph.push(ExecGraphNode::Store);
+                                    i
+                                })
+                                .collect(),
+                        ),
+                        Some(ExecGraphExpr::Array(items.len())),
                     )
                 }
             }
@@ -548,7 +554,10 @@ impl Lowerer {
                 let value = self.lower_expr(value);
                 self.exec_graph.push(ExecGraphNode::Store);
                 let size = self.lower_expr(size);
-                fir::ExprKind::ArrayRepeat(value, size)
+                (
+                    fir::ExprKind::ArrayRepeat(value, size),
+                    Some(ExecGraphExpr::ArrayRepeat),
+                )
             }
             hir::ExprKind::Assign(lhs, rhs) => {
                 let idx = self.exec_graph.len();
@@ -556,11 +565,16 @@ impl Lowerer {
                 // The left-hand side of an assignment is not really an expression to be executed,
                 // so remove any added nodes from the execution graph.
                 self.exec_graph.truncate(idx);
-                fir::ExprKind::Assign(lhs, self.lower_expr(rhs))
+                (
+                    fir::ExprKind::Assign(lhs, self.lower_expr(rhs)),
+                    Some(ExecGraphExpr::Assign(lhs)),
+                )
             }
             hir::ExprKind::AssignOp(op, lhs, rhs) => {
                 let idx = self.exec_graph.len();
                 let is_array = matches!(lhs.ty, qsc_hir::ty::Ty::Array(..));
+                let lhs_span = lhs.span;
+                let rhs_span = rhs.span;
                 let lhs = self.lower_expr(lhs);
                 if is_array {
                     // The left-hand side of an array append is not really an expression to be
@@ -592,16 +606,26 @@ impl Lowerer {
                     }
                     _ => {}
                 }
-                fir::ExprKind::AssignOp(lower_binop(*op), lhs, rhs)
+                let op = lower_binop(*op);
+                (
+                    fir::ExprKind::AssignOp(op, lhs, rhs),
+                    Some(ExecGraphExpr::AssignOp {
+                        op,
+                        lhs,
+                        lhs_span,
+                        rhs_span,
+                    }),
+                )
             }
             hir::ExprKind::AssignField(container, field, replace) => {
                 let field = lower_field(field);
                 let replace = self.lower_expr(replace);
                 self.exec_graph.push(ExecGraphNode::Store);
                 let container = self.lower_expr(container);
-                fir::ExprKind::AssignField(container, field, replace)
+                (fir::ExprKind::AssignField(container, field, replace), None)
             }
             hir::ExprKind::AssignIndex(container, index, replace) => {
+                let index_span = index.span;
                 let index = self.lower_expr(index);
                 self.exec_graph.push(ExecGraphNode::Store);
                 let replace = self.lower_expr(replace);
@@ -610,9 +634,17 @@ impl Lowerer {
                 // The left-hand side of an array index assignment is not really an expression to be
                 // executed, so remove any added nodes from the execution graph.
                 self.exec_graph.truncate(idx);
-                fir::ExprKind::AssignIndex(container, index, replace)
+                (
+                    fir::ExprKind::AssignIndex(container, index, replace),
+                    Some(ExecGraphExpr::AssignIndex {
+                        lhs: container,
+                        mid_span: index_span,
+                    }),
+                )
             }
             hir::ExprKind::BinOp(op, lhs, rhs) => {
+                let lhs_span = lhs.span;
+                let rhs_span = rhs.span;
                 let lhs = self.lower_expr(lhs);
                 let idx = self.exec_graph.len();
                 if matches!(op, hir::BinOp::AndL | hir::BinOp::OrL) {
@@ -643,24 +675,43 @@ impl Lowerer {
                     }
                     _ => {}
                 }
-                fir::ExprKind::BinOp(lower_binop(*op), lhs, rhs)
+                let op = lower_binop(*op);
+                (
+                    fir::ExprKind::BinOp(op, lhs, rhs),
+                    Some(ExecGraphExpr::BinOp {
+                        op,
+                        lhs_span,
+                        rhs_span,
+                    }),
+                )
             }
-            hir::ExprKind::Block(block) => fir::ExprKind::Block(self.lower_block(block)),
+            hir::ExprKind::Block(block) => (fir::ExprKind::Block(self.lower_block(block)), None),
             hir::ExprKind::Call(callee, arg) => {
+                let callee_span = callee.span;
+                let args_span = arg.span;
                 let call = self.lower_expr(callee);
                 self.exec_graph.push(ExecGraphNode::Store);
                 let arg = self.lower_expr(arg);
-                fir::ExprKind::Call(call, arg)
+                (
+                    fir::ExprKind::Call(call, arg),
+                    Some(ExecGraphExpr::Call {
+                        callee_span,
+                        args_span,
+                    }),
+                )
             }
             hir::ExprKind::Fail(message) => {
                 // Ensure the right-hand side expression is lowered first so that it
                 // is executed before the fail node, if any.
-                fir::ExprKind::Fail(self.lower_expr(message))
+                (
+                    fir::ExprKind::Fail(self.lower_expr(message)),
+                    Some(ExecGraphExpr::Fail),
+                )
             }
             hir::ExprKind::Field(container, field) => {
                 let container = self.lower_expr(container);
                 let field = lower_field(field);
-                fir::ExprKind::Field(container, field)
+                (fir::ExprKind::Field(container, field), None)
             }
             hir::ExprKind::If(cond, if_true, if_false) => {
                 let cond = self.lower_expr(cond);
@@ -687,13 +738,17 @@ impl Lowerer {
                 // Update the placeholder to skip the true branch if the condition is false
                 self.exec_graph
                     .set_with_arg(ExecGraphNode::JumpIfNot, branch_idx, else_idx);
-                fir::ExprKind::If(cond, if_true, if_false)
+                (fir::ExprKind::If(cond, if_true, if_false), None)
             }
             hir::ExprKind::Index(container, index) => {
+                let index_span = index.span;
                 let container = self.lower_expr(container);
                 self.exec_graph.push(ExecGraphNode::Store);
                 let index = self.lower_expr(index);
-                fir::ExprKind::Index(container, index)
+                (
+                    fir::ExprKind::Index(container, index),
+                    Some(ExecGraphExpr::Index { index_span }),
+                )
             }
             hir::ExprKind::Parallel(limit, expr) => {
                 let limit = limit.as_ref().map(|l| self.lower_expr(l));
@@ -704,9 +759,9 @@ impl Lowerer {
                 let expr = self.lower_expr(expr);
                 self.exec_graph.push(ExecGraphNode::ParEnd);
                 self.parallel_count -= 1;
-                fir::ExprKind::Parallel(limit, expr)
+                (fir::ExprKind::Parallel(limit, expr), None)
             }
-            hir::ExprKind::Lit(lit) => lower_lit(lit),
+            hir::ExprKind::Lit(lit) => (lower_lit(lit), None),
             hir::ExprKind::Range(start, step, end) => {
                 let start = start.as_ref().map(|s| self.lower_expr(s));
                 if start.is_some() {
@@ -717,7 +772,14 @@ impl Lowerer {
                     self.exec_graph.push(ExecGraphNode::Store);
                 }
                 let end = end.as_ref().map(|e| self.lower_expr(e));
-                fir::ExprKind::Range(start, step, end)
+                (
+                    fir::ExprKind::Range(start, step, end),
+                    Some(ExecGraphExpr::Range {
+                        has_start: start.is_some(),
+                        has_step: step.is_some(),
+                        has_end: end.is_some(),
+                    }),
+                )
             }
             hir::ExprKind::Return(expr) => {
                 let expr = self.lower_expr(expr);
@@ -729,7 +791,7 @@ impl Lowerer {
                     self.exec_graph.push(ExecGraphNode::ParEnd);
                 }
                 self.exec_graph.push_ret();
-                fir::ExprKind::Return(expr)
+                (fir::ExprKind::Return(expr), None)
             }
             hir::ExprKind::Struct(name, copy, fields) => {
                 let res = self.lower_res(name);
@@ -746,20 +808,27 @@ impl Lowerer {
                         f
                     })
                     .collect();
-                fir::ExprKind::Struct(res, copy, fields)
+                (fir::ExprKind::Struct(res, copy, fields), None)
             }
-            hir::ExprKind::Tuple(items) => fir::ExprKind::Tuple(
-                items
-                    .iter()
-                    .map(|i| {
-                        let i = self.lower_expr(i);
-                        self.exec_graph.push(ExecGraphNode::Store);
-                        i
-                    })
-                    .collect(),
+            hir::ExprKind::Tuple(items) => (
+                fir::ExprKind::Tuple(
+                    items
+                        .iter()
+                        .map(|i| {
+                            let i = self.lower_expr(i);
+                            self.exec_graph.push(ExecGraphNode::Store);
+                            i
+                        })
+                        .collect(),
+                ),
+                Some(ExecGraphExpr::Tuple(items.len())),
             ),
             hir::ExprKind::UnOp(op, operand) => {
-                fir::ExprKind::UnOp(lower_unop(*op), self.lower_expr(operand))
+                let op = lower_unop(*op);
+                (
+                    fir::ExprKind::UnOp(op, self.lower_expr(operand)),
+                    Some(ExecGraphExpr::UnOp(op)),
+                )
             }
             hir::ExprKind::While(cond, body) => {
                 self.exec_graph
@@ -785,69 +854,95 @@ impl Lowerer {
                 // While-exprs never have a return value, so we need to insert a no-op to ensure
                 // a Unit value is returned for the expr.
                 self.exec_graph.push(ExecGraphNode::Unit);
-                fir::ExprKind::While(cond, body)
+                (fir::ExprKind::While(cond, body), None)
             }
             hir::ExprKind::Closure(ids, id) => {
                 let ids = ids.iter().map(|id| self.lower_local_id(*id)).collect();
-                fir::ExprKind::Closure(ids, lower_local_item_id(*id))
+                (fir::ExprKind::Closure(ids, lower_local_item_id(*id)), None)
             }
-            hir::ExprKind::String(components) => fir::ExprKind::String(
-                components
-                    .iter()
-                    .map(|c| self.lower_string_component(c))
-                    .collect(),
+            hir::ExprKind::String(components) => (
+                fir::ExprKind::String(
+                    components
+                        .iter()
+                        .map(|c| self.lower_string_component(c))
+                        .collect(),
+                ),
+                None,
             ),
             hir::ExprKind::UpdateIndex(lhs, mid, rhs) => {
+                let mid_span = mid.span;
                 let mid = self.lower_expr(mid);
                 self.exec_graph.push(ExecGraphNode::Store);
                 let rhs = self.lower_expr(rhs);
                 self.exec_graph.push(ExecGraphNode::Store);
                 let lhs = self.lower_expr(lhs);
-                fir::ExprKind::UpdateIndex(lhs, mid, rhs)
+                (
+                    fir::ExprKind::UpdateIndex(lhs, mid, rhs),
+                    Some(ExecGraphExpr::UpdateIndex { mid_span }),
+                )
             }
             hir::ExprKind::UpdateField(record, field, replace) => {
                 let field = lower_field(field);
                 let replace = self.lower_expr(replace);
                 self.exec_graph.push(ExecGraphNode::Store);
                 let record = self.lower_expr(record);
-                fir::ExprKind::UpdateField(record, field, replace)
+                (fir::ExprKind::UpdateField(record, field, replace), None)
             }
             hir::ExprKind::Var(res, args) => {
                 let res = self.lower_res(res);
                 let args = args.iter().map(|arg| self.lower_generic_arg(arg)).collect();
-                fir::ExprKind::Var(res, args)
+                (fir::ExprKind::Var(res, args), Some(ExecGraphExpr::Var(res)))
             }
             hir::ExprKind::Break => panic!("break should be eliminated by passes"),
             hir::ExprKind::Conjugate(..) => panic!("conjugate should be eliminated by passes"),
             hir::ExprKind::Continue => panic!("continue should be eliminated by passes"),
             hir::ExprKind::Err => panic!("error expr should not be present"),
             hir::ExprKind::For(..) => panic!("for-loop should be eliminated by passes"),
-            hir::ExprKind::Hole => fir::ExprKind::Hole, // allowed for discards
+            hir::ExprKind::Hole => (fir::ExprKind::Hole, None), // allowed for discards
             hir::ExprKind::Repeat(..) => panic!("repeat-loop should be eliminated by passes"),
         };
 
-        match kind {
+        match (&kind, exec_expr) {
             // These expressions express specific control flow that is handled above.
-            fir::ExprKind::BinOp(fir::BinOp::AndL | fir::BinOp::OrL, _, _)
-            | fir::ExprKind::Block(..)
-            | fir::ExprKind::If(..)
-            | fir::ExprKind::Return(..)
-            | fir::ExprKind::While(..)
-            | fir::ExprKind::Parallel(..) => {}
+            (
+                fir::ExprKind::BinOp(fir::BinOp::AndL | fir::BinOp::OrL, _, _)
+                | fir::ExprKind::Block(..)
+                | fir::ExprKind::If(..)
+                | fir::ExprKind::Return(..)
+                | fir::ExprKind::While(..)
+                | fir::ExprKind::Parallel(..),
+                None,
+            ) => {}
 
-            fir::ExprKind::Assign(..)
-            | fir::ExprKind::AssignField(..)
-            | fir::ExprKind::AssignIndex(..)
-            | fir::ExprKind::AssignOp(..) => {
+            (
+                fir::ExprKind::Assign(..)
+                | fir::ExprKind::AssignField(..)
+                | fir::ExprKind::AssignIndex(..)
+                | fir::ExprKind::AssignOp(..),
+                exec_expr,
+            ) => {
                 // Assignments are expressions that always produce the value `Unit`,
                 // so we need to push the expr first and then follow up with an explicit
                 // `Unit` node.
-                self.exec_graph.push(ExecGraphNode::Expr(id));
+                if let Some(exec_expr) = exec_expr {
+                    self.exec_graph
+                        .push(ExecGraphNode::Expr(exec_expr, expr.span));
+                } else {
+                    self.exec_graph
+                        .push(ExecGraphNode::Expr(ExecGraphExpr::Expr(id), expr.span));
+                }
                 self.exec_graph.push(ExecGraphNode::Unit);
             }
 
+            (_, Some(exec_expr)) => {
+                self.exec_graph
+                    .push(ExecGraphNode::Expr(exec_expr, expr.span));
+            }
+
             // All other expressions should be added to the execution graph.
-            _ => self.exec_graph.push(ExecGraphNode::Expr(id)),
+            _ => self
+                .exec_graph
+                .push(ExecGraphNode::Expr(ExecGraphExpr::Expr(id), expr.span)),
         }
 
         let expr = fir::Expr {


### PR DESCRIPTION
This change updates the structure of the execution graph to have expression specific nodes, bringing the graph one step closer to a bytecode. Previously for many expressions, the evaluator would use the expression ID to query the FIR only for the span and one or two simple properties. By instead embedding these values into the execution graph during lowering, we can save queries and matches. Some complex expressions that include data that is not `Copy` compatible have been left as generic `Expr` nodes and are queried as before.

In testing, this showed improvement in many of the evaluation-related benchmarks:
<span data-teams="true">
Benchmark | Performance
-- | --
Teleportation | −9.8297%
Deutsch-Jozsa | −11.350%
Large File Parity | −6.3031%
Bench 5x5 | −1.9456%
Array Append | −8.7422%
Array Update | −8.9330%
Array Literal | −2.5433%

</span>