### PR TITLE
[STIM] Introduce non-Clifford gates to qdk-stim

### DIFF
--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -13,6 +13,7 @@ use Pauli::{X, Y, Z};
 use miette::Diagnostic;
 use qsc_data_structures::span::Span;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::f64::consts::PI;
 use std::fmt::Write;
 use std::slice::Chunks;
 use thiserror::Error;
@@ -20,6 +21,10 @@ use thiserror::Error;
 type StimQubitId = u32;
 type QubitId = u32;
 type ResultId = u32;
+
+// Angle units
+type HalfTurns = f64; // used in qdk-stim
+type Radians = f64; // used in QIR
 
 struct QirWriter {
     output: String,
@@ -90,6 +95,21 @@ impl QirWriter {
     /// `noise_intrinsic_{id}`
     fn write_noise_call(&mut self, name: &str, qubits: &[QubitId]) {
         self.call_noise_intrinsic(name, qubits);
+    }
+
+    // Writes: `  call void @{name}(double {angle:?}, ptr inttoptr (i64 N to ptr), ...)`
+    fn write_rotation_call(&mut self, intrinsic: &str, angle: Radians, qubits: &[QubitId]) {
+        let name = format!("__quantum__qis__{intrinsic}__body");
+        write!(self, "  call void @{name}(double {angle:?}");
+        for &qubit in qubits {
+            write!(self, ", ");
+            self.write_ptr(qubit);
+        }
+        writeln!(self, ")");
+        self.declare(&name, || {
+            let params = vec!["ptr"; qubits.len()].join(", ");
+            format!("declare void @{name}(double, {params})")
+        });
     }
 
     fn call_noise_intrinsic(&mut self, intrinsic: &str, qubits: &[QubitId]) {
@@ -379,6 +399,16 @@ pub enum Error {
         instruction: String,
         expected: usize,
         found: usize,
+        #[label]
+        span: Span,
+    },
+    #[error(
+        "angle for {instruction} must be finite and representable in radians; found {angle} half turns"
+    )]
+    #[diagnostic(code("Qdk.Stim.Compiler.InvalidAngle"))]
+    InvalidAngle {
+        instruction: String,
+        angle: HalfTurns,
         #[label]
         span: Span,
     },
@@ -1386,6 +1416,13 @@ impl<'noise> Compiler<'noise> {
             "DETECTOR" | "MPAD" | "OBSERVABLE_INCLUDE" | "QUBIT_COORDS" | "SHIFT_COORDS"
             | "TICK" => (),
 
+            // Non-Clifford Gates
+            "T" => self.broadcast(instruction, |s, q| s.op("t", q)),
+            "T_DAG" => self.broadcast(instruction, |s, q| s.op_adj("t", q)),
+            "R_X" | "R_Y" | "R_Z" => self.broadcast_rotation(instruction, |s, angle, q| {
+                s.op_rotation(&instruction.name.to_lowercase().replace("_", ""), angle, q);
+            }),
+
             _ => self.unknown(instruction),
         }
     }
@@ -1492,6 +1529,17 @@ impl<'noise> Compiler<'noise> {
             let result_id = measure(s, q, negated);
             s.op_readout_noise(readout_noise, result_id);
         });
+    }
+
+    fn broadcast_rotation(
+        &mut self,
+        instruction: &Instruction,
+        mut operation: impl FnMut(&mut Self, Radians, StimQubitId),
+    ) {
+        let Some(angle) = self.expect_angle(instruction) else {
+            return;
+        };
+        self.for_each_qubit(instruction, |s, q| operation(s, angle, q));
     }
 
     fn accumulate_correlated_noise(&mut self, instruction: &Instruction) {
@@ -1870,6 +1918,11 @@ impl<'noise> Compiler<'noise> {
         }
     }
 
+    fn op_rotation(&mut self, intrinsic: &str, angle: Radians, qubit: StimQubitId) {
+        let qubit = self.id_map.allocate_qubit(qubit);
+        self.writer.write_rotation_call(intrinsic, angle, &[qubit]);
+    }
+
     fn build_noise_table(
         &mut self,
         num_qubits: u32,
@@ -2138,6 +2191,20 @@ impl<'noise> Compiler<'noise> {
                 None
             }
         }
