### PR TITLE
Improve build build times

### DIFF
--- a/build.py
+++ b/build.py
@@ -407,6 +407,8 @@ if build_cli:
             # Disable LTO for release tests to speed up compilation
             cargo_test_args.append("--config")
             cargo_test_args.append('profile.release.lto="off"')
+            cargo_test_args.append("--config")
+            cargo_test_args.append("profile.release.codegen-units=16")
         subprocess.run(cargo_test_args, check=True, text=True, cwd=root_dir)
         step_end()
 

--- a/build.py
+++ b/build.py
@@ -105,27 +105,6 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-
-def step_start(description):
-    global start_time
-    prefix = "::group::" if os.getenv("GITHUB_ACTIONS") == "true" else ""
-    print(f"{prefix}build.py: {description}")
-    start_time = time.time()
-
-
-def step_end():
-    global start_time
-    duration = time.time() - start_time
-    print(f"build.py: Finished in {duration:.3f}s.")
-    if os.getenv("GITHUB_ACTIONS") == "true":
-        print(f"::endgroup::")
-
-
-if args.check_prereqs:
-    step_start("Checking prerequisites")
-    check_prereqs()
-    step_end()
-
 # If no specific project given then build all
 build_all = (
     not args.cli
@@ -147,6 +126,27 @@ build_play = build_all or args.play
 build_vscode = build_all or args.vscode
 build_jupyterlab = build_all or args.jupyterlab
 ci_bench = args.ci_bench
+
+
+def step_start(description):
+    global start_time
+    prefix = "::group::" if os.getenv("GITHUB_ACTIONS") == "true" else ""
+    print(f"{prefix}build.py: {description}")
+    start_time = time.time()
+
+
+def step_end():
+    global start_time
+    duration = time.time() - start_time
+    print(f"build.py: Finished in {duration:.3f}s.")
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        print(f"::endgroup::")
+
+
+if args.check_prereqs:
+    step_start("Checking prerequisites")
+    check_prereqs(skip_wasm=not build_wasm)
+    step_end()
 
 # JavaScript projects and eslint, prettier depend on npm_install
 # However the JupyterLab extension uses yarn in a separate workspace

--- a/source/compiler/qsc/Cargo.toml
+++ b/source/compiler/qsc/Cargo.toml
@@ -15,7 +15,7 @@ log = { workspace = true }
 miette = { workspace = true }
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
-qdk_simulators =  { path = "../../simulators" }
+qdk_simulators =  { path = "../../simulators", default-features = false }
 qsc_codegen = { path = "../qsc_codegen" }
 qsc_data_structures = { path = "../qsc_data_structures" }
 qsc_doc_gen = { path = "../qsc_doc_gen" }

--- a/source/compiler/qsc_eval/Cargo.toml
+++ b/source/compiler/qsc_eval/Cargo.toml
@@ -14,7 +14,7 @@ ndarray = { workspace = true }
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
 num-traits = { workspace = true }
-qdk_simulators =  { path = "../../simulators" }
+qdk_simulators =  { path = "../../simulators", default-features = false }
 qsc_data_structures = { path = "../qsc_data_structures" }
 qsc_fir = { path = "../qsc_fir" }
 qsc_hir = { path = "../qsc_hir" }

--- a/source/compiler/stim_compiler/Cargo.toml
+++ b/source/compiler/stim_compiler/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 
 [dependencies]
 enum-iterator.workspace = true
-qdk_simulators = { path = "../../simulators" }
+qdk_simulators = { path = "../../simulators", default-features = false }
 qsc_data_structures = { path = "../qsc_data_structures" }
 rustc-hash = { workspace = true }
 miette = { workspace = true }

--- a/source/qdk_package/Cargo.toml
+++ b/source/qdk_package/Cargo.toml
@@ -17,7 +17,7 @@ num-complex = { workspace = true }
 num-traits = { workspace = true }
 qsc = { path = "../compiler/qsc" }
 stim_compiler = { path = "../compiler/stim_compiler" }
-qdk_simulators = { path = "../simulators" }
+qdk_simulators = { path = "../simulators", features = ["gpu"] }
 resource_estimator = { path = "../resource_estimator" }
 qre = { path = "../qre" }
 miette = { workspace = true, features = ["fancy"] }

--- a/source/simulators/Cargo.toml
+++ b/source/simulators/Cargo.toml
@@ -8,11 +8,15 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["gpu"]
+gpu = ["dep:futures", "dep:wgpu"]
+
 [dependencies]
 binar = { workspace = true }
-bytemuck = { workspace = true }
-futures = { workspace = true }
-wgpu = { workspace = true }
+bytemuck = { workspace = true, features = ["derive"] }
+futures = { workspace = true, optional = true }
+wgpu = { workspace = true, optional = true }
 rand = { workspace = true }
 nalgebra = { workspace = true }
 ndarray = { workspace = true }
@@ -59,3 +63,4 @@ harness = false
 [[bin]]
 name = "gpu-runner"
 path = "src/bin/gpu-runner.rs"
+required-features = ["gpu"]

--- a/source/simulators/src/lib.rs
+++ b/source/simulators/src/lib.rs
@@ -3,11 +3,13 @@
 
 pub mod bytecode;
 pub mod cpu_full_state_simulator;
+#[cfg(feature = "gpu")]
 mod gpu_full_state_simulator;
 pub mod noise_config;
 pub mod sparse_state_simulator;
 pub mod stabilizer_simulator;
 
+#[cfg(feature = "gpu")]
 pub use gpu_full_state_simulator::*;
 pub use sparse_state_simulator::SparseStateSim;
 pub use sparse_state_simulator::nearly_zero::NearlyZero;


### PR DESCRIPTION
- Skip wasm prereqs check when not compiling wasm
- Use more codegen units when building tests from `build.py` to decrease build time
- Only compile gpu deps when needed