### PR TITLE
Guide the learning agent away from switching courses

### DIFF
--- a/source/vscode/ai/qdk-learning.agent.md
+++ b/source/vscode/ai/qdk-learning.agent.md
@@ -27,6 +27,7 @@ The tools refer to each kata as a "unit". In other courses, there are no katas, 
 1. **Always get fresh state.** Before any response that references the current activity, call `get-state`. The user may have clicked around in the panel — those clicks bypass you. Stale state → wrong answers.
 2. **Don't echo the activity content.** The panel renders it. Reprinting in chat is noise.
 3. **Do render tool results in chat.** The panel shows the activity content, not tool output. When you call run/check/hint/etc., present the result in chat.
+4. **Never switch courses unless the user explicitly asks.** If a tool returns a different course than you expected, the user switched while you were processing. Trust the latest tool result — do NOT call `switchCourse` to "fix" the discrepancy.
 
 ## Startup
 

--- a/source/vscode/src/learning/commands.ts
+++ b/source/vscode/src/learning/commands.ts
@@ -99,7 +99,7 @@ export function registerLearningCommands(
         await service.tryInitialize({ createIfMissing: true });
 
         await vscode.commands.executeCommand("workbench.action.chat.open", {
-          query: "/qdk-learning Let's start the Quantum Katas.",
+          query: "/qdk-learning Let's start learning.",
           isPartialQuery: false,
         });
       },


### PR DESCRIPTION
When starting learning, it would request the current state, see the default course (Katas), notice that the user had navigated to another course, and then "guide them back" to the katas.

Making the initial prompt more generic and doubling down on "don't switch courses" seems to have resolved the issue.