### PR TITLE
Fixed errors in teleportation kata

### DIFF
--- a/katas/content/teleportation/index.md
+++ b/katas/content/teleportation/index.md
@@ -65,7 +65,7 @@ We split the teleportation protocol into several steps:
     "title": "Testing Quantum Teleportation"
 })
 
-In this lesson, your goal is to put together the code from the previous exercises to teleport the states $\ket{0}$ and $\ket{1}$, as well as superposition states $\frac{1}{2}(\ket{0}+\ket{1})$, $\frac{1}{2}(\ket{0}-\ket{1})$, $\frac{1}{2}(\ket{0}+i\ket{1})$ and $\frac{1}{2}(\ket{0}-i\ket{1})$, and to verify that teleportation succeeds each time.
+In this lesson, your goal is to put together the code from the previous exercises to teleport the states $\ket{0}$ and $\ket{1}$, as well as superposition states $\frac{1}{\sqrt{2}}(\ket{0}+\ket{1})$, $\frac{1}{\sqrt{2}}(\ket{0}-\ket{1})$, $\frac{1}{\sqrt{2}}(\ket{0}+i\ket{1})$ and $\frac{1}{\sqrt{2}}(\ket{0}-i\ket{1})$, and to verify that teleportation succeeds each time.
 
 > This is an open-ended task that is not tested automatically, unlike the previous exercises. Follow the suggestions in the comments to write your code and test it!
 

--- a/katas/content/teleportation/reconstruct_message_phi_minus/solution.md
+++ b/katas/content/teleportation/reconstruct_message_phi_minus/solution.md
@@ -5,8 +5,8 @@ Bob's side of this protocol can actually be represented as a sequence of two ste
 
 The final set of corrections we need is the $Z$ gate, followed by the standard teleportation corrections. This adds up to the following corrections:
 - For 00, only the $Z$ correction is required.
-- For 01, no change is required.
-- For 10, both $Z$ and $X$ corrections are required.
+- For 01, both $Z$ and $X$ corrections are required.
+- For 10, no change is required.
 - For 11, only the $X$ correction is requried.
 
 @[solution]({

--- a/katas/content/teleportation/reconstruct_message_psi_minus/solution.md
+++ b/katas/content/teleportation/reconstruct_message_psi_minus/solution.md
@@ -4,8 +4,8 @@ Bob's side of this protocol can be represented as a sequence of two steps:
  
 The final set of corrections we need is the $Z$ and $X$ gates, followed by the standard teleportation corrections. This adds up to the following corrections:
 - For 00, both $Z$ and $X$ corrections are required.
-- For 01, only the $X$ correction is required.
-- For 10, only the $Z$ correction is required.
+- For 01, only the $Z$ correction is required.
+- For 10, only the $X$ correction is required.
 - For 11, no change is requried.
 
 @[solution]({

--- a/katas/content/teleportation/reconstruct_message_psi_plus/solution.md
+++ b/katas/content/teleportation/reconstruct_message_psi_plus/solution.md
@@ -4,8 +4,8 @@ Bob's side of this protocol can be represented as a sequence of two steps:
  
 The final set of corrections we need is the $X$ gate, followed by the standard teleportation corrections. This adds up to the following corrections:
 - For 00, only the $X$ correction is required.
-- For 01, both $Z$ and $X$ corrections are required.
-- For 10, no change is required.
+- For 01, no change is required.
+- For 10, both $Z$ and $X$ corrections are required.
 - For 11, only the $Z$ correction is requried.
 
 @[solution]({


### PR DESCRIPTION
1. The teleportation corrections to be applied were described wrongly in the `solution.md` files - they did not match `Solution.qs` files (which were correct all along). 01 and 10 were swapped.

For example: 

```
namespace Kata {
    operation ReconstructMessage_PsiPlus(qBob : Qubit, (b1 : Bool, b2 : Bool)) : Unit {
        if b1 {
            Z(qBob);
        }
        if not b2 {
            X(qBob);
        }
    }
}
```

was described (wrongly) as:

```
- For 00, only the $X$ correction is required.
- For 01, both $Z$ and $X$ corrections are required.
- For 10, no change is required.
- For 11, only the $Z$ correction is requried.\
```

notice how 01 and 10 are swapped.


2. There was a typo in `index.md` - the superposition states were written with `\frac{1}{2}` instead of `\frac{1}{\sqrt{2}}`