### PR TITLE
Use mapped qubit ids in constant arrays to respect `Relabel`

### DIFF
--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -4749,7 +4749,8 @@ impl<'a> PartialEvaluator<'a> {
             // that will be stored in the global section of the program. If it matches an existing array literal, we can
             // reuse that identifier, otherwise a new one is generated and stored into the program.
             // The index instruction will then be emitted to index into that array literal.
-            let array_literal = convert_to_array_literal(array, array_package_span, array_elem_ty)?;
+            let array_literal =
+                self.convert_to_array_literal(array, array_package_span, array_elem_ty)?;
             let array_elem_ty = array_literal.ty;
 
             let const_array_id = if let Some(idx) = self
@@ -4884,6 +4885,50 @@ impl<'a> PartialEvaluator<'a> {
 
     fn in_parallel_scope(&self) -> bool {
         self.eval_context.get_current_scope().in_parallel
+    }
+
+    fn convert_to_array_literal(
+        &self,
+        array: &Rc<Vec<Value>>,
+        array_package_span: PackageSpan,
+        array_elem_ty: &Ty,
+    ) -> Result<rir::ArrayLiteral, Error> {
+        let Ok(rir::Ty::Prim(elem_rir_prim_ty)) = map_fir_type_to_rir_type(array_elem_ty) else {
+            return Err(Error::Unexpected(
+                "array with non-primitive RIR type".to_string(),
+                array_package_span,
+            ));
+        };
+
+        let mut elem_literals = Vec::new();
+        for elem in array.iter() {
+            let elem_literal = match elem {
+                Value::Bool(b) => rir::Literal::Bool(*b),
+                Value::Int(i) => rir::Literal::Integer(*i),
+                Value::Double(d) => rir::Literal::Double(*d),
+                Value::Qubit(q) => rir::Literal::Qubit(
+                    self.resource_manager
+                        .map_qubit(q)
+                        .try_into()
+                        .expect("could not convert qubit ID to u32"),
+                ),
+                Value::Result(val::Result::Id(r)) => rir::Literal::Result(
+                    (*r).try_into().expect("could not convert result ID to u32"),
+                ),
+                _ => {
+                    return Err(Error::Unimplemented(
+                        format!("array element type `{}`", elem.type_name()),
+                        array_package_span,
+                    ));
+                }
+            };
+            elem_literals.push(elem_literal);
+        }
+
+        Ok(rir::ArrayLiteral {
+            contents: elem_literals,
+            ty: elem_rir_prim_ty,
+        })
     }
 }
 
@@ -5239,49 +5284,6 @@ fn try_get_eval_var_type(value: &Value) -> Option<VarTy> {
         Value::Var(var) => Some(var.ty),
         _ => None,
     }
-}
-
-fn convert_to_array_literal(
-    array: &Rc<Vec<Value>>,
-    array_package_span: PackageSpan,
-    array_elem_ty: &Ty,
-) -> Result<rir::ArrayLiteral, Error> {
-    let Ok(rir::Ty::Prim(elem_rir_prim_ty)) = map_fir_type_to_rir_type(array_elem_ty) else {
-        return Err(Error::Unexpected(
-            "array with non-primitive RIR type".to_string(),
-            array_package_span,
-        ));
-    };
-
-    let mut elem_literals = Vec::new();
-    for elem in array.iter() {
-        let elem_literal = match elem {
-            Value::Bool(b) => rir::Literal::Bool(*b),
-            Value::Int(i) => rir::Literal::Integer(*i),
-            Value::Double(d) => rir::Literal::Double(*d),
-            Value::Qubit(q) => rir::Literal::Qubit(
-                q.deref()
-                    .0
-                    .try_into()
-                    .expect("could not convert qubit ID to u32"),
-            ),
-            Value::Result(val::Result::Id(r)) => {
-                rir::Literal::Result((*r).try_into().expect("could not convert result ID to u32"))
-            }
-            _ => {
-                return Err(Error::Unimplemented(
-                    format!("array element type `{}`", elem.type_name()),
-                    array_package_span,
-                ));
-            }
-        };
-        elem_literals.push(elem_literal);
-    }
-
-    Ok(rir::ArrayLiteral {
-        contents: elem_literals,
-        ty: elem_rir_prim_ty,
-    })
 }
 
 /// Recursively traverse the given array to collect any arrays with dynamic contents (arrays that contain RIR variables),

