### PR TITLE
RCA Perf: Remove early termination check in `analyze_expr_while`

### DIFF
--- a/source/compiler/qsc_rca/src/applications.rs
+++ b/source/compiler/qsc_rca/src/applications.rs
@@ -660,15 +660,6 @@ impl LocalsLookup for LocalsComputeKindMap {
 }
 
 impl LocalsComputeKindMap {
-    pub fn has_same_compute_kinds(&self, other: &Self) -> bool {
-        self.0.iter().count() == other.0.iter().count()
-            && self.0.iter().all(|(local_var_id, local)| {
-                other
-                    .find_local_compute_kind(local_var_id)
-                    .is_some_and(|other_local| local.compute_kind == other_local.compute_kind)
-            })
-    }
-
     pub fn aggregate_compute_kind(&mut self, local_var_id: LocalVarId, delta: ComputeKind) {
         let local_compute_kind = self
             .0

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -1234,15 +1234,6 @@ impl<'a> Analyzer<'a> {
             let stabilization_limit = AssignmentStmtCounter::new(package).count_in_block(block_id)
                 + AssignmentStmtCounter::new(package).count_in_expr(condition_expr_id);
             for _ in 0..=stabilization_limit {
-                let application_instance = self.get_current_application_instance();
-                let previous_locals_map = application_instance.locals_map.clone();
-                let previous_condition_compute_kind = application_instance
-                    .find_expr_compute_kind(condition_expr_id)
-                    .copied();
-                let previous_block_compute_kind = application_instance
-                    .find_block_compute_kind(block_id)
-                    .copied();
-
                 // If the condition expression is a variable value kind
                 // OR
                 // we are trying to emit loops and the block is dynamic,
@@ -1269,20 +1260,6 @@ impl<'a> Analyzer<'a> {
                         .pop()
                         .expect("at least one dynamic scope should exist");
                     assert!(dynamic_scope_expr_id == condition_expr_id);
-                }
-
-                let application_instance = self.get_current_application_instance();
-                if previous_locals_map.has_same_compute_kinds(&application_instance.locals_map)
-                    && previous_condition_compute_kind
-                        == application_instance
-                            .find_expr_compute_kind(condition_expr_id)
-                            .copied()
-                    && previous_block_compute_kind
-                        == application_instance
-                            .find_block_compute_kind(block_id)
-                            .copied()
-                {
-                    break;
                 }
             }
 


### PR DESCRIPTION
This is the first of a few RCA perf improvements. This removes code that performs checks to see if iterations of the stabilization loop in `analyze_expr_while` don't make progress and can be exited early. In practice, this has a perf cost rather than a perf gain, so is not really an optimization.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>