### PR TITLE
RCA Perf: Reduce `RuntimeFeatureFlags` size

### DIFF
--- a/source/compiler/qsc_fir/src/fir.rs
+++ b/source/compiler/qsc_fir/src/fir.rs
@@ -283,7 +283,7 @@ impl From<(PackageId, BlockId)> for StoreBlockId {
 }
 
 /// A unique identifier for an expression within a package store.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash, Eq)]
 pub struct StoreExprId {
     /// The package ID.
     pub package: PackageId,

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -1620,11 +1620,13 @@ impl<'a> PartialEvaluator<'a> {
         // moved into the call scope; these are used to generate the `Instruction::Call` at the call
         // site instead of inlining the body. Eligible callees only have scalar/qubit leaf
         // parameters, so the operand mapping below cannot encounter composite values.
-        let ir_function_arg_operands = if matches!(self.get_expr_compute_kind(call_expr_id),
-            ComputeKind::Dynamic {runtime_features, ..} if runtime_features.contains(RuntimeFeatureFlags::MustBeInlined))
-            || self.in_parallel_expr()
+        let ir_function_arg_operands = if self.is_must_inline_call(
+            store_item_id,
+            functor_app,
+            (self.get_current_package_id(), call_expr_id).into(),
+        ) || self.in_parallel_expr()
         {
-            // A call site that has the `MustBeInlined` runtime feature flag set is not eligible to be emitted as an IR function
+            // A call site that has been marked for inlining is not eligible to be emitted as an IR function
             // based on Runtime Capabilities Analysis, so we fall through to the inline path
             // OR we are currently in a parrallel expression which requires that all calls are inlined to ensure the whole parallel
             // ends up in a single block.
@@ -2161,8 +2163,6 @@ impl<'a> PartialEvaluator<'a> {
             .contains(TargetCapabilityFlags::CallSupport)
         {
             // In this case, we know the target can't support any IR function calls, so always return false.
-            // This is needed because when the target does not have that support we don't emit the `MustBeInlined`
-            // capability on the call site.
             return false;
         }
 
@@ -3519,6 +3519,16 @@ impl<'a> PartialEvaluator<'a> {
         let store_expr_id = StoreExprId::from((current_package_id, expr_id));
         self.compute_properties
             .is_unresolved_callee_expr(store_expr_id, self.in_parallel_scope())
+    }
+
+    fn is_must_inline_call(
+        &self,
+        callee: StoreItemId,
+        functor_app: FunctorApp,
+        expr: StoreExprId,
+    ) -> bool {
+        self.compute_properties
+            .is_must_inline_call(&(callee, functor_app).into(), &expr)
     }
 
     fn get_call_compute_kind(&self, callable_scope: &Scope) -> ComputeKind {

--- a/source/compiler/qsc_rca/src/common.rs
+++ b/source/compiler/qsc_rca/src/common.rs
@@ -77,7 +77,7 @@ impl From<(LocalItemId, FunctorSetValue)> for LocalSpecId {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct GlobalSpecId {
     pub callable: StoreItemId,
     pub functor_set_value: FunctorSetValue,
@@ -97,6 +97,15 @@ impl From<(StoreItemId, FunctorSetValue)> for GlobalSpecId {
         Self {
             callable: value.0,
             functor_set_value: value.1,
+        }
+    }
+}
+
+impl From<(StoreItemId, FunctorApp)> for GlobalSpecId {
+    fn from(value: (StoreItemId, FunctorApp)) -> Self {
+        Self {
+            callable: value.0,
+            functor_set_value: value.1.functor_set_value(),
         }
     }
 }

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -366,6 +366,7 @@ impl<'a> Analyzer<'a> {
 
     fn analyze_expr_call(
         &mut self,
+        call_expr: ExprId,
         callee_expr_id: ExprId,
         args_expr_id: ExprId,
         expr_type: &Ty,
@@ -392,13 +393,8 @@ impl<'a> Analyzer<'a> {
                 value_kind,
             }
         } else {
-            self.analyze_expr_call_with_static_callee(callee_expr_id, args_expr_id)
+            self.analyze_expr_call_with_static_callee(call_expr, callee_expr_id, args_expr_id)
         };
-
-        // Cache the `MustBeInlined` runtime feature flag if it was set on the compute kind of the call expression.
-        // This allows it to be added again later after aggregating the runtime features of the callee and arguments expressions,
-        // which may have cleared that flag.
-        let must_inline = matches!(compute_kind, ComputeKind::Dynamic { runtime_features, .. } if runtime_features.contains(RuntimeFeatureFlags::MustBeInlined));
 
         // If this call happens within a dynamic scope, there might be additional runtime features being used.
         let application_instance = self.get_current_application_instance();
@@ -445,20 +441,13 @@ impl<'a> Analyzer<'a> {
         // Aggregate the runtime features of the callee and arguments expressions.
         compute_kind.aggregate_runtime_features(callee_expr_compute_kind, ValueKind::Constant);
         compute_kind.aggregate_runtime_features(args_expr_compute_kind, ValueKind::Constant);
-
-        if must_inline
-            && let ComputeKind::Dynamic {
-                runtime_features, ..
-            } = &mut compute_kind
-        {
-            *runtime_features |= RuntimeFeatureFlags::MustBeInlined;
-        }
-
         compute_kind
     }
 
+    #[allow(clippy::too_many_lines)]
     fn analyze_expr_call_with_spec_callee(
         &mut self,
+        call_expr: ExprId,
         callee: &Callee,
         callable_decl: &'a CallableDecl,
         args_expr_id: ExprId,
@@ -519,6 +508,7 @@ impl<'a> Analyzer<'a> {
             .target_capabilities
             .contains(TargetCapabilityFlags::CallSupport)
             && self.check_must_inline(
+                callee_id,
                 callable_decl,
                 &arg_compute_kinds,
                 &mut compute_kind,
@@ -579,12 +569,26 @@ impl<'a> Analyzer<'a> {
             }
         }
 
-        if must_inline
-            && let ComputeKind::Dynamic {
-                runtime_features, ..
-            } = &mut compute_kind
+        if must_inline && !matches!(compute_kind, ComputeKind::Static) {
+            // This is a dynamic call expression that must be inlined, so track the call expr id
+            // in the map to ensure that partial eval will inline it.
+            self.package_store_compute_properties
+                .insert_must_inline_call_expr((self.get_current_package_id(), call_expr).into());
+        }
+
+        // If the callee must always be inlined, mark the current item as requiring inlining too.
+        // This ensures that whole call stack gets inlined into the entry point if a must-inline callable is invoked.
+        if self
+            .package_store_compute_properties
+            .is_must_inline_callable(callee_id)
+            && let AnalysisContext::Item(item_context) = self.get_current_context()
         {
-            *runtime_features |= RuntimeFeatureFlags::MustBeInlined;
+            let functor = item_context
+                .current_spec_context
+                .as_ref()
+                .map_or(FunctorSetValue::Empty, |c| c.functor_set_value);
+            self.package_store_compute_properties
+                .insert_must_inline_callable((item_context.id, functor).into());
         }
 
         compute_kind
@@ -592,6 +596,7 @@ impl<'a> Analyzer<'a> {
 
     fn check_must_inline(
         &self,
+        callee_id: GlobalSpecId,
         callable_decl: &'a CallableDecl,
         arg_compute_kinds: &[ComputeKind],
         compute_kind: &mut ComputeKind,
@@ -610,8 +615,8 @@ impl<'a> Analyzer<'a> {
             && if let ComputeKind::Dynamic {
                 runtime_features, ..
             } = &ir_function_compute_kind
-            // ...and the computed runtime features of the resulting IR function does not require qubit allocation when the target doesn't support it...
-            && (!runtime_features.contains(RuntimeFeatureFlags::QubitAllocation) || self.target_capabilities.contains(TargetCapabilityFlags::DynamicQubitAllocation))
+            // ...and the call is not one that we've marked as must-inline...
+            && !self.package_store_compute_properties.is_must_inline_callable(callee_id)
             // ...and the computed runtime features of the function do not involve call to unresolved callee...
             && !runtime_features.contains(RuntimeFeatureFlags::CallToUnresolvedCallee)
             // ...and those computed runtime features are all supported by the target capabilities...
@@ -635,6 +640,7 @@ impl<'a> Analyzer<'a> {
 
     fn analyze_expr_call_with_static_callee(
         &mut self,
+        call_expr: ExprId,
         callee_expr_id: ExprId,
         args_expr_id: ExprId,
     ) -> ComputeKind {
@@ -690,6 +696,7 @@ impl<'a> Analyzer<'a> {
         };
         match global_callee {
             Global::Callable(callable_decl) => self.analyze_expr_call_with_spec_callee(
+                call_expr,
                 &callee,
                 callable_decl,
                 args_expr_id,
@@ -1395,6 +1402,19 @@ impl<'a> Analyzer<'a> {
                 derive_instrinsic_operation_application_generator_set(callable_context)
             }
         };
+
+        if matches!(callable_context.kind, CallableKind::Operation)
+            && is_qubit_allocation_output(&callable_context.output_type)
+            && !self
+                .target_capabilities
+                .contains(TargetCapabilityFlags::DynamicQubitAllocation)
+        {
+            // The only intrinsic operations whose output is a qubit (or an array of qubits) are the qubit
+            // allocate/borrow intrinsics. Tag the allocate leaf so that qubit allocation is always inlined
+            // and propagated bottom-up to every transitive caller.
+            self.package_store_compute_properties
+                .insert_must_inline_callable(body_specialization_id);
+        }
 
         // Insert the generator set in the entry corresponding to the body specialization of the callable.
         self.package_store_compute_properties.insert_spec(
@@ -2161,7 +2181,7 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
             }
             ExprKind::Block(block_id) => self.analyze_expr_block(*block_id),
             ExprKind::Call(callee_expr_id, args_expr_id) => {
-                self.analyze_expr_call(*callee_expr_id, *args_expr_id, &expr.ty)
+                self.analyze_expr_call(expr_id, *callee_expr_id, *args_expr_id, &expr.ty)
             }
             ExprKind::Closure(..) => ComputeKind::Static,
             ExprKind::Fail(msg_expr_id) => self.analyze_expr_fail(*msg_expr_id),
@@ -2645,12 +2665,6 @@ fn derive_instrinsic_operation_application_generator_set(
     }
     if callable_context.attrs.contains(&Attr::Reset) {
         inherent_runtime_features |= RuntimeFeatureFlags::CallToCustomReset;
-    }
-    // The only intrinsic operations whose output is a qubit (or an array of qubits) are the qubit
-    // allocate/borrow intrinsics. Tag the allocate leaf so that qubit allocation is surfaced as an
-    // inherent runtime feature and propagated bottom-up to every transitive caller.
-    if is_qubit_allocation_output(&callable_context.output_type) {
-        inherent_runtime_features |= RuntimeFeatureFlags::QubitAllocation;
     }
 
     // The compute kind of intrinsic operations is always dynamic.

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -37,6 +37,7 @@ use std::{
 };
 
 pub use crate::analyzer::Analyzer;
+use crate::common::GlobalSpecId;
 
 /// A trait to look for the compute properties of elements in a package store.
 pub trait ComputePropertiesLookup {
@@ -66,6 +67,12 @@ pub struct PackageStoreComputeProperties {
     // The alternative compute properties for each package if the callables are invoked
     // from within a parallel expression, keyed by package ID.
     parallel_props: IndexMap<PackageId, PackageComputeProperties>,
+    // The set of global callables that must be inlined (usually due to qubit allocation) and
+    // cause any caller to also require inlining.
+    must_inline_callables: FxHashSet<GlobalSpecId>,
+    // The set of call expressions that must be inlined either because of the callable being invoked,
+    // or because of the combination of callable and runtime features of the arguments to the call expr.
+    must_inline_call_exprs: FxHashSet<StoreExprId>,
 }
 
 impl ComputePropertiesLookup for PackageStoreComputeProperties {
@@ -143,6 +150,11 @@ impl PackageStoreComputeProperties {
         self.get(id.package, parallel)
             .unresolved_callee_exprs
             .contains(&id.expr)
+    }
+
+    #[must_use]
+    pub fn is_must_inline_call(&self, id: &GlobalSpecId, expr: &StoreExprId) -> bool {
+        self.must_inline_callables.contains(id) || self.must_inline_call_exprs.contains(expr)
     }
 }
 
@@ -557,11 +569,10 @@ impl ComputeKind {
         };
 
         // Determine the aggregated runtime features, use the value kind equivalent from self or the default.
-        // We don't propagate the `MustBeInlined` runtime feature because it is only relevant at call expressions.
         match self {
             Self::Static => {
                 *self = ComputeKind::Dynamic {
-                    runtime_features: runtime_features & !RuntimeFeatureFlags::MustBeInlined,
+                    runtime_features,
                     value_kind: default_value_kind,
                 }
             }
@@ -570,7 +581,6 @@ impl ComputeKind {
                 ..
             } => {
                 *self_runtime_features |= runtime_features;
-                self_runtime_features.remove(RuntimeFeatureFlags::MustBeInlined);
             }
         }
     }
@@ -650,7 +660,7 @@ bitflags! {
     /// Runtime features represent anything a program can do that is more complex than executing quantum operations on
     /// statically allocated qubits and using constant arguments.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct RuntimeFeatureFlags: u64 {
+    pub struct RuntimeFeatureFlags: u32 {
         /// Use of a dynamic `Bool`.
         const UseOfDynamicBool = 1 << 0;
         /// Use of a dynamic `Int`.
@@ -709,16 +719,12 @@ bitflags! {
         const CallToCustomReset = 1 << 27;
         /// Use of a dynamic generic parameter.
         const UseOfDynamicGeneric = 1 << 28;
-        /// A callable allocates qubits (directly or transitively).
-        const QubitAllocation = 1 << 29;
         /// A dynamic release of a qubit.
-        const UseOfDynamicQubitRelease = 1 << 30;
-        /// A callable whose required features mean it must be inlined rather than emitted as an IR function.
-        const MustBeInlined = 1 << 31;
+        const UseOfDynamicQubitRelease = 1 << 29;
         /// Use of dynamic branching in a parallel expression.
-        const UseOfDynamicBranchingInParallelExpr = 1 << 32;
+        const UseOfDynamicBranchingInParallelExpr = 1 << 30;
         /// Use of a dynamic limit in a parallel expression.
-        const UseOfDynamicLimitInParallelExpr = 1 << 33;
+        const UseOfDynamicLimitInParallelExpr = 1 << 31;
     }
 }
 

--- a/source/compiler/qsc_rca/src/scaffolding.rs
+++ b/source/compiler/qsc_rca/src/scaffolding.rs
@@ -14,6 +14,7 @@ use qsc_fir::{
     },
     ty::FunctorSetValue,
 };
+use rustc_hash::FxHashSet;
 
 /// Scaffolding used to build the package store compute properties.
 #[derive(Debug)]
@@ -23,6 +24,12 @@ pub struct InternalPackageStoreComputeProperties {
     // The alternative compute properties for each package if the callables are invoked
     // from within a parallel expression, keyed by package ID.
     parallel_props: IndexMap<PackageId, InternalPackageComputeProperties>,
+    // The set of global callables that must be inlined (usually due to qubit allocation) and
+    // cause any caller to also require inlining.
+    must_inline_callables: FxHashSet<GlobalSpecId>,
+    // The set of call expressions that must be inlined either because of the callable being invoked,
+    // or because of the combination of callable and runtime features of the arguments to the call expr.
+    must_inline_call_exprs: FxHashSet<StoreExprId>,
 }
 
 impl From<PackageStoreComputeProperties> for InternalPackageStoreComputeProperties {
@@ -70,6 +77,8 @@ impl From<PackageStoreComputeProperties> for InternalPackageStoreComputeProperti
         Self {
             props: scaffolding,
             parallel_props: parallel_scaffolding,
+            must_inline_callables: value.must_inline_callables,
+            must_inline_call_exprs: value.must_inline_call_exprs,
         }
     }
 }
@@ -122,6 +131,8 @@ impl From<InternalPackageStoreComputeProperties> for PackageStoreComputeProperti
         Self {
             props: package_store_compute_properties,
             parallel_props: parallel_package_store_compute_properties,
+            must_inline_callables: value.must_inline_callables,
+            must_inline_call_exprs: value.must_inline_call_exprs,
         }
     }
 }
@@ -227,6 +238,8 @@ impl InternalPackageStoreComputeProperties {
         Self {
             props: packages,
             parallel_props: parallel_packages,
+            must_inline_callables: Default::default(),
+            must_inline_call_exprs: Default::default(),
         }
     }
 
@@ -277,6 +290,18 @@ impl InternalPackageStoreComputeProperties {
         self.get_mut(id.package, parallel)
             .stmts
             .insert(id.stmt, value);
+    }
+
+    pub(crate) fn insert_must_inline_callable(&mut self, id: GlobalSpecId) {
+        self.must_inline_callables.insert(id);
+    }
+
+    pub(crate) fn is_must_inline_callable(&self, id: GlobalSpecId) -> bool {
+        self.must_inline_callables.contains(&id)
+    }
+
+    pub(crate) fn insert_must_inline_call_expr(&mut self, id: StoreExprId) {
+        self.must_inline_call_exprs.insert(id);
     }
 }
 

--- a/source/compiler/qsc_rca/src/tests/arrays.rs
+++ b/source/compiler/qsc_rca/src/tests/arrays.rs
@@ -33,7 +33,7 @@ fn check_rca_for_array_with_dynamic_results() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -54,7 +54,7 @@ fn check_rca_for_array_with_dynamic_bools() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -88,7 +88,7 @@ fn check_rca_for_array_repeat_with_dynamic_result_value_and_classical_size() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -127,7 +127,7 @@ fn check_rca_for_concatenation_of_dynamic_variable_array() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -148,7 +148,7 @@ fn check_rca_for_concatenation_of_result_dynamic_constant_array() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -169,7 +169,7 @@ fn check_rca_for_array_repeat_with_dynamic_bool_value_and_classical_size() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -190,7 +190,7 @@ fn check_rca_for_array_repeat_with_classical_value_and_dynamic_size() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -214,7 +214,7 @@ fn check_rca_for_array_repeat_with_dynamic_double_value_and_dynamic_size() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | UseOfDynamicallySizedArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -238,7 +238,7 @@ fn check_rca_for_mutable_array_statically_appended() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -329,7 +329,7 @@ fn check_rca_for_immutable_array_bound_to_dynamic_array() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -400,7 +400,7 @@ fn check_rca_for_mutable_array_assign_index_dynamic_content_in_dynamic_context()
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -425,7 +425,7 @@ fn check_rca_for_mutable_array_assign_index_dynamic_nested_array_content_in_dyna
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -466,7 +466,7 @@ fn check_rca_for_access_using_dynamic_index() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | UseOfDynamicIndex | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | UseOfDynamicIndex)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -489,7 +489,7 @@ fn check_rca_for_array_with_dynamic_size_bound_through_tuple() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -515,7 +515,7 @@ fn check_rca_for_array_with_dynamic_size_bound_through_tuple_from_callable() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -581,7 +581,7 @@ fn check_rca_for_array_with_static_size_bound_through_dynamic_tuple() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -620,7 +620,7 @@ fn check_rca_for_index_range_on_array_with_dynamic_contents() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -641,7 +641,7 @@ fn check_rca_for_indirect_length_on_array_with_dynamic_contents() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -663,7 +663,7 @@ fn check_rca_for_indirect_length_on_array_with_dynamic_length() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/assigns.rs
+++ b/source/compiler/qsc_rca/src/tests/assigns.rs
@@ -41,7 +41,7 @@ fn check_rca_for_dynamic_result_assign_to_local() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -64,7 +64,7 @@ fn check_rca_for_dynamic_bool_assign_to_local() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -89,7 +89,7 @@ fn check_rca_for_dynamic_int_assign_to_local() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -115,7 +115,7 @@ fn check_rca_for_dynamic_double_assign_to_local() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -245,7 +245,7 @@ fn check_rca_for_assign_dynamic_call_result_to_tuple_of_vars() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -259,7 +259,7 @@ fn check_rca_for_assign_dynamic_call_result_to_tuple_of_vars() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -284,7 +284,7 @@ fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -298,7 +298,7 @@ fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -346,7 +346,7 @@ fn check_rca_for_mutable_classical_integer_assigned_updated_with_dynamic_integer
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -371,7 +371,7 @@ fn check_rca_for_mutable_dynamic_integer_assigned_updated_with_classical_integer
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -396,7 +396,7 @@ fn check_rca_for_mutable_dynamic_integer_assigned_updated_with_dynamic_integer()
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -422,7 +422,7 @@ fn check_rca_for_mutable_dynamic_result_assigned_updated_in_dynamic_context() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicResult)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -444,7 +444,7 @@ fn check_rca_for_immutable_dynamic_result_bound_to_dynamic_result() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicResult)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -471,7 +471,7 @@ fn check_rca_for_immutable_dynamic_result_bound_to_result_from_classical_conditi
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -500,7 +500,7 @@ fn check_rca_for_immutable_dynamic_result_bound_to_call_with_dynamic_args() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicResult)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -527,7 +527,7 @@ fn check_rca_for_mutable_int_defined_and_updated_in_dynamic_scope() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -559,7 +559,7 @@ fn check_rca_for_mutable_int_defined_outer_scope_and_updated_in_inner_dynamic_sc
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | MeasurementWithinDynamicScope | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | MeasurementWithinDynamicScope)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -632,7 +632,7 @@ fn check_rca_for_immutable_tuple_bound_to_dynamic_tuple() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicTuple | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicTuple)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/bindings.rs
+++ b/source/compiler/qsc_rca/src/tests/bindings.rs
@@ -39,7 +39,7 @@ fn check_rca_for_immutable_dynamic_result_binding() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -79,7 +79,7 @@ fn check_rca_for_mutable_dynamic_bool_binding() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -121,7 +121,7 @@ fn check_rca_for_immutable_dynamic_int_binding() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -164,7 +164,7 @@ fn check_rca_for_mutable_dynamic_double_binding() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/binops.rs
+++ b/source/compiler/qsc_rca/src/tests/binops.rs
@@ -32,7 +32,7 @@ fn check_rca_for_bin_op_with_dynamic_lhs_and_classical_rhs() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -52,7 +52,7 @@ fn check_rca_for_bin_op_with_classical_lhs_and_dynamic_rhs() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -73,7 +73,7 @@ fn check_rca_for_bin_op_with_dynamic_lhs_and_dynamic_rhs() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -112,7 +112,7 @@ fn check_rca_for_nested_bin_ops_with_a_dynamic_operand() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -148,7 +148,7 @@ fn check_rca_for_exp_op_with_dynamic_lhs_and_classical_rhs() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -170,7 +170,7 @@ fn check_rca_for_exp_op_with_classical_lhs_and_dynamic_rhs() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicExponent | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicExponent)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -194,7 +194,7 @@ fn check_rca_for_exp_op_with_dynamic_lhs_and_dynamic_rhs() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicExponent | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicExponent)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/callables.rs
+++ b/source/compiler/qsc_rca/src/tests/callables.rs
@@ -148,7 +148,7 @@ fn check_rca_for_operation_with_one_classical_return_and_one_dynamic_return() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope | QubitAllocation | UseOfDynamicQubitRelease)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope | UseOfDynamicQubitRelease)
                         value_kind: Variable
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -205,7 +205,7 @@ fn check_rca_for_callable_block_with_dynamic_unreachable_binding() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope | QubitAllocation | UseOfDynamicQubitRelease)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope | UseOfDynamicQubitRelease)
                         value_kind: Variable
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -280,27 +280,27 @@ fn check_rca_for_unrestricted_h() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -340,27 +340,27 @@ fn check_rca_for_base_h() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -414,41 +414,41 @@ fn check_rca_for_unrestricted_r1() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -502,41 +502,41 @@ fn check_rca_for_base_r1() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -590,41 +590,41 @@ fn check_rca_for_unrestricted_rx() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -678,41 +678,41 @@ fn check_rca_for_base_rx() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -780,55 +780,55 @@ fn check_rca_for_unrestricted_rxx() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -896,55 +896,55 @@ fn check_rca_for_base_rxx() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -998,41 +998,41 @@ fn check_rca_for_unrestricted_ry() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1086,41 +1086,41 @@ fn check_rca_for_base_ry() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1188,55 +1188,55 @@ fn check_rca_for_unrestricted_ryy() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1304,55 +1304,55 @@ fn check_rca_for_base_ryy() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1406,41 +1406,41 @@ fn check_rca_for_unrestricted_rz() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1494,41 +1494,41 @@ fn check_rca_for_base_rz() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1596,55 +1596,55 @@ fn check_rca_for_unrestricted_rzz() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1712,55 +1712,55 @@ fn check_rca_for_base_rzz() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                                 value_kind: Constant
                         [1]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                         [2]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1800,27 +1800,27 @@ fn check_rca_for_unrestricted_s() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1860,27 +1860,27 @@ fn check_rca_for_base_s() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1920,27 +1920,27 @@ fn check_rca_for_unrestricted_t() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -1980,27 +1980,27 @@ fn check_rca_for_base_t() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -2040,27 +2040,27 @@ fn check_rca_for_unrestricted_x() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -2100,27 +2100,27 @@ fn check_rca_for_base_x() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -2160,27 +2160,27 @@ fn check_rca_for_unrestricted_y() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -2220,27 +2220,27 @@ fn check_rca_for_base_y() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -2280,27 +2280,27 @@ fn check_rca_for_unrestricted_z() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }
