### PR TITLE
Fix OpenQASM errors when editing unsaved files

### DIFF
--- a/source/language_service/src/state.rs
+++ b/source/language_service/src/state.rs
@@ -201,7 +201,7 @@ impl<'a> CompilationStateUpdater<'a> {
         language_id: &str,
     ) -> Project {
         match self
-            .load_manifest_or_openqasm_project(doc_uri, language_id)
+            .load_manifest_or_openqasm_project(doc_uri, Some(text), language_id)
             .await
         {
             Ok(Some(p)) => p,
@@ -228,12 +228,13 @@ impl<'a> CompilationStateUpdater<'a> {
     async fn load_manifest_or_openqasm_project(
         &self,
         doc_uri: &Arc<str>,
+        text: Option<&Arc<str>>,
         language_id: &str,
     ) -> Result<Option<Project>, Vec<project::Error>> {
         if is_openqasm_file(language_id) {
             return Ok(Some(
                 self.project_host
-                    .load_openqasm_project(Path::new(doc_uri.as_ref()), None)
+                    .load_openqasm_project(Path::new(doc_uri.as_ref()), text.cloned())
                     .await,
             ));
         }
@@ -333,7 +334,7 @@ impl<'a> CompilationStateUpdater<'a> {
 
     pub(super) async fn close_document(&mut self, uri: &str, language_id: &str) {
         let project = self
-            .load_manifest_or_openqasm_project(&uri.into(), language_id)
+            .load_manifest_or_openqasm_project(&uri.into(), None, language_id)
             .await;
 
         let removed_compilation = self.remove_open_document(uri);

--- a/source/language_service/src/state/tests.rs
+++ b/source/language_service/src/state/tests.rs
@@ -371,6 +371,32 @@ async fn close_last_doc_in_openqasm_project() {
 }
 
 #[tokio::test]
+async fn untitled_openqasm_document_uses_buffer_contents() {
+    let received_errors = RefCell::new(Vec::new());
+    let test_cases = RefCell::new(Vec::new());
+    let mut updater = new_updater(&received_errors, &test_cases);
+
+    updater
+        .update_document(
+            "untitled:Untitled-1",
+            1,
+            "OPENQASM 3.0;\ninclude \"stdgates.inc\";\nqubit q;\nh q;\n",
+            "openqasm",
+        )
+        .await;
+
+    assert_compilation_sources(
+        &updater,
+        &expect![[r#"
+            untitled:Untitled-1: [
+              "untitled:Untitled-1": "OPENQASM 3.0;\ninclude \"stdgates.inc\";\nqubit q;\nh q;\n",
+            ],
+        "#]],
+    );
+    expect_errors(&received_errors, &expect!["[]"]);
+}
+
+#[tokio::test]
 async fn clear_on_document_close() {
     let errors = RefCell::new(Vec::new());
     let test_cases = RefCell::new(Vec::new());


### PR DESCRIPTION
Buffer context is now used when creating an OpenQASM compilation. This lets unsaved buffers operate in single file project mode.