### PR TITLE
Add unit to unit navigation links to Chemistry QPE notebooks

### DIFF
--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/00-overview/overview.ipynb
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/00-overview/overview.ipynb
@@ -63,6 +63,12 @@
     ]
    },
    "source": "## Tutorial scope and structure\n\nThe tutorial deliberately selects a compact active-space model that can be solved exactly on a classical computer, allowing each quantum stage to be checked against a classical reference.\nThe circuits are executed on a classical simulator to validate the workflow.\nComplete active space configuration interaction (CASCI) performs full configuration interaction within the selected active space rather than across all orbitals in the molecular model.\nThe final quantum calculation is compared with the CASCI energy of the same selected active-space Hamiltonian.\nThe tutorial uses one [millihartree ↗](https://en.wikipedia.org/wiki/Hartree) ($1\\ \\mathrm{m}E_{\\mathrm{h}}$) as a teaching target for this algorithmic comparison; however, meeting that target does not establish agreement with experiment or remove basis-set and active-space errors.\n\nEach required chapter:\n\n- introduces one stage of the calculation;\n- provides a testable Python example where appropriate.\n\nThe required chapters follow the stages in the workflow diagram:\n\n- *Define the target energy and accuracy comparison*.\n- *Construct the molecular system and Hartree–Fock starting wavefunction*.\n- *Select a correlated active-space model*.\n- *Map the active-space Hamiltonian to qubits*.\n- *Prepare a trial state*.\n- *Estimate the energy with IQPE and compare it with the matching classical reference*.\n\nThe final circuit simulation is the only intentionally long required example and reports progress after each complete run."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c-6bd3f9592d30",
+   "metadata": {},
+   "source": "<div style=\"display:flex;justify-content:space-between;align-items:stretch;gap:12px;margin-top:8px\"><span></span><a href=\"../01-energy-and-accuracy/energy_and_accuracy.workbook.ipynb\" title=\"Next unit: Energy and Accuracy\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-background, #005fb8);color:var(--vscode-button-foreground, #ffffff);border-color:var(--vscode-button-background, #005fb8)\"><span style=\"text-align:right\"><span style=\"display:block;font-size:11px;opacity:.75\">Next unit</span><span style=\"display:block;font-weight:600\">Energy and Accuracy</span></span><span aria-hidden=\"true\">&#8250;</span></a></div>"
   }
  ],
  "metadata": {

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/01-energy-and-accuracy/energy_and_accuracy.ipynb
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/01-energy-and-accuracy/energy_and_accuracy.ipynb
@@ -103,6 +103,12 @@
     ]
    },
    "source": "## Further reading\n\n- [Equilibrium constants ↗](https://en.wikipedia.org/wiki/Equilibrium_constant)\n- [Eyring equation ↗](https://en.wikipedia.org/wiki/Eyring_equation)\n- [Hartree energy ↗](https://en.wikipedia.org/wiki/Hartree)\n- [Features and methods ↗](https://microsoft.github.io/qdk-chemistry/user/features.html)\n- [Quickstart ↗](https://microsoft.github.io/qdk-chemistry/user/quickstart.html)\n- [References ↗](https://microsoft.github.io/qdk-chemistry/references.html)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c-326382a26df5",
+   "metadata": {},
+   "source": "<div style=\"display:flex;justify-content:space-between;align-items:stretch;gap:12px;margin-top:8px\"><a href=\"../00-overview/overview.workbook.ipynb\" title=\"Previous unit: Tutorial Overview\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-secondaryBackground, transparent);color:var(--vscode-button-secondaryForeground, inherit);border-color:var(--vscode-widget-border, #8884)\"><span aria-hidden=\"true\">&#8249;</span><span><span style=\"display:block;font-size:11px;opacity:.75\">Previous unit</span><span style=\"display:block;font-weight:600\">Tutorial Overview</span></span></a><a href=\"../02-describe-molecule/describe_molecule.workbook.ipynb\" title=\"Next unit: Describing the Molecule\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-background, #005fb8);color:var(--vscode-button-foreground, #ffffff);border-color:var(--vscode-button-background, #005fb8)\"><span style=\"text-align:right\"><span style=\"display:block;font-size:11px;opacity:.75\">Next unit</span><span style=\"display:block;font-weight:600\">Describing the Molecule</span></span><span aria-hidden=\"true\">&#8250;</span></a></div>"
   }
  ],
  "metadata": {

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/02-describe-molecule/describe_molecule.ipynb
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/02-describe-molecule/describe_molecule.ipynb
@@ -201,6 +201,12 @@
     ]
    },
    "source": "## Further reading\n\n- [Molecular structures ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/structure.html)\n- [Basis sets ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/basis_set.html)\n- [Available basis sets ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/basis_functionals.html)\n- [Self-consistent field calculations ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/scf_solver.html)\n- [Molecular orbitals ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/orbitals.html)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c-f55ea919efeb",