@@ -2340,27 +2340,27 @@ fn check_rca_for_base_z() {
                                 value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(0x0)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/calls.rs
+++ b/source/compiler/qsc_rca/src/tests/calls.rs
@@ -3,7 +3,6 @@
 
 use super::{CompilationContext, check_last_statement_compute_properties};
 use expect_test::expect;
-use qsc_data_structures::target::Profile;
 
 #[test]
 fn check_rca_for_call_to_cyclic_function_with_classical_argument() {
@@ -52,7 +51,7 @@ fn check_rca_for_call_to_cyclic_function_with_dynamic_argument() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -105,7 +104,7 @@ fn check_rca_for_call_to_cyclic_operation_with_dynamic_argument() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -173,7 +172,7 @@ fn check_rca_for_call_to_static_closure_operation() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -197,7 +196,7 @@ fn check_rca_for_call_to_dynamic_closure_operation() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -223,7 +222,7 @@ fn check_rca_for_call_to_operation_with_one_classical_return_and_one_dynamic_ret
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | ReturnWithinDynamicScope | QubitAllocation | UseOfDynamicQubitRelease)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | ReturnWithinDynamicScope | UseOfDynamicQubitRelease)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -280,7 +279,7 @@ fn check_rca_for_call_to_operation_with_codegen_intrinsic_override_treated_as_in
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -323,7 +322,7 @@ fn check_rca_for_call_to_function_that_receives_tuple_with_a_non_tuple_dynamic_a
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -346,7 +345,7 @@ fn check_rca_for_call_to_function_passed_single_tuple_variable_for_multiple_args
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -369,61 +368,8 @@ fn check_rca_for_call_to_lambda_passed_single_tuple_variable_for_multiple_args()
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
-                dynamic_param_applications: <empty>"#]],
-    );
-}
-
-#[test]
-fn check_rca_for_adaptive_call_to_operation_using_integer_for_range_has_mustbeinlined() {
-    let mut compilation_context = CompilationContext::new(Profile::Adaptive.into());
-    compilation_context.update(
-        r#"
-        operation RepeatX(numTimes : Int, q : Qubit) : Unit {
-            for i in 1..numTimes {
-                X(q);
-            }
-        }
-        use q = Qubit();
-        RepeatX(3, q)
-        "#,
-    );
-    let package_store_compute_properties = compilation_context.get_compute_properties();
-    check_last_statement_compute_properties(
-        package_store_compute_properties,
-        &expect![[r#"
-            ApplicationsGeneratorSet:
-                inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicQubit | LoopWithDynamicCondition | QubitAllocation | MustBeInlined)
-                    value_kind: Constant
-                dynamic_param_applications: <empty>"#]],
-    );
-}
-
-#[test]
-fn check_rca_for_adaptive_rif_call_to_operation_using_integer_for_range_does_not_have_mustbeinlined()
- {
-    let mut compilation_context = CompilationContext::new(Profile::AdaptiveRIF.into());
-    compilation_context.update(
-        r#"
-        operation RepeatX(numTimes : Int, q : Qubit) : Unit {
-            for i in 1..numTimes {
-                X(q);
-            }
-        }
-        use q = Qubit();
-        RepeatX(3, q)
-        "#,
-    );
-    let package_store_compute_properties = compilation_context.get_compute_properties();
-    check_last_statement_compute_properties(
-        package_store_compute_properties,
-        &expect![[r#"
-            ApplicationsGeneratorSet:
-                inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
-                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/cycles.rs
+++ b/source/compiler/qsc_rca/src/tests/cycles.rs
@@ -1189,7 +1189,7 @@ fn check_rca_for_call_to_preparepurestated_cyclic_library_operation() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>

--- a/source/compiler/qsc_rca/src/tests/ifs.rs
+++ b/source/compiler/qsc_rca/src/tests/ifs.rs
@@ -54,7 +54,7 @@ fn check_rca_for_if_stmt_with_dynamic_condition_and_classic_if_true_block() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -104,7 +104,7 @@ fn check_rca_for_if_else_expr_with_dynamic_condition_and_classic_branch_blocks()
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/intrinsics.rs
+++ b/source/compiler/qsc_rca/src/tests/intrinsics.rs
@@ -15,7 +15,7 @@ fn check_rca_for_quantum_rt_qubit_allocate() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>

--- a/source/compiler/qsc_rca/src/tests/lambdas.rs
+++ b/source/compiler/qsc_rca/src/tests/lambdas.rs
@@ -169,7 +169,7 @@ fn check_rca_for_dynamic_lambda_two_dynamic_parameters_one_classical_capture() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -190,7 +190,7 @@ fn check_rca_for_operation_lambda_two_parameters() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -212,7 +212,7 @@ fn check_rca_for_operation_lambda_two_parameters_with_controls() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/loops.rs
+++ b/source/compiler/qsc_rca/src/tests/loops.rs
@@ -41,7 +41,7 @@ fn check_rca_for_dynamic_for_loop() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | LoopWithDynamicCondition | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | LoopWithDynamicCondition)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -85,7 +85,7 @@ fn check_rca_for_dynamic_repeat_until_loop_with_initial_dynamic_condition() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | LoopWithDynamicCondition | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | LoopWithDynamicCondition)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -112,7 +112,7 @@ fn check_rca_for_dynamic_repeat_until_loop_with_initial_classical_condition_and_
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -135,7 +135,7 @@ fn check_rca_for_dynamic_repeat_until_loop_with_measurement_in_condition() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -163,7 +163,7 @@ fn check_rca_for_dynamic_repeat_until_loop_with_initial_classical_condition_and_
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -205,7 +205,7 @@ fn check_rca_for_dynamic_while_loop_with_initial_dynamic_condition() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | LoopWithDynamicCondition | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | LoopWithDynamicCondition)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -231,7 +231,7 @@ fn check_rca_for_dynamic_while_loop_with_initial_classical_condition_and_measure
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -253,7 +253,7 @@ fn check_rca_for_dynamic_while_loop_with_measurement_in_condition() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -282,7 +282,7 @@ fn check_rca_for_dynamic_while_loop_with_initial_classical_condition_and_dynamic
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -310,7 +310,7 @@ fn check_rca_for_dynamic_while_loop_with_assignments_in_both_the_condition_and_t
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -332,7 +332,7 @@ fn check_rca_for_static_for_loop() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -354,7 +354,7 @@ fn check_rca_for_static_for_loop_with_loop_and_array_support() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicQubit | LoopWithDynamicCondition | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicQubit | LoopWithDynamicCondition)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -376,7 +376,7 @@ fn check_rca_for_static_for_loop_over_array() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -398,7 +398,7 @@ fn check_rca_for_static_for_loop_over_array_with_loop_and_array_support() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | UseOfDynamicQubit | UseOfDynamicIndex | LoopWithDynamicCondition | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | UseOfDynamicQubit | UseOfDynamicIndex | LoopWithDynamicCondition)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/measurements.rs
+++ b/source/compiler/qsc_rca/src/tests/measurements.rs
@@ -18,7 +18,7 @@ fn check_rca_for_static_single_qubit_measurement() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -42,7 +42,7 @@ fn check_rca_for_dynamic_single_measurement() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(MeasurementWithinDynamicScope | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(MeasurementWithinDynamicScope | UseOfDynamicResult)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -63,7 +63,7 @@ fn check_rca_for_static_single_measurement_and_reset() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -88,7 +88,7 @@ fn check_rca_for_dynamic_single_measurement_and_reset() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(MeasurementWithinDynamicScope | UseOfDynamicResult | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(MeasurementWithinDynamicScope | UseOfDynamicResult)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -109,7 +109,7 @@ fn check_rca_for_static_multi_qubit_measurement() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/overrides.rs
+++ b/source/compiler/qsc_rca/src/tests/overrides.rs
@@ -32,7 +32,7 @@ fn check_rca_for_length_of_statically_sized_array_with_dynamic_content() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -54,7 +54,7 @@ fn check_rca_for_length_of_dynamically_sized_array_with_static_content() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -77,7 +77,7 @@ fn check_rca_for_length_of_dynamically_sized_array_with_dynamic_content() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/parallel.rs
+++ b/source/compiler/qsc_rca/src/tests/parallel.rs
@@ -69,7 +69,7 @@ fn check_rca_for_parallel_with_dynamic_operations_no_branching() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -102,7 +102,7 @@ fn check_rca_for_parallel_within_with_dynamic_operations_no_branching() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -134,7 +134,7 @@ fn check_rca_for_parallel_with_dynamic_if_in_body() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation | UseOfDynamicBranchingInParallelExpr)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicBranchingInParallelExpr)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -166,7 +166,7 @@ fn check_rca_for_parallel_with_short_circuit_bool_in_body() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation | UseOfDynamicBranchingInParallelExpr)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicBranchingInParallelExpr)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -198,7 +198,7 @@ fn check_rca_for_parallel_with_while_loop_with_dynamic_condition() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | QubitAllocation | UseOfDynamicBranchingInParallelExpr)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicBranchingInParallelExpr)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -232,7 +232,7 @@ fn check_rca_for_parallel_within_with_dynamic_limit() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -268,7 +268,7 @@ fn check_rca_for_nested_parallel_with_dynamic_if_in_inner_body() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation | UseOfDynamicBranchingInParallelExpr)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicBranchingInParallelExpr)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -328,7 +328,7 @@ fn check_rca_for_parallel_calling_operation_that_branches_dynamically() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation | UseOfDynamicBranchingInParallelExpr)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicBranchingInParallelExpr)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -386,7 +386,7 @@ fn check_rca_for_parallel_within_calling_operation_that_branches_dynamically() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation | UseOfDynamicBranchingInParallelExpr)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicBranchingInParallelExpr)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -422,7 +422,7 @@ fn check_rca_for_parallel_with_dynamic_arg_to_rotation_does_not_branch() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -452,18 +452,18 @@ fn check_rca_for_callable_with_parallel_loop_invoking_stdlib_callable_with_inner
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Array] ArrayParamApplication:
                             constant_content: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                             static_size: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                             dynamic_size: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicPauli | UseOfDynamicRange | UseOfDynamicQubit | UseOfDynamicArray | UseOfDynamicallySizedArray | MeasurementWithinDynamicScope | UseOfDynamicIndex | LoopWithDynamicCondition | UseOfDynamicResult | QubitAllocation | UseOfDynamicBranchingInParallelExpr)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicPauli | UseOfDynamicRange | UseOfDynamicQubit | UseOfDynamicArray | UseOfDynamicallySizedArray | MeasurementWithinDynamicScope | UseOfDynamicIndex | LoopWithDynamicCondition | UseOfDynamicResult | UseOfDynamicBranchingInParallelExpr)
                                 value_kind: Constant
                 adj: <none>
                 ctl: <none>