+    }
+
+    fn expect_angle(&mut self, instruction: &Instruction) -> Option<Radians> {
+        let angle: HalfTurns = self.expect_arg(instruction)?;
+        let radians = angle * PI;
+        if !radians.is_finite() {
+            self.push_error(Error::InvalidAngle {
+                instruction: instruction.name.clone(),
+                angle,
+                span: instruction.span,
+            });
+            return None;
+        }
+        Some(radians)
     }
 
     fn expect_arg(&mut self, instruction: &Instruction) -> Option<f64> {

--- a/source/compiler/stim_compiler/src/qir/tests.rs
+++ b/source/compiler/stim_compiler/src/qir/tests.rs
@@ -7,6 +7,7 @@ mod generalized_pauli_product_gates;
 mod measurement_record_targets;
 mod noise_channels;
 mod noise_channels_broadcasting;
+mod non_clifford_gates;
 mod pair_measurements;
 mod pair_measurements_broadcasting;
 mod peek_loss;

--- a/source/compiler/stim_compiler/src/qir/tests/non_clifford_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/non_clifford_gates.rs
@@ -1,0 +1,362 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::check;
+use expect_test::expect;
+use indoc::indoc;
+
+#[test]
+fn t_gate_yields_expected_qir() {
+    check(
+        "T 0",
+        &expect![[r#"
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__rt__array_record_output(i64 0, ptr null)
+              ret i64 0
+            }
+
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__qis__t__body(ptr)
+            declare void @__quantum__rt__initialize(ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
+    );
+}
+
+#[test]
+fn t_dag_gate_yields_expected_qir() {
+    check(
+        "T_DAG 0",
+        &expect![[r#"
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__rt__array_record_output(i64 0, ptr null)
+              ret i64 0
+            }
+
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__t__adj(ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
+    );
+}
+
+#[test]
+fn t_gate_with_argument_yields_error() {
+    check(
+        "T(0.5) 0",
+        &expect![[r#"
+            Qdk.Stim.Compiler.UnsupportedArgument
+
+              x unsupported argument in instruction: T
+               ,----
+             1 | T(0.5) 0
+               : ^^^^^^^^
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn t_gate_with_negated_target_yields_error() {
+    check(
+        "T !0",
+        &expect![[r#"
+            Qdk.Stim.Compiler.NegatedTarget
+
+              x target cannot be negated in instruction: T
+               ,----
+             1 | T !0
+               :   ^^
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn t_gate_with_measurement_record_target_yields_error() {
+    let source = indoc! {"
+        M 0
+        T rec[-1]
+    "};
+    check(
+        source,
+        &expect![[r#"
+            Qdk.Stim.Compiler.UnsupportedTarget
+
+              x unsupported target in instruction: T
+               ,-[2:3]
+             1 | M 0
+             2 | T rec[-1]
+               :   ^^^^^^^
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn t_gate_with_pauli_target_yields_error() {
+    check(
+        "T X0",
+        &expect![[r#"
+            Qdk.Stim.Compiler.UnsupportedTarget
+
+              x unsupported target in instruction: T
+               ,----
+             1 | T X0
+               :   ^^
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn r_x_yields_expected_qir() {
+    check(
+        "R_X(0.25) 0",
+        &expect![[r#"
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__rx__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__rt__array_record_output(i64 0, ptr null)
+              ret i64 0
+            }
+
+            declare void @__quantum__qis__rx__body(double, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
+    );
+}
+
+#[test]
+fn r_y_yields_expected_qir() {
+    check(
+        "R_Y(0.25) 0",
+        &expect![[r#"
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__ry__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__rt__array_record_output(i64 0, ptr null)
+              ret i64 0
+            }
+
+            declare void @__quantum__qis__ry__body(double, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
+    );
+}
+
+#[test]
+fn r_z_yields_expected_qir() {
+    check(
+        "R_Z(0.25) 0",
+        &expect![[r#"
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__rt__array_record_output(i64 0, ptr null)
+              ret i64 0
+            }
+
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__qis__rz__body(double, ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
+    );
+}
+
+#[test]
+fn r_x_broadcasts_over_targets() {
+    check(
+        "R_X(0.125) 0 1 2",
+        &expect![[r#"
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 1 to ptr))
+              call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 2 to ptr))
+              call void @__quantum__rt__array_record_output(i64 0, ptr null)
+              ret i64 0
+            }
+
+            declare void @__quantum__qis__rx__body(double, ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
+    );
+}
+
+#[test]
+fn r_x_without_argument_yields_error() {
+    check(
+        "R_X 0",
+        &expect![[r#"
+            Qdk.Stim.Compiler.MissingArg
+
+              x missing argument in instruction: R_X
+               ,----
+             1 | R_X 0
+               : ^^^^^
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn r_x_with_two_arguments_yields_error() {
+    check(
+        "R_X(0.25, 0.5) 0",
+        &expect![[r#"
+            Qdk.Stim.Compiler.WrongArgCount
+
+              x instruction R_X requires 1 arguments, but found 2
+               ,----
+             1 | R_X(0.25, 0.5) 0
+               : ^^^^^^^^^^^^^^^^
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn r_x_with_negated_target_yields_error() {
+    check(
+        "R_X(0.25) !0",
+        &expect![[r#"
+            Qdk.Stim.Compiler.NegatedTarget
+
+              x target cannot be negated in instruction: R_X
+               ,----
+             1 | R_X(0.25) !0
+               :           ^^
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn r_x_with_angle_that_overflows_radians_yields_error() {
+    check(
+        "R_X(1e308) 0",
+        &expect![[r#"
+            Qdk.Stim.Compiler.InvalidAngle
+
+              x angle for R_X must be finite and representable in radians; found
+              | 10000000000000000000000000000000000000000000000000000000000000000000000000
+              | 00000000000000000000000000000000000000000000000000000000000000000000000000
+              | 00000000000000000000000000000000000000000000000000000000000000000000000000
+              | 00000000000000000000000000000000000000000000000000000000000000000000000000
+              | 0000000000000 half turns
+               ,----
+             1 | R_X(1e308) 0
+               : ^^^^^^^^^^^^
+               `----
+        "#]],
+    );
+}

--- a/source/compiler/stim_compiler/src/qir/tests/non_clifford_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/non_clifford_gates.rs
@@ -183,13 +183,13 @@ fn r_x_yields_expected_qir() {
 }
 
 #[test]
-fn r_y_yields_expected_qir() {
+fn r_y_with_negative_angle_yields_expected_qir() {
     check(
-        "R_Y(0.25) 0",
+        "R_Y(-0.25) 0",
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__ry__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__ry__body(double -0.7853981633974483, ptr inttoptr (i64 0 to ptr))
               call void @__quantum__rt__array_record_output(i64 0, ptr null)
               ret i64 0
             }
@@ -219,13 +219,13 @@ fn r_y_yields_expected_qir() {
 }
 
 #[test]
-fn r_z_yields_expected_qir() {
+fn r_z_with_large_angle_yields_expected_qir() {
     check(
-        "R_Z(0.25) 0",
+        "R_Z(123.432) 0",
         &expect![[r#"
             define i64 @ENTRYPOINT__main() #0 {
               call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+              call void @__quantum__qis__rz__body(double 387.77306441789534, ptr inttoptr (i64 0 to ptr))
               call void @__quantum__rt__array_record_output(i64 0, ptr null)
               ret i64 0
             }

--- a/source/qdk_package/tests/test_stim.py
+++ b/source/qdk_package/tests/test_stim.py
@@ -1,15 +1,35 @@
 import math
 
 import qdk.stim as stim
+from qdk import Result
 
 from simulator_test_utils import check_histogram
+
+
+def map_result_list_to_str(results):
+    s = ""
+    if isinstance(results, (list, tuple)):
+        for r in results:
+            s += map_result_list_to_str(r)
+    else:
+        match results:
+            case Result.Zero:
+                s += "0"
+            case Result.One:
+                s += "1"
+            case Result.Loss:
+                s += "L"
+    return s
 
 
 def test_t_gate_runs_on_clifford_simulator() -> None:
     results = stim.run("H 0\nT 0\nH 0\nM 0", shots=2_000, seed=42, type="clifford")
 
     one_probability = math.sin(math.pi / 8.0) ** 2
-    check_histogram(results, {"0": 1.0 - one_probability, "1": one_probability})
+    check_histogram(
+        [map_result_list_to_str(result) for result in results],
+        {"0": 1.0 - one_probability, "1": one_probability},
+    )
 
 
 def test_arbitrary_rotation_runs_on_clifford_simulator() -> None:
@@ -19,4 +39,7 @@ def test_arbitrary_rotation_runs_on_clifford_simulator() -> None:
     )
 
     one_probability = math.sin(math.pi * half_turns / 2.0) ** 2
-    check_histogram(results, {"0": 1.0 - one_probability, "1": one_probability})
+    check_histogram(
+        [map_result_list_to_str(result) for result in results],
+        {"0": 1.0 - one_probability, "1": one_probability},
+    )

--- a/source/qdk_package/tests/test_stim.py
+++ b/source/qdk_package/tests/test_stim.py
@@ -1,0 +1,22 @@
+import math
+
+import qdk.stim as stim
+
+from simulator_test_utils import check_histogram
+
+
+def test_t_gate_runs_on_clifford_simulator() -> None:
+    results = stim.run("H 0\nT 0\nH 0\nM 0", shots=2_000, seed=42, type="clifford")
+
+    one_probability = math.sin(math.pi / 8.0) ** 2
+    check_histogram(results, {"0": 1.0 - one_probability, "1": one_probability})
+
+
+def test_arbitrary_rotation_runs_on_clifford_simulator() -> None:
+    half_turns = 0.4
+    results = stim.run(
+        f"R_Y({half_turns}) 0\nM 0", shots=2_000, seed=42, type="clifford"
+    )
+
+    one_probability = math.sin(math.pi * half_turns / 2.0) ** 2
+    check_histogram(results, {"0": 1.0 - one_probability, "1": one_probability})


### PR DESCRIPTION
This PR introduces support for `T`, `T_DAG`, `R_X`, `R_Y`, and `R_Z` to qdk-stim.

These gates aren't supported by official stim, so we used the [clifft docs](https://github.com/unitaryfoundation/clifft/blob/main/docs/reference/gates.md#supported-gates) as a basis for these changes. For example, while QIR expresses angles in radians, all of our rotation gates will be representing them in half turns (pi radians), similar to clifft.