+   "metadata": {},
+   "source": "<div style=\"display:flex;justify-content:space-between;align-items:stretch;gap:12px;margin-top:8px\"><a href=\"../01-energy-and-accuracy/energy_and_accuracy.workbook.ipynb\" title=\"Previous unit: Energy and Accuracy\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-secondaryBackground, transparent);color:var(--vscode-button-secondaryForeground, inherit);border-color:var(--vscode-widget-border, #8884)\"><span aria-hidden=\"true\">&#8249;</span><span><span style=\"display:block;font-size:11px;opacity:.75\">Previous unit</span><span style=\"display:block;font-weight:600\">Energy and Accuracy</span></span></a><a href=\"../03-active-space/active_space.workbook.ipynb\" title=\"Next unit: Choosing the Active Space\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-background, #005fb8);color:var(--vscode-button-foreground, #ffffff);border-color:var(--vscode-button-background, #005fb8)\"><span style=\"text-align:right\"><span style=\"display:block;font-size:11px;opacity:.75\">Next unit</span><span style=\"display:block;font-weight:600\">Choosing the Active Space</span></span><span aria-hidden=\"true\">&#8250;</span></a></div>"
   }
  ],
  "metadata": {

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/03-active-space/active_space.ipynb
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/03-active-space/active_space.ipynb
@@ -317,6 +317,12 @@
     ]
    },
    "source": "## Further reading\n\n- [Orbital localization and transformation ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/localizer.html)\n- [Active-space selection ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/active_space.html)\n- [Multi-configuration calculations ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/mc_calculator.html)\n- [Wavefunctions ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/wavefunction.html)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c-b02607941b9e",
+   "metadata": {},
+   "source": "<div style=\"display:flex;justify-content:space-between;align-items:stretch;gap:12px;margin-top:8px\"><a href=\"../02-describe-molecule/describe_molecule.workbook.ipynb\" title=\"Previous unit: Describing the Molecule\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-secondaryBackground, transparent);color:var(--vscode-button-secondaryForeground, inherit);border-color:var(--vscode-widget-border, #8884)\"><span aria-hidden=\"true\">&#8249;</span><span><span style=\"display:block;font-size:11px;opacity:.75\">Previous unit</span><span style=\"display:block;font-weight:600\">Describing the Molecule</span></span></a><a href=\"../04-map-to-qubits/map_to_qubits.workbook.ipynb\" title=\"Next unit: Mapping the Problem to Qubits\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-background, #005fb8);color:var(--vscode-button-foreground, #ffffff);border-color:var(--vscode-button-background, #005fb8)\"><span style=\"text-align:right\"><span style=\"display:block;font-size:11px;opacity:.75\">Next unit</span><span style=\"display:block;font-weight:600\">Mapping the Problem to Qubits</span></span><span aria-hidden=\"true\">&#8250;</span></a></div>"
   }
  ],
  "metadata": {

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/04-map-to-qubits/map_to_qubits.ipynb
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/04-map-to-qubits/map_to_qubits.ipynb
@@ -269,6 +269,12 @@
     ]
    },
    "source": "## Further reading\n\n- [Hamiltonian construction ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/hamiltonian_constructor.html)\n- [Electronic Hamiltonians ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/hamiltonian.html)\n- [Qubit mapping ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/qubit_mapper.html)\n- [Majorana mappings ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/majorana_mapping.html)\n- [Pauli operators ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/pauli_operator.html)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c-05a931fb5080",
+   "metadata": {},
+   "source": "<div style=\"display:flex;justify-content:space-between;align-items:stretch;gap:12px;margin-top:8px\"><a href=\"../03-active-space/active_space.workbook.ipynb\" title=\"Previous unit: Choosing the Active Space\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-secondaryBackground, transparent);color:var(--vscode-button-secondaryForeground, inherit);border-color:var(--vscode-widget-border, #8884)\"><span aria-hidden=\"true\">&#8249;</span><span><span style=\"display:block;font-size:11px;opacity:.75\">Previous unit</span><span style=\"display:block;font-weight:600\">Choosing the Active Space</span></span></a><a href=\"../05-trial-state/trial_state.workbook.ipynb\" title=\"Next unit: Preparing the Trial State\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-background, #005fb8);color:var(--vscode-button-foreground, #ffffff);border-color:var(--vscode-button-background, #005fb8)\"><span style=\"text-align:right\"><span style=\"display:block;font-size:11px;opacity:.75\">Next unit</span><span style=\"display:block;font-weight:600\">Preparing the Trial State</span></span><span aria-hidden=\"true\">&#8250;</span></a></div>"
   }
  ],
  "metadata": {

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/05-trial-state/trial_state.ipynb
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/05-trial-state/trial_state.ipynb
@@ -289,6 +289,12 @@
     ]
    },
    "source": "## Further reading\n\n- [State preparation ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/state_preparation.html)\n- [Projected multi-configuration calculations ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/pmc.html)\n- [Wavefunctions ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/wavefunction.html)\n- [Quantum circuits ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/circuit.html)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c-fbd1de0e715d",
