### PR TITLE
[QRE] Show errors in case when resource estimation has no results.

### DIFF
--- a/source/qdk_package/qdk/qre/_estimation.py
+++ b/source/qdk_package/qdk/qre/_estimation.py
@@ -211,6 +211,22 @@ def estimate(
         total_jobs = collection.total_jobs
         successful = collection.successful_estimates
 
+    if len(collection) == 0:
+        warning_message = "Resource estimation produced zero results.\n"
+        if any(
+            "resource estimation exceeded the maximum allowed error" in err
+            for err in collection.errors
+        ):
+            warning_message += (
+                "This was caused by error exceeding max_error for every trace. "
+                "Try increasing max_error to get results.\n"
+            )
+        if len(collection.errors) > 0:
+            warning_message += "Resource estimation produced the following errors:\n"
+            for err in collection.errors[:10]:
+                warning_message += "  " + err + "\n"
+        print(warning_message)
+
     # Post-process the results and add them to a results table
     table = EstimationTable()
 

--- a/source/qdk_package/qdk/qre/_qre.pyi
+++ b/source/qdk_package/qdk/qre/_qre.pyi
@@ -1197,6 +1197,16 @@ class _EstimationCollection:
         ...
 
     @property
+    def errors(self) -> list[str]:
+        """
+        Return the errors reported by failed estimation jobs.
+
+        Returns:
+            list[str]: The error messages from failed estimates.
+        """
+        ...
+
+    @property
     def all_summaries(self) -> list[tuple[int, int, int, int]]:
         """
         Return lightweight summaries of ALL successful estimates as a list

--- a/source/qdk_package/src/qre.rs
+++ b/source/qdk_package/src/qre.rs
@@ -978,6 +978,11 @@ impl EstimationCollection {
         self.0.successful_estimates()
     }
 
+    #[getter]
+    pub fn errors(&self) -> Vec<String> {
+        self.0.errors().to_vec()
+    }
+
     /// Returns lightweight summaries of ALL successful estimates as a list
     /// of (trace index, isa index, qubits, runtime) tuples.
     #[getter]

--- a/source/qre/src/result.rs
+++ b/source/qre/src/result.rs
@@ -8,7 +8,7 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use crate::{ISA, ParetoFrontier2D, ParetoItem2D, Property};
+use crate::{Error, ISA, ParetoFrontier2D, ParetoItem2D, Property};
 
 /// Controls how individual error contributions passed to
 /// [`EstimationResult::add_error`] are composed into the total error.
@@ -225,6 +225,8 @@ pub struct EstimationCollection {
     total_jobs: usize,
     successful_estimates: usize,
     isas: Vec<ISA>,
+    /// Errors for failed estimates.
+    errors: Vec<String>,
 }
 
 impl EstimationCollection {
@@ -272,6 +274,15 @@ impl EstimationCollection {
     #[must_use]
     pub fn isas(&self) -> &[ISA] {
         &self.isas
+    }
+
+    pub fn push_error(&mut self, err: &Error) {
+        self.errors.push(err.to_string());
+    }
+
+    #[must_use]
+    pub fn errors(&self) -> &[String] {
+        &self.errors
     }
 }
 

--- a/source/qre/src/trace/estimation.rs
+++ b/source/qre/src/trace/estimation.rs
@@ -443,7 +443,7 @@ pub fn estimate_with_graph(
             let runtime_affecting_ids = &runtime_affecting_ids;
             let isa_index = Arc::clone(&isa_index);
             scope.spawn(move || {
-                let mut local_results: Vec<Result<EstimationResult, Error>> = Vec::new();
+                let mut local_results = Vec::new();
                 loop {
                     let job_idx = next_job.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     if job_idx >= total_jobs {

--- a/source/qre/src/trace/estimation.rs
+++ b/source/qre/src/trace/estimation.rs
@@ -10,7 +10,10 @@ use std::{
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::{ErrorComposition, EstimationCollection, ISA, ProvenanceGraph, ResultSummary, Trace};
+use crate::{
+    Error, ErrorComposition, EstimationCollection, EstimationResult, ISA, ProvenanceGraph,
+    ResultSummary, Trace,
+};
 
 /// Estimates all (trace, ISA) combinations in parallel, returning only the
 /// successful results collected into an [`EstimationCollection`].
@@ -58,7 +61,7 @@ pub fn estimate_parallel<'a>(
             let tx = tx.clone();
             let next_job = &next_job;
             scope.spawn(move || {
-                let mut local_results = Vec::new();
+                let mut local_results: Vec<Result<EstimationResult, Error>> = Vec::new();
                 loop {
                     // Atomically claim the next job.  Relaxed ordering is
                     // sufficient because there is no dependent data between
@@ -72,14 +75,14 @@ pub fn estimate_parallel<'a>(
                     let trace_idx = job / num_isas;
                     let isa_idx = job % num_isas;
 
-                    if let Ok(mut estimation) =
-                        traces[trace_idx].estimate(isas[isa_idx], max_error, composition)
-                    {
-                        estimation.set_isa_index(isa_idx);
-                        estimation.set_trace_index(trace_idx);
-
-                        local_results.push(estimation);
-                    }
+                    let result = traces[trace_idx]
+                        .estimate(isas[isa_idx], max_error, composition)
+                        .map(|mut estimation| {
+                            estimation.set_isa_index(isa_idx);
+                            estimation.set_trace_index(trace_idx);
+                            estimation
+                        });
+                    local_results.push(result);
                 }
                 // Send all results from this worker in one batch.
                 let _ = tx.send(local_results);
@@ -92,18 +95,23 @@ pub fn estimate_parallel<'a>(
         // Collect results from all workers into the shared collection.
         let mut successful = 0;
         for local_results in rx {
-            if post_process {
-                for result in &local_results {
-                    collection.push_summary(ResultSummary {
-                        trace_index: result.trace_index().unwrap_or(0),
-                        isa_index: result.isa_index().unwrap_or(0),
-                        qubits: result.qubits(),
-                        runtime: result.runtime(),
-                    });
+            for result in local_results {
+                match result {
+                    Ok(result) => {
+                        if post_process {
+                            collection.push_summary(ResultSummary {
+                                trace_index: result.trace_index().unwrap_or(0),
+                                isa_index: result.isa_index().unwrap_or(0),
+                                qubits: result.qubits(),
+                                runtime: result.runtime(),
+                            });
+                        }
+                        successful += 1;
+                        collection.insert(result);
+                    }
+                    Err(error) => collection.push_error(&error),
                 }
             }
-            successful += local_results.len();
-            collection.extend(local_results);
         }
         collection.set_successful_estimates(successful);
     });
@@ -297,6 +305,19 @@ pub fn estimate_with_graph(
     // cartesian product of Pareto-filtered nodes.  Each node carries
     // pre-computed (space, time) values for dominance pruning in Phase 2.
     let mut jobs: Vec<(usize, Vec<CombinationEntry>)> = Vec::new();
+    let mut collection = EstimationCollection::new();
+
+    let min_trace_error = traces
+        .iter()
+        .map(|trace| trace.base_error())
+        .reduce(f64::min)
+        .unwrap_or(0.0);
+    if min_trace_error > max_error {
+        collection.push_error(&Error::MaximumErrorExceeded {
+            actual_error: min_trace_error,
+            max_error,
+        });
+    }
 
     // Use the maximum number of instruction slots across all combinations to
     // size the pruning witness structure.  This will updated while we generate
@@ -407,7 +428,6 @@ pub fn estimate_with_graph(
     // index.
     let isa_index = Arc::new(RwLock::new(ISAIndex::default()));
 
-    let mut collection = EstimationCollection::new();
     collection.set_total_jobs(total_jobs);
 
     std::thread::scope(|scope| {
@@ -423,7 +443,7 @@ pub fn estimate_with_graph(
             let runtime_affecting_ids = &runtime_affecting_ids;
             let isa_index = Arc::clone(&isa_index);
             scope.spawn(move || {
-                let mut local_results = Vec::new();
+                let mut local_results: Vec<Result<EstimationResult, Error>> = Vec::new();
                 loop {
                     let job_idx = next_job.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     if job_idx >= total_jobs {
@@ -447,9 +467,8 @@ pub fn estimate_with_graph(
                         isa.add_node(entry.instruction_id, entry.node.node_index);
                     }
 
-                    if let Ok(mut result) =
-                        traces[*trace_idx].estimate(&isa, Some(max_error), composition)
-                    {
+                    let result = traces[*trace_idx].estimate(&isa, Some(max_error), composition);
+                    if let Ok(mut result) = result {
                         let isa_idx = isa_index
                             .write()
                             .expect("RwLock should not be poisoned")
@@ -458,8 +477,10 @@ pub fn estimate_with_graph(
 
                         result.set_trace_index(*trace_idx);
 
-                        local_results.push(result);
+                        local_results.push(Ok(result));
                         record_success(combination, &pruning_witnesses[*trace_idx]);
+                    } else {
+                        local_results.push(result);
                     }
                 }
                 let _ = tx.send(local_results);
@@ -469,18 +490,23 @@ pub fn estimate_with_graph(
 
         let mut successful = 0;
         for local_results in rx {
-            if post_process {
-                for result in &local_results {
-                    collection.push_summary(ResultSummary {
-                        trace_index: result.trace_index().unwrap_or(0),
-                        isa_index: result.isa_index().unwrap_or(0),
-                        qubits: result.qubits(),
-                        runtime: result.runtime(),
-                    });
+            for result in local_results {
+                match result {
+                    Ok(result) => {
+                        if post_process {
+                            collection.push_summary(ResultSummary {
+                                trace_index: result.trace_index().unwrap_or(0),
+                                isa_index: result.isa_index().unwrap_or(0),
+                                qubits: result.qubits(),
+                                runtime: result.runtime(),
+                            });
+                        }
+                        successful += 1;
+                        collection.insert(result);
+                    }
+                    Err(error) => collection.push_error(&error),
                 }
             }
-            successful += local_results.len();
-            collection.extend(local_results);
         }
         collection.set_successful_estimates(successful);
     });

--- a/source/qre/src/trace/tests.rs
+++ b/source/qre/src/trace/tests.rs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::isa::{Encoding, ISA, Instruction};
+use std::sync::{Arc, RwLock};
+
+use crate::isa::{Encoding, ISA, Instruction, ProvenanceGraph};
 use crate::result::ErrorComposition;
-use crate::trace::{Trace, instruction_ids::*};
+use crate::trace::{Trace, estimate_parallel, estimate_with_graph, instruction_ids::*};
 
 #[test]
 fn test_trace_iteration() {
@@ -233,6 +235,68 @@ fn test_estimate_simple() {
     assert!((result.error() - 0.001).abs() <= f64::EPSILON);
     assert_eq!(result.runtime(), 100);
     assert_eq!(result.qubits(), 50);
+}
+
+#[test]
+fn estimate_parallel_propagates_errors() {
+    let mut trace = Trace::new(1);
+    trace.add_operation(T, vec![0], vec![]);
+
+    let isa = ISA::new();
+    let collection = estimate_parallel(
+        &[&trace],
+        &[&isa],
+        None,
+        false,
+        ErrorComposition::UnionBound,
+    );
+
+    assert_eq!(collection.total_jobs(), 1);
+    assert_eq!(collection.successful_estimates(), 0);
+    assert_eq!(collection.errors().len(), 1);
+    assert!(collection.errors()[0].contains("not present in ISA"));
+}
+
+#[test]
+fn estimate_with_graph_reports_base_error_over_budget() {
+    let mut trace1 = Trace::new(1);
+    trace1.increment_base_error(0.3);
+    let mut trace2 = Trace::new(1);
+    trace2.increment_base_error(0.2);
+    let graph = Arc::new(RwLock::new(ProvenanceGraph::new()));
+
+    let collection = estimate_with_graph(
+        &[&trace1, &trace2],
+        &graph,
+        Some(0.1),
+        false,
+        ErrorComposition::UnionBound,
+    );
+
+    assert_eq!(collection.total_jobs(), 0);
+    assert_eq!(collection.successful_estimates(), 0);
+    assert_eq!(collection.errors().len(), 1);
+    assert!(collection.errors()[0].contains("0.2 > 0.1"));
+}
+
+#[test]
+fn estimate_with_graph_ignores_base_error_for_some_traces() {
+    let mut rejected_trace = Trace::new(1);
+    rejected_trace.increment_base_error(0.2);
+    let valid_trace = Trace::new(1);
+    let graph = Arc::new(RwLock::new(ProvenanceGraph::new()));
+
+    let collection = estimate_with_graph(
+        &[&rejected_trace, &valid_trace],
+        &graph,
+        Some(0.1),
+        false,
+        ErrorComposition::UnionBound,
+    );
+
+    assert_eq!(collection.total_jobs(), 1);
+    assert_eq!(collection.successful_estimates(), 1);
+    assert!(collection.errors().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
* Add mechanism to propagate resource estimation errors from Rust to Python (new `Vec<String>` in EstimationCollection).
* Add errors there for failed estimates.
* Add error for the case when all traces have error higher then max_error.
* In Python, when estimation produced zero results, print a message containing:
  * All errors.
  * Suggestion to increase max_error.

Example:
<img width="856" height="186" alt="image" src="https://github.com/user-attachments/assets/8df25fa9-2fd7-420c-87c3-04e55b16c629" />