@@ -489,15 +489,15 @@ fn check_rca_for_parallel_with_only_call_to_controlled_specialization() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                         value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] ElementParamApplication:
                             constant: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                             variable: Dynamic:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | QubitAllocation)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Constant
                 adj: <none>
                 ctl: <none>

--- a/source/compiler/qsc_rca/src/tests/qubits.rs
+++ b/source/compiler/qsc_rca/src/tests/qubits.rs
@@ -20,7 +20,7 @@ fn check_rca_for_static_single_qubit_allcation() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -50,7 +50,7 @@ fn check_rca_for_dynamic_single_qubit_allcation() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -73,7 +73,7 @@ fn check_rca_for_static_multi_qubit_allcation() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -95,7 +95,7 @@ fn check_rca_for_dynamic_multi_qubit_allcation() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicQubit | UseOfDynamicallySizedArray | LoopWithDynamicCondition | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicQubit | UseOfDynamicallySizedArray | LoopWithDynamicCondition)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -118,7 +118,7 @@ fn check_rca_for_leaf_operation_allocating_qubit_shows_qubit_allocation() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -147,7 +147,7 @@ fn check_rca_for_caller_of_allocating_operation_shows_qubit_allocation() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -173,7 +173,7 @@ fn check_rca_for_leaf_operation_borrowing_qubit_shows_qubit_allocation() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -232,7 +232,7 @@ fn check_rca_for_leaf_operation_allocating_qubit_array_shows_qubit_allocation() 
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Dynamic:
-                        runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>

