### PR TITLE
Open notebooks at the top when switching courses or resetting a unit

### DIFF
--- a/source/vscode/src/learning/commands.ts
+++ b/source/vscode/src/learning/commands.ts
@@ -75,7 +75,9 @@ export function registerLearningCommands(
         }
 
         await service.resetExercise();
-        await openCourseNotebook(service);
+        // The whole unit was reset, so the learner's old position no longer
+        // means anything — start them at the top of the fresh notebook.
+        await openCourseNotebook(service, { reveal: "top" });
         vscode.window.showInformationMessage("Unit has been reset.");
       },
     ),
@@ -156,9 +158,11 @@ export function registerLearningCommands(
         await service.switchCourse(courseId, "tree");
 
         // python-notebook courses don't use the lesson panel — open the
-        // notebook directly and pick up where the learner left off.
+        // notebook directly. Switching lands on a unit rather than a specific
+        // activity, so start at the top of the notebook: the first activity is
+        // a code cell, which would otherwise skip the unit's introduction.
         if (isNotebookCourse(service.getActiveCourseInfo())) {
-          await openCourseNotebook(service);
+          await openCourseNotebook(service, { reveal: "top" });
           return;
         }
 


### PR DESCRIPTION
Switching to a notebook course or resetting a unit scrolled to the first activity. Only code cells are activities, so that's the check_env() cell below the title and intro.

Both now open at the top. As mentioned by @amcasey for the switch-course case.