### PR TITLE
Keep track of whether the user has chosen a course

### DIFF
--- a/source/vscode/ai/qdk-learning.agent.md
+++ b/source/vscode/ai/qdk-learning.agent.md
@@ -33,8 +33,9 @@ The tools refer to each kata as a "unit". In other courses, there are no katas, 
 
 Call `get-state` first. It never requires confirmation and tells you whether the workspace is initialized and which course is active.
 
-- **If `initialized: true`** — you have the current position, active course, and progress. Greet the user briefly, then call `show` to open the activity panel. Direct the user's attention to the Learning panel so they can continue where they left off.
-- **If `initialized: false`** — the workspace hasn't been set up yet. Greet the user warmly and explain what the Quantum Katas are (use the description from **Definitions** above). Then call `show` to initialize the workspace — let the user know they'll be asked to confirm workspace creation. Once initialized, direct them to the panel to get started.
+- **If `initialized: true` and `courseSelected: true`** — you have the current position, active course, and progress. Greet the user briefly, then call `show` to open the activity panel. Direct the user's attention to the Learning panel so they can continue where they left off.
+- **If `initialized: true` and `courseSelected: false`** — the workspace is set up but the user hasn't picked a course yet. Call `list-courses` and present the available courses so the user can choose. Once they pick one, call `switch-course`, then `show`. Do **not** auto-select a course.
+- **If `initialized: false`** — the workspace hasn't been set up yet. Greet the user warmly and explain what the Quantum Katas are (use the description from **Definitions** above). Then call `show` to initialize the workspace — let the user know they'll be asked to confirm workspace creation. Once initialized, call `list-courses` and present the available courses so the user can choose one.
 
 Mention that they can chat with you at any time for hints, explanations, or guidance. Don't explain how the agent works, list tools, or show menus.
 