--- a/source/compiler/qsc_partial_eval/src/tests/qubits.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/qubits.rs
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::too_many_lines)]
+
 use super::{
     assert_block_instructions, assert_callable, assert_error, get_partial_evaluation_error,
     get_rir_program,
 };
+use crate::tests::get_rir_program_with_capabilities;
 use expect_test::expect;
 use indoc::indoc;
+use qsc_data_structures::target::Profile;
 use qsc_rir::rir::{BlockId, CallableId};
 
 #[test]
@@ -505,4 +509,119 @@ fn qubit_relabel_in_dynamic_block_triggers_capability_error() {
         &error,
         &expect!["CapabilityError(UseOfDynamicQubit(Span { lo: 67160, hi: 67173 }))"],
     );
+}
+
+#[test]
+fn qubit_relabel_uses_expected_ids_in_adaptive_global_arrays() {
+    let program = get_rir_program_with_capabilities(
+        indoc! {
+            r#"
+        operation Main() : Unit {
+            use qs = Qubit[2];
+            use aux = Qubit[2];
+            for q in aux {
+                H(q);
+            }
+            Relabel(qs+aux, aux+qs);
+            for q in qs {
+                H(q);
+            }
+        }
+        "#,
+        },
+        Profile::Adaptive.into(),
+    );
+
+    // Since the qubits are relabeled, both loops should iterate over the same qubit IDs and only
+    // one array literal of ids should be included in the program.
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: Integer
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__rt__initialize
+                    call_type: Regular
+                    input_type:
+                        [0]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: H
+                    call_type: Regular
+                    input_type:
+                        [0]: Qubit
+                    input_vars:
+                        [0]: 6
+                    output_type: <VOID>
+                    body: 4
+                Callable 3: Callable:
+                    name: __quantum__qis__h__body
+                    call_type: Regular
+                    input_type:
+                        [0]: Qubit
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 4: Callable:
+                    name: __quantum__rt__tuple_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Pointer, )
+                    Variable(0, Integer) = Store Integer(0)
+                    Variable(0, Integer) = Store Integer(1)
+                    Variable(0, Integer) = Store Integer(2)
+                    Variable(1, Integer) = Store Integer(0)
+                    Variable(1, Integer) = Store Integer(1)
+                    Variable(1, Integer) = Store Integer(2)
+                    Variable(2, Integer) = Store Integer(0)
+                    Jump(1)
+                Block 1: Block:
+                    Variable(3, Boolean) = Icmp Slt, Variable(2, Integer), Integer(2)
+                    Branch Variable(3, Boolean), 3, 2
+                Block 2: Block:
+                    Variable(8, Integer) = Store Integer(0)
+                    Jump(5)
+                Block 3: Block:
+                    Variable(4, Qubit) = Index Array(0), Variable(2, Integer)
+                    Variable(5, Qubit) = Store Variable(4, Qubit)
+                    Call id(2), args( Variable(5, Qubit), )
+                    Variable(7, Integer) = Add Variable(2, Integer), Integer(1)
+                    Variable(2, Integer) = Store Variable(7, Integer)
+                    Jump(1)
+                Block 4: Block:
+                    Call id(3), args( Variable(6, Qubit), )
+                    Return
+                Block 5: Block:
+                    Variable(9, Boolean) = Icmp Slt, Variable(8, Integer), Integer(2)
+                    Branch Variable(9, Boolean), 7, 6
+                Block 6: Block:
+                    Call id(4), args( Integer(0), Tag(0, 3), )
+                    Return Integer(0)
+                Block 7: Block:
+                    Variable(10, Qubit) = Index Array(0), Variable(8, Integer)
+                    Variable(11, Qubit) = Store Variable(10, Qubit)
+                    Call id(2), args( Variable(11, Qubit), )
+                    Variable(12, Integer) = Add Variable(8, Integer), Integer(1)
+                    Variable(8, Integer) = Store Variable(12, Integer)
+                    Jump(5)
+            config: Config:
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | StaticSizedArrays | CallSupport)
+            num_qubits: 4
+            num_results: 0
+            tags:
+                [0]: 0_t
+            array_literals:
+                [0]: [Qubit(2), Qubit(3)]
+    "#]].assert_eq(&program.to_string());
 }


### PR DESCRIPTION
When `Adaptive` profile emits globally constant qubit identifiers, it was uses the unmapped id for each qubit which did not correctly respect any `Relabel` operations the program might have performed. This fixes the bug and adds a test.