### PR TITLE
Skip loop normalization when package uses no loop control

### DIFF
--- a/source/compiler/qsc_passes/src/lib.rs
+++ b/source/compiler/qsc_passes/src/lib.rs
@@ -135,6 +135,7 @@ impl PassContext {
         let mut loop_control = LoopControl::default();
         loop_control.visit_package(package);
         let loop_control_errors = loop_control.errors;
+        let uses_loop_control = loop_control.uses_loop_control;
 
         ConvertToWSlash { assigner }.visit_package(package);
         Validator::default().visit_package(package);
@@ -159,14 +160,19 @@ impl PassContext {
         let entry_point_errors = generate_entry_expr(package, assigner, package_type);
         Validator::default().visit_package(package);
 
-        // Hoist operand-position break/continue to statement position so the
-        // loop_unification desugar can rewrite them in place.
-        let loop_normalize_errors = {
-            let mut normalize = loop_normalize::LoopNormalize::new(assigner);
-            normalize.visit_package(package);
-            normalize.errors
+        let loop_normalize_errors = if uses_loop_control {
+            // Hoist operand-position break/continue to statement position so the
+            // loop_unification desugar can rewrite them in place.
+            let loop_normalize_errors = {
+                let mut normalize = loop_normalize::LoopNormalize::new(assigner);
+                normalize.visit_package(package);
+                normalize.errors
+            };
+            Validator::default().visit_package(package);
+            loop_normalize_errors
+        } else {
+            Vec::new()
         };
-        Validator::default().visit_package(package);
 
         let loop_uni_errors = {
             let mut loop_uni = LoopUni {
@@ -180,13 +186,14 @@ impl PassContext {
         Validator::default().visit_package(package);
 
         // Defense-in-depth: after loop_unification, no raw `break`/`continue`
-        // node should remain. `ResidualBreakContinue` is an internal invariant
+        // node should remain. `UnsupportedBreakContinue` is an internal invariant
         // check, so when `loop_control` already reported a misplaced
         // `break`/`continue`, the surviving raw node is the expected consequence
         // of that user error and `loop_control`'s diagnostic is the correct
         // user-facing one — only surface the invariant when `loop_control` found
         // no misplaced `break`/`continue`.
-        let residual_break_continue_errors = if loop_control_errors.is_empty() {
+        let residual_break_continue_errors = if uses_loop_control && loop_control_errors.is_empty()
+        {
             loop_unification::check_no_break_continue(package)
         } else {
             Vec::new()
@@ -255,14 +262,8 @@ pub fn run_core_passes(core: &mut CompileUnit) -> Vec<Error> {
 
     let table = global::iter_package(PackageId::CORE, &core.package).collect();
 
-    // Hoist operand-position break/continue to statement position before the
-    // loop_unification desugar, matching the default pass pipeline.
-    let loop_normalize_errors = {
-        let mut normalize = loop_normalize::LoopNormalize::new(&mut core.assigner);
-        normalize.visit_package(&mut core.package);
-        normalize.errors
-    };
-    Validator::default().visit_package(&core.package);
+    // Core library is not expected to contain any break/continue, but if it does, report them as errors.
+    let break_continue_errors = loop_unification::check_no_break_continue(&core.package);
 
     let loop_uni_errors = {
         let mut loop_uni = LoopUni {
@@ -275,23 +276,18 @@ pub fn run_core_passes(core: &mut CompileUnit) -> Vec<Error> {
     };
     Validator::default().visit_package(&core.package);
 
-    // The core pipeline has no `loop_control` pass, so this residual-node check
-    // is the sole guard that no raw `break`/`continue` survived desugaring.
-    let residual_break_continue_errors = loop_unification::check_no_break_continue(&core.package);
-
     ReplaceQubitAllocation::new(&table, &mut core.assigner).visit_package(&mut core.package);
     Validator::default().visit_package(&core.package);
 
     borrow_errors
         .into_iter()
         .map(Error::BorrowCk)
-        .chain(loop_normalize_errors.into_iter().map(Error::LoopNormalize))
-        .chain(loop_uni_errors.into_iter().map(Error::LoopUnification))
         .chain(
-            residual_break_continue_errors
+            break_continue_errors
                 .into_iter()
                 .map(Error::LoopUnification),
         )
+        .chain(loop_uni_errors.into_iter().map(Error::LoopUnification))
         .collect()
 }
 

--- a/source/compiler/qsc_passes/src/loop_control.rs
+++ b/source/compiler/qsc_passes/src/loop_control.rs
@@ -44,9 +44,11 @@ enum ForbiddenPosition {
 /// runs on HIR after lambda lifting, so each callable is walked with a fresh loop
 /// depth of zero and needs no lambda special-casing: a `break`/`continue` in a
 /// lambda body binds only to a loop within that same lambda.
+#[allow(clippy::struct_field_names)]
 #[derive(Default)]
 pub(super) struct LoopControl {
     pub(super) errors: Vec<Error>,
+    pub(super) uses_loop_control: bool,
     loop_depth: u32,
     forbidden: Option<ForbiddenPosition>,
 }
@@ -88,6 +90,7 @@ impl<'a> Visitor<'a> for LoopControl {
     fn visit_expr(&mut self, expr: &'a Expr) {
         match &expr.kind {
             ExprKind::Break | ExprKind::Continue => {
+                self.uses_loop_control = true;
                 if let Some(error) = self.control_flow_error(expr.span) {
                     self.errors.push(error);
                 }

--- a/source/compiler/qsc_passes/src/loop_unification.rs
+++ b/source/compiler/qsc_passes/src/loop_unification.rs
@@ -51,13 +51,12 @@ pub enum Error {
         #[label("break/continue in a value with no classical default")] Span,
     ),
 
-    #[error("internal error: `break`/`continue` was not eliminated by loop desugaring")]
-    #[diagnostic(code("Qdk.Qsc.LoopUnification.ResidualBreakContinue"))]
+    #[error("unsupported use of `break`/`continue`")]
+    #[diagnostic(code("Qdk.Qsc.LoopUnification.UnsupportedBreakContinue"))]
     #[diagnostic(help(
-        "this indicates a compiler invariant was violated; every `break`/`continue` should be \
-         rewritten to loop-flag writes during desugaring"
+        "this indicates a compiler invariant was violated, please report this as a bug to the compiler team"
     ))]
-    ResidualBreakContinue(#[label("`break`/`continue` survived loop desugaring")] Span),
+    UnsupportedBreakContinue(#[label("unsupported `break`/`continue`")] Span),
 }
 
 pub(crate) struct LoopUni<'a> {
@@ -1405,31 +1404,23 @@ fn expr_always_escapes(expr: &Expr) -> bool {
     }
 }
 
-/// Scans `package` for any raw `break`/`continue` node that survived loop
-/// desugaring and returns one [`Error::ResidualBreakContinue`] per occurrence.
-///
-/// After [`LoopUni`] runs, every `break`/`continue` should have been rewritten to
-/// loop-flag writes, so any surviving raw node signals a violated compiler
-/// invariant. Unlike the per-loop [`EnclosingBreakContinueScan`], this walk is
-/// intentionally not loop-depth aware: once desugaring is complete, no raw
-/// `break`/`continue` should remain anywhere, so every occurrence is a violation.
+/// Scans `package` for any unsupported `break`/`continue` nodes.
 pub(crate) fn check_no_break_continue(package: &Package) -> Vec<Error> {
-    let mut scan = ResidualBreakContinueScan { errors: Vec::new() };
+    let mut scan = UnsupportedBreakContinueScan { errors: Vec::new() };
     scan.visit_package(package);
     scan.errors
 }
 
-/// Read-only visitor that records a [`Error::ResidualBreakContinue`] for each raw
-/// `break`/`continue` node it encounters.
-struct ResidualBreakContinueScan {
+/// Read-only visitor that records a [`Error::BreakContinue`] for each use of `break`/`continue`.
+struct UnsupportedBreakContinueScan {
     errors: Vec<Error>,
 }
 
-impl<'a> Visitor<'a> for ResidualBreakContinueScan {
+impl<'a> Visitor<'a> for UnsupportedBreakContinueScan {
     fn visit_expr(&mut self, expr: &'a Expr) {
         match &expr.kind {
             ExprKind::Break | ExprKind::Continue => {
-                self.errors.push(Error::ResidualBreakContinue(expr.span));
+                self.errors.push(Error::UnsupportedBreakContinue(expr.span));
             }
             _ => {}
         }

--- a/source/compiler/qsc_passes/src/loop_unification/break_continue_tests.rs
+++ b/source/compiler/qsc_passes/src/loop_unification/break_continue_tests.rs
@@ -1712,8 +1712,8 @@ fn check_no_break_continue_reports_residual_node() {
     assert!(
         residual
             .iter()
-            .all(|e| matches!(e, Error::ResidualBreakContinue(_))),
-        "expected only ResidualBreakContinue errors, got {residual:?}"
+            .all(|e| matches!(e, Error::UnsupportedBreakContinue(_))),
+        "expected only UnsupportedBreakContinue errors, got {residual:?}"
     );
 
     expect![[r#"
@@ -1797,7 +1797,7 @@ fn default_passes_gate_residual_error_when_loop_control_reports() {
     // `loop_control` reports. The residual raw node it leaves behind is the
     // expected consequence of that error, so the default pipeline must surface
     // only the `loop_control` diagnostic and gate out the internal
-    // `ResidualBreakContinue` invariant to avoid double-reporting.
+    // `UnsupportedBreakContinue` invariant to avoid double-reporting.
     let store = PackageStore::new(compile::core());
     let sources = SourceMap::new(
         [(
@@ -1832,9 +1832,9 @@ fn default_passes_gate_residual_error_when_loop_control_reports() {
     assert!(
         !errors.iter().any(|e| matches!(
             e,
-            crate::Error::LoopUnification(Error::ResidualBreakContinue(_))
+            crate::Error::LoopUnification(Error::UnsupportedBreakContinue(_))
         )),
-        "gating should suppress ResidualBreakContinue when loop_control reports, got {errors:?}"
+        "gating should suppress UnsupportedBreakContinue when loop_control reports, got {errors:?}"
     );
 
     expect![[r#"


### PR DESCRIPTION
This change updates the default passes to skip the loop normalization pass when the package doesn't include any usage of break/continue loop controls. This avoids the transformation on the stdlib, which saves about 6% (or 1 ms) in local compilation perf tests. This also changes the core lib passes to disallow loop controls there.