--- a/source/vscode/src/gh-copilot/learningTools.ts
+++ b/source/vscode/src/gh-copilot/learningTools.ts
@@ -112,7 +112,7 @@ export class LearningTools {
    */
   async getState(): Promise<
     | { initialized: false; error?: string }
-    | ({ initialized: true } & StateSnapshot)
+    | ({ initialized: true; courseSelected: boolean } & StateSnapshot)
   > {
     if (!this.service.initialized) {
       const progressError = this.service.progressLoadingError;
@@ -125,7 +125,11 @@ export class LearningTools {
       }
       await this.ensureInitialized();
     }
-    return { initialized: true, state: this.serializeState() };
+    return {
+      initialized: true,
+      courseSelected: this.service.hasUserSelectedCourse(),
+      state: this.serializeState(),
+    };
   }
 
   /**

--- a/source/vscode/src/learning/commands.ts
+++ b/source/vscode/src/learning/commands.ts
@@ -98,8 +98,11 @@ export function registerLearningCommands(
         // finds it already set up and skips the confirmation prompt.
         await service.tryInitialize({ createIfMissing: true });
 
+        const query = service.hasUserSelectedCourse()
+          ? "/qdk-learning Let's start learning."
+          : "/qdk-learning What courses are available?";
         await vscode.commands.executeCommand("workbench.action.chat.open", {
-          query: "/qdk-learning Let's start learning.",
+          query,
           isPartialQuery: false,
         });
       },
@@ -266,6 +269,7 @@ async function openCourseNotebook(
   service: LearningService,
   options?: { reveal?: "exercise" | "top" },
 ): Promise<void> {
+  await service.setCourseSelectedAndSave();
   const notebookUri = service.getCurrentCodeFileUri();
   if (!notebookUri) {
     log.warn("No notebook associated with the current position.");

--- a/source/vscode/src/learning/panel.ts
+++ b/source/vscode/src/learning/panel.ts
@@ -80,6 +80,8 @@ export class LessonPanelManager {
       return;
     }
 
+    await this.service.setCourseSelectedAndSave();
+
     if (this.panel) {
       this.panel.reveal(vscode.ViewColumn.One);
       return;
@@ -125,6 +127,12 @@ export class LessonPanelManager {
 
     if (this.isNotebookCourse) {
       // The active course no longer uses the panel — drop the serialized one.
+      panel.dispose();
+      return;
+    }
+
+    if (!this.service.hasUserSelectedCourse()) {
+      // No course chosen yet — don't auto-show the panel from a prior session.
       panel.dispose();
       return;
     }

--- a/source/vscode/src/learning/progressTreeView.ts
+++ b/source/vscode/src/learning/progressTreeView.ts
@@ -31,7 +31,7 @@ export function registerLearningProgressView(
   context.subscriptions.push(
     service.onDidChangeProgress((snapshot) => {
       treeDataProvider.update(snapshot);
-      treeView.message = buildTreeMessage(snapshot);
+      treeView.message = buildTreeMessage(snapshot, service);
     }),
     treeView.onDidChangeVisibility((e) => {
       if (e.visible) {
@@ -73,7 +73,7 @@ class LearningProgressTreeProvider implements vscode.TreeDataProvider<LearningPr
       ).length;
       const item = new vscode.TreeItem(
         descriptor.title,
-        isActive
+        isActive && this.service.hasUserSelectedCourse()
           ? vscode.TreeItemCollapsibleState.Expanded
           : vscode.TreeItemCollapsibleState.Collapsed,
       );
@@ -89,8 +89,14 @@ class LearningProgressTreeProvider implements vscode.TreeDataProvider<LearningPr
       item.tooltip = `${descriptor.title}${
         descriptor.shortDescription ? `\n${descriptor.shortDescription}` : ""
       }`;
-      item.id = isActive
-        ? `course:${descriptor.id}:active`
+      // Vary the id when courseSelected changes so VS Code applies the new collapsibleState.
+      const suffix = isActive
+        ? this.service.hasUserSelectedCourse()
+          ? "selected"
+          : "active"
+        : undefined;
+      item.id = suffix
+        ? `course:${descriptor.id}:${suffix}`
         : `course:${descriptor.id}`;
       return item;
     }
@@ -212,7 +218,11 @@ class LearningProgressTreeProvider implements vscode.TreeDataProvider<LearningPr
       // The "Up next" shortcut targets the active course's saved position.
       // Notebook courses don't have a meaningful per-activity position, so the
       // shortcut is only shown for Q# courses.
-      if (isActive && !isNotebookCourse(descriptor)) {
+      if (
+        isActive &&
+        this.service.hasUserSelectedCourse() &&
+        !isNotebookCourse(descriptor)
+      ) {
         const { courseId, unitId, activityId } = progress.currentPosition;
         const unit = progress.units.find((u) => u.id === unitId);
         const activity = unit?.activities.find((a) => a.id === activityId);
@@ -271,9 +281,14 @@ class LearningProgressTreeProvider implements vscode.TreeDataProvider<LearningPr
 /** Builds the italic summary shown at the top of the tree view. */
 function buildTreeMessage(
   snapshot: OverallProgress | undefined,
+  service: LearningService,
 ): string | undefined {
   if (!snapshot) {
     return undefined;
+  }
+
+  if (!service.hasUserSelectedCourse()) {
+    return "Pick a course to get started!";
   }
 
   const units = snapshot.units;

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -319,6 +319,7 @@ export class LearningService {
 
   async next(source: TelemetrySource): Promise<NavigationResult> {
     const ws = this.requireWorkspace();
+    this.setCourseSelected();
     const currentPos = ws.progressData.position;
     const nextPos = this.nextActivity(currentPos);
 
@@ -346,6 +347,7 @@ export class LearningService {
 
   async previous(source: TelemetrySource): Promise<NavigationResult> {
     const ws = this.requireWorkspace();
+    this.setCourseSelected();
     const prevPos = this.previousActivity(ws.progressData.position);
     if (!prevPos) {
       return { moved: false };
@@ -363,6 +365,7 @@ export class LearningService {
     source?: TelemetrySource,
   ): Promise<LearningState> {
     const ws = this.requireWorkspace();
+    this.setCourseSelected();
     const course = this.activeCourse;
     const unit = course.units.find((u) => u.id === location.unitId);
     if (!unit || unit.activities.length === 0) {
@@ -648,6 +651,29 @@ export class LearningService {
     return { id: course.id, title: course.title, kind: course.kind };
   }
 
+  /** True once the user has explicitly picked a course. */
+  hasUserSelectedCourse(): boolean {
+    const ws = this.workspace;
+    if (!ws) return false;
+    // Missing field (legacy files) → treat as selected.
+    return ws.progressData.courseSelected !== false;
+  }
+
+  /** Persist the fact that the user has engaged with a course. */
+  async setCourseSelectedAndSave(): Promise<void> {
+    const old = this.setCourseSelected();
+    if (old === true) return;
+    await this.saveProgress();
+    this.emitProgress();
+  }
+
+  private setCourseSelected(): boolean | undefined {
+    const ws = this.requireWorkspace();
+    const old = ws.progressData.courseSelected;
+    ws.progressData.courseSelected = true;
+    return old;
+  }
+
   /**
    * Switch the active course, creating its learner-editable files if they
    * don't exist yet, then move the position to the first incomplete
@@ -659,6 +685,7 @@ export class LearningService {
   ): Promise<LearningState> {
     const ws = this.requireWorkspace();
     const course = this.requireCourse(ws, courseId);
+    this.setCourseSelected();
     // Idempotent: existing workbooks are left alone, so this only writes
     // files the first time the learner opens the course.
     // Note: if materializing fails, you basically have to reload the window.
@@ -1694,6 +1721,7 @@ export class LearningService {
       completions: {},
       startedAt: new Date().toISOString(),
       pythonEnvironments: {},
+      courseSelected: false,
     };
   }
 

--- a/source/vscode/src/learning/types.d.ts
+++ b/source/vscode/src/learning/types.d.ts
@@ -136,6 +136,16 @@ export interface ProgressFileData {
   completions: Record<string, { completedAt: string }>;
   startedAt: string;
   pythonEnvironments: Record<string, { id: string; path: string }>;
+  /**
+   * Set to `true` once the user explicitly picks a course. When `false`
+   * (or absent on legacy files that predate this field), the tree view
+   * shows all courses collapsed so no single course dominates.
+   *
+   * Missing (`undefined`) is treated as `true` for backward compatibility:
+   * existing progress files were written while a course was active, so the
+   * user has already made a choice.
+   */
+  courseSelected?: boolean;
 }
 
 // ─── Bundled state ───


### PR DESCRIPTION
Until then, leave the tree collapsed to give them all equal visual weight.  Have the agent simply list available courses, rather than kicking one off.