--- a/source/compiler/qsc_rca/src/tests/strings.rs
+++ b/source/compiler/qsc_rca/src/tests/strings.rs
@@ -32,7 +32,7 @@ fn check_rca_for_dynamic_string() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -66,7 +66,7 @@ fn check_rca_for_dynamic_interpolated_string() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -100,7 +100,7 @@ fn check_rca_for_dynamic_nested_interpolated_string() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -135,7 +135,7 @@ fn check_rca_for_dynamic_concatenated_string() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -169,7 +169,7 @@ fn check_rca_for_dynamic_string_comparison() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicString | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicString)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/structs.rs
+++ b/source/compiler/qsc_rca/src/tests/structs.rs
@@ -38,7 +38,7 @@ fn check_rca_for_struct_constructor_with_a_dynamic_value() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -80,7 +80,7 @@ fn check_rca_for_struct_copy_constructor_with_dynamic_value() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -103,7 +103,7 @@ fn check_rca_for_struct_dynamic_constructor_overwritten_with_classic_value() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/types.rs
+++ b/source/compiler/qsc_rca/src/tests/types.rs
@@ -32,7 +32,7 @@ fn check_rca_for_dynamic_result() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -67,7 +67,7 @@ fn check_rca_for_dynamic_bool() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -104,7 +104,7 @@ fn check_rca_for_dynamic_int() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -138,7 +138,7 @@ fn check_rca_for_dynamic_pauli() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicPauli | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicPauli)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -173,7 +173,7 @@ fn check_rca_for_dynamic_range() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -211,7 +211,7 @@ fn check_rca_for_dynamic_double() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -245,7 +245,7 @@ fn check_rca_for_dynamic_big_int() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicBigInt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicBigInt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/udts.rs
+++ b/source/compiler/qsc_rca/src/tests/udts.rs
@@ -38,7 +38,7 @@ fn check_rca_for_udt_constructor_with_a_dynamic_value() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
@@ -82,7 +82,7 @@ fn check_rca_for_udt_field_update_with_dynamic_value() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt | QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
                     value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/compiler/qsc_rca/src/tests/vars.rs
+++ b/source/compiler/qsc_rca/src/tests/vars.rs
@@ -68,7 +68,7 @@ fn check_rca_for_static_qubit_var() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
@@ -89,7 +89,7 @@ fn check_rca_for_dynamic_result_var() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Dynamic:
-                    runtime_features: RuntimeFeatureFlags(QubitAllocation)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );


### PR DESCRIPTION
This change removes `QubitAllocation` and `MustBeInlined` feature flags in favor of tracking those via out-of-band hash sets. `QubitAllocation` was only ever used to determine callables whose entire call chain must be inlined, while `MustBeInlined` was about tracking call expressions that must be inlined. By tracking these separately, the `RuntimeFeatureFlags` enum can be reduced back to `u32` and significantly improve RCA perf.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>