### PR TITLE
Delete duplicate notebook init code

### DIFF
--- a/source/vscode/src/notebook.ts
+++ b/source/vscode/src/notebook.ts
@@ -27,12 +27,6 @@ export function registerQSharpNotebookHandlers() {
     }
   });
 
-  vscode.workspace.notebookDocuments.forEach((notebookDocument) => {
-    if (notebookDocument.notebookType === jupyterNotebookType) {
-      updateQdkCellLanguages(notebookDocument.getCells());
-    }
-  });
-
   const subscriptions = [];
   subscriptions.push(
     vscode.workspace.onDidOpenNotebookDocument((notebookDocument) => {


### PR DESCRIPTION
We have some code for updating code cell languages in jupyter notebooks and we run it twice.  I think the extra work may be worsening the race between the save-on-open in openCourseNotebook and the changes caused by updateQdkCellLanguages.  Even if not, there's no reason to loop through the cells twice.