+   "metadata": {},
+   "source": "<div style=\"display:flex;justify-content:space-between;align-items:stretch;gap:12px;margin-top:8px\"><a href=\"../04-map-to-qubits/map_to_qubits.workbook.ipynb\" title=\"Previous unit: Mapping the Problem to Qubits\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-secondaryBackground, transparent);color:var(--vscode-button-secondaryForeground, inherit);border-color:var(--vscode-widget-border, #8884)\"><span aria-hidden=\"true\">&#8249;</span><span><span style=\"display:block;font-size:11px;opacity:.75\">Previous unit</span><span style=\"display:block;font-weight:600\">Mapping the Problem to Qubits</span></span></a><a href=\"../06-iterative-phase-estimation/iterative_phase_estimation.workbook.ipynb\" title=\"Next unit: Iterative Quantum Phase Estimation\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-background, #005fb8);color:var(--vscode-button-foreground, #ffffff);border-color:var(--vscode-button-background, #005fb8)\"><span style=\"text-align:right\"><span style=\"display:block;font-size:11px;opacity:.75\">Next unit</span><span style=\"display:block;font-weight:600\">Iterative Quantum Phase Estimation</span></span><span aria-hidden=\"true\">&#8250;</span></a></div>"
   }
  ],
  "metadata": {

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/06-iterative-phase-estimation/iterative_phase_estimation.ipynb
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/06-iterative-phase-estimation/iterative_phase_estimation.ipynb
@@ -355,6 +355,12 @@
     ]
    },
    "source": "## Further reading\n\n- [Phase estimation ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/phase_estimation.html)\n- [Phase-estimation circuit builders ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/qpe_circuit_builder.html)\n- [Hamiltonian unitary builders ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/hamiltonian_unitary_builder.html)\n- [Circuit execution ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/circuit_executor.html)\n- [Phase-estimation results ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/data/qpe_result.html)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c-5754e24d4034",
+   "metadata": {},
+   "source": "<div style=\"display:flex;justify-content:space-between;align-items:stretch;gap:12px;margin-top:8px\"><a href=\"../05-trial-state/trial_state.workbook.ipynb\" title=\"Previous unit: Preparing the Trial State\" style=\"display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border:1px solid;border-radius:4px;text-decoration:none;background:var(--vscode-button-secondaryBackground, transparent);color:var(--vscode-button-secondaryForeground, inherit);border-color:var(--vscode-widget-border, #8884)\"><span aria-hidden=\"true\">&#8249;</span><span><span style=\"display:block;font-size:11px;opacity:.75\">Previous unit</span><span style=\"display:block;font-weight:600\">Preparing the Trial State</span></span></a><span></span></div>"
   }
  ],
  "metadata": {

--- a/source/vscode/resources/qdk-learning/utils/chemistry-qpe/README.md
+++ b/source/vscode/resources/qdk-learning/utils/chemistry-qpe/README.md
@@ -25,6 +25,12 @@ theme. `tutorial_qpe_atomic_basis_functions.png` and
 `tutorial_qpe_example_molecular_orbitals.png` stay PNG attachments. Every
 figure needs an `:alt:`, which becomes the SVG's accessible name.
 
+Each notebook ends with links to the neighbouring units. Unit order and titles
+come from `course.json` and the notebook names from `RECIPES`, so the two must
+list the same units; the converter stops if they disagree. The links point at
+the learner's `*.workbook.ipynb` copies, which the extension materializes beside
+the authored notebooks, so they only resolve inside a learner's workspace.
+
 | Script               | What it does                                                                                                                |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `rst_to_notebook.py` | Converts one tutorial chapter to a unit notebook. `RECIPES` holds the per-chapter decisions a human still has to make.      |

--- a/source/vscode/resources/qdk-learning/utils/chemistry-qpe/rst_to_notebook.py
+++ b/source/vscode/resources/qdk-learning/utils/chemistry-qpe/rst_to_notebook.py
@@ -1076,6 +1076,95 @@ def inline_svg(picture, alt):
     return re.sub(r"<svg\b([^>]*)>", add_attributes, svg, count=1).strip()
 
 
+# Unit-to-unit navigation. The links point at the learner's `*.workbook.ipynb`
+# copies, which the extension materializes beside the authored notebooks, so
+# following one lands in the learner's own file rather than the pristine source.
+WORKBOOK_SUFFIX = ".workbook.ipynb"
+NAV_ROW = "display:flex;justify-content:space-between;align-items:stretch;gap:12px;margin-top:8px"
+NAV_BUTTON = (
+    "display:inline-flex;align-items:center;gap:8px;padding:6px 12px;"
+    "border:1px solid;border-radius:4px;text-decoration:none"
+)
+NAV_STYLES = {
+    "next": (
+        "background:var(--vscode-button-background, #005fb8);"
+        "color:var(--vscode-button-foreground, #ffffff);"
+        "border-color:var(--vscode-button-background, #005fb8)"
+    ),
+    "previous": (
+        "background:var(--vscode-button-secondaryBackground, transparent);"
+        "color:var(--vscode-button-secondaryForeground, inherit);"
+        "border-color:var(--vscode-widget-border, #8884)"
+    ),
+}
+
+
+def course_units():
+    """Return the ordered units from course.json with their notebook names."""
+    manifest_path = COURSE / "course.json"
+    if not manifest_path.is_file():
+        raise SystemExit(f"missing {manifest_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    notebooks = {r["unit_dir"]: r["notebook"] for r in RECIPES.values()}
+
+    units = []
+    for unit in manifest["units"]:
+        notebook = notebooks.get(unit["dir"])
+        if notebook is None:
+            raise SystemExit(
+                f"course.json lists unit directory {unit['dir']}, "
+                "which no recipe builds"
+            )
+        units.append((unit["dir"], unit["title"], notebook))
+    return units
+
+
+def nav_button(unit, kind):
+    """Return one navigation link, styled as a themed button."""
+    directory, title, notebook = unit
+    href = f"../{directory}/{Path(notebook).stem}{WORKBOOK_SUFFIX}"
+    label = "Next unit" if kind == "next" else "Previous unit"
+    escaped = html.escape(title, quote=True)
+    text = (
+        '<span style="display:block;font-size:11px;opacity:.75">'
+        f"{label}</span>"
+        f'<span style="display:block;font-weight:600">{escaped}</span>'
+    )
+    if kind == "next":
+        inner = (
+            f'<span style="text-align:right">{text}</span>'
+            '<span aria-hidden="true">&#8250;</span>'
+        )
+    else:
+        inner = f'<span aria-hidden="true">&#8249;</span><span>{text}</span>'
+    return (
+        f'<a href="{html.escape(href, quote=True)}" '
+        f'title="{label}: {escaped}" '
+        f'style="{NAV_BUTTON};{NAV_STYLES[kind]}">{inner}</a>'
+    )
+
+
+def navigation(unit_dir):
+    """Return the navigation row for a unit, or None when it has no neighbours."""
+    units = course_units()
+    index = next((i for i, u in enumerate(units) if u[0] == unit_dir), None)
+    if index is None:
+        raise SystemExit(f"{unit_dir} is not listed in course.json")
+
+    previous = nav_button(units[index - 1], "previous") if index > 0 else ""
+    following = (
+        nav_button(units[index + 1], "next") if index + 1 < len(units) else ""
+    )
+    if not previous and not following:
+        return None
+    # An empty span holds the unused side so a lone link keeps its alignment.
+    return (
+        f'<div style="{NAV_ROW}">'
+        f"{previous or '<span></span>'}{following or '<span></span>'}"
+        "</div>"
+    )
+
+
 def render_directive(name, argument, options, body):
     text = "\n".join(inline(ln) for ln in body)
     if name == "math":
@@ -1402,6 +1491,9 @@ def convert(key):
 
     cells = merge_markdown_runs(cells)
     cells = merge_code_runs(cells)
+    nav = navigation(recipe["unit_dir"])
+    if nav:
+        cells.append(md(nav))
     out = COURSE / recipe["unit_dir"] / recipe["notebook"]
     out.parent.mkdir(parents=True, exist_ok=True)
     notebook = {

--- a/source/vscode/resources/qdk-learning/utils/chemistry-qpe/verify_course.py
+++ b/source/vscode/resources/qdk-learning/utils/chemistry-qpe/verify_course.py
@@ -27,7 +27,7 @@ COURSE = args.course
 EXPECTED_TOTALS = Counter(
     {
         "units": 7,
-        "cells": 174,
+        "cells": 181,
         "exercises": 6,
         "hints": 6,
         "solutions": 6,


### PR DESCRIPTION
Each unit notebook now ends with links to the previous and next units, so a
learner can move through the course without going back to the Learning view.