### PR TITLE
Use `PackageSpan` in Capability Errors to fix panic

### DIFF
--- a/source/compiler/qsc/src/codegen.rs
+++ b/source/compiler/qsc/src/codegen.rs
@@ -2317,10 +2317,7 @@ pub mod qir {
         } = prepared_fir;
 
         fir_to_qir(&fir_store, capabilities, &compute_properties, &entry).map_err(|e| {
-            let source_package_id = match e.span() {
-                Some(span) => span.package,
-                None => package_id,
-            };
+            let source_package_id = e.span().package;
             let source_package = store
                 .get(source_package_id)
                 .expect("package should be in store");
@@ -2338,7 +2335,7 @@ pub mod qir {
         mut package_store: PackageStore,
         dependencies: &Dependencies,
     ) -> Result<Vec<String>, Vec<Error>> {
-        let (package_id, prepared_fir) = compile_to_codegen_fir(
+        let (_, prepared_fir) = compile_to_codegen_fir(
             sources,
             language_features,
             capabilities,
@@ -2362,10 +2359,7 @@ pub mod qir {
             },
         )
         .map_err(|e| {
-            let source_package_id = match e.span() {
-                Some(span) => span.package,
-                None => package_id,
-            };
+            let source_package_id = e.span().package;
             let source_package = package_store
                 .get(source_package_id)
                 .expect("package should be in store");
@@ -2384,7 +2378,7 @@ pub mod qir {
         mut package_store: PackageStore,
         dependencies: &Dependencies,
     ) -> Result<String, Vec<Error>> {
-        let (package_id, prepared_fir) = compile_to_codegen_fir(
+        let (_, prepared_fir) = compile_to_codegen_fir(
             sources,
             language_features,
             capabilities,
@@ -2399,10 +2393,7 @@ pub mod qir {
         } = prepared_fir;
 
         fir_to_qir(&fir_store, capabilities, &compute_properties, &entry).map_err(|e| {
-            let source_package_id = match e.span() {
-                Some(span) => span.package,
-                None => package_id,
-            };
+            let source_package_id = e.span().package;
             let source_package = package_store
                 .get(source_package_id)
                 .expect("package should be in store");

--- a/source/compiler/qsc/src/interpret.rs
+++ b/source/compiler/qsc/src/interpret.rs
@@ -1165,15 +1165,8 @@ impl Interpreter {
         }
     }
 
-    fn partial_evaluation_error(
-        &self,
-        error: qsc_partial_eval::Error,
-        fallback_package: qsc_hir::hir::PackageId,
-    ) -> Vec<Error> {
-        let hir_package_id = match error.span() {
-            Some(span) => span.package,
-            None => fallback_package,
-        };
+    fn partial_evaluation_error(&self, error: qsc_partial_eval::Error) -> Vec<Error> {
+        let hir_package_id = error.span().package;
         let source_package = self
             .compiler
             .package_store()
@@ -1196,13 +1189,12 @@ impl Interpreter {
         let entry = entry_from_codegen_fir(&prepared_fir);
         let CodegenFir {
             fir_store,
-            fir_package_id,
             compute_properties,
             ..
         } = prepared_fir;
 
         fir_to_qir(&fir_store, self.capabilities, &compute_properties, &entry)
-            .map_err(|e| self.partial_evaluation_error(e, map_fir_package_to_hir(fir_package_id)))
+            .map_err(|e| self.partial_evaluation_error(e))
     }
 
     /// Performs RIR codegen using the given entry expression on a new instance of the environment
@@ -1243,10 +1235,7 @@ impl Interpreter {
             },
         )
         .map_err(|e| {
-            let hir_package_id = match e.span() {
-                Some(span) => span.package,
-                None => map_fir_package_to_hir(self.package),
-            };
+            let hir_package_id = e.span().package;
             let source_package = self
                 .compiler
                 .package_store()
@@ -1285,14 +1274,12 @@ impl Interpreter {
                 let entry = entry_from_codegen_fir(&prepared_fir);
                 let CodegenFir {
                     fir_store,
-                    fir_package_id,
                     compute_properties,
                     ..
                 } = prepared_fir;
 
-                fir_to_qir(&fir_store, self.capabilities, &compute_properties, &entry).map_err(
-                    |e| self.partial_evaluation_error(e, map_fir_package_to_hir(fir_package_id)),
-                )
+                fir_to_qir(&fir_store, self.capabilities, &compute_properties, &entry)
+                    .map_err(|e| self.partial_evaluation_error(e))
             }
             CallableArgsBackend::ReinvokeOriginal { callable, args } => {
                 let CodegenFir {
@@ -1308,7 +1295,7 @@ impl Interpreter {
                     callable,
                     args,
                 )
-                .map_err(|e| self.partial_evaluation_error(e, callable_id.package))
+                .map_err(|e| self.partial_evaluation_error(e))
             }
         }
     }
@@ -1462,7 +1449,7 @@ impl Interpreter {
                         generate_debug_metadata: true,
                     },
                 )
-                .map_err(|e| self.partial_evaluation_error(e, callable_id.package))?;
+                .map_err(|e| self.partial_evaluation_error(e))?;
 
                 rir_to_circuit(
                     &transformed,
@@ -1489,7 +1476,7 @@ impl Interpreter {
                         generate_debug_metadata: true,
                     },
                 )
-                .map_err(|e| self.partial_evaluation_error(e, callable_id.package))?;
+                .map_err(|e| self.partial_evaluation_error(e))?;
 
                 rir_to_circuit(
                     &transformed,
@@ -1507,7 +1494,7 @@ impl Interpreter {
         entry_expr: Option<&str>,
     ) -> std::result::Result<(qsc_partial_eval::Program, qsc_fir::fir::PackageStore), Vec<Error>>
     {
-        let (prepared_fir, fallback_package) =
+        let (prepared_fir, _) =
             if let Some(entry_expr) = entry_expr.or(self.entry_point_call_expr().as_deref()) {
                 (
                     self.prepare_codegen_entry_expr(entry_expr)?,
@@ -1535,7 +1522,7 @@ impl Interpreter {
                 generate_debug_metadata: true,
             },
         )
-        .map_err(|e| self.partial_evaluation_error(e, fallback_package))?;
+        .map_err(|e| self.partial_evaluation_error(e))?;
         Ok((transformed, fir_store))
     }
 

--- a/source/compiler/qsc_fir_transforms/src/return_unify/normalize/anf/tests/capabilities.rs
+++ b/source/compiler/qsc_fir_transforms/src/return_unify/normalize/anf/tests/capabilities.rs
@@ -67,7 +67,7 @@ fn base_profile_check_still_fires_on_a_pinned_program() {
     // Sensitivity control for the post-transform check.
     assert_eq!(
         base_profile_capability_errors(EFFECTFUL_ARROW_OPERAND_PIN_WITH_BOOL_OUTPUT),
-        vec!["CapabilitiesCk(UseOfBoolOutput(Span { lo: 182, hi: 186 }))".to_string()],
+        vec!["CapabilitiesCk(UseOfBoolOutput(PackageSpan { package: PackageId(2), span: Span { lo: 182, hi: 186 } }))".to_string()],
         "the post-transform capability check should still reject a bool output"
     );
 }

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -41,7 +41,7 @@ use qsc_fir::{
 };
 
 pub use qsc_data_structures::intrinsic_names::is_codegen_noop_intrinsic;
-use qsc_lowerer::map_fir_package_to_hir;
+use qsc_lowerer::{map_fir_package_to_hir, map_hir_package_to_fir};
 use qsc_rca::{
     ComputeKind, ComputePropertiesLookup, ItemComputeProperties, PackageStoreComputeProperties,
     RuntimeFeatureFlags, ValueKind,
@@ -163,9 +163,12 @@ impl From<EvalError> for Error {
 
 impl Error {
     #[must_use]
-    pub fn span(&self) -> Option<PackageSpan> {
+    pub fn span(&self) -> PackageSpan {
         match self {
-            Self::CapabilityError(_) => None,
+            Self::CapabilityError(e) => {
+                let fir_span = e.span();
+                PackageSpan::new(map_fir_package_to_hir(fir_span.package), fir_span.span)
+            }
             Self::UnexpectedDynamicValue(span)
             | Self::UnsupportedCustomIntrinsicType(_, span)
             | Self::EvaluationFailed(_, span)
@@ -173,7 +176,7 @@ impl Error {
             | Self::Unexpected(_, span)
             | Self::Unimplemented(_, span)
             | Self::UnsupportedTestCallable(span)
-            | Self::UnsupportedSimulationIntrinsic(_, span) => Some(*span),
+            | Self::UnsupportedSimulationIntrinsic(_, span) => *span,
         }
     }
 }
@@ -1767,7 +1770,10 @@ impl<'a> PartialEvaluator<'a> {
                 if !missing_features.is_empty()
                     && let Some(error) = generate_errors_from_runtime_features(
                         missing_features,
-                        self.get_expr(call_expr_id).span,
+                        fir::PackageSpan::new(
+                            self.get_current_package_id(),
+                            self.get_expr(call_expr_id).span,
+                        ),
                     )
                     .drain(..)
                     .next()
@@ -1922,7 +1928,10 @@ impl<'a> PartialEvaluator<'a> {
                     // If we are in a dynamic branch anywhere up the call stack, we cannot support relabel,
                     // as later qubit usage would need to be dynamic on whether the branch was taken.
                     return Err(Error::CapabilityError(CapabilityError::UseOfDynamicQubit(
-                        callee_expr_span.span,
+                        fir::PackageSpan::new(
+                            map_hir_package_to_fir(callee_expr_span.package),
+                            callee_expr_span.span,
+                        ),
                     )));
                 }
                 qubit_relabel(args_value, callee_expr_span, args_span, |q0, q1| {

--- a/source/compiler/qsc_partial_eval/src/tests/calls.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/calls.rs
@@ -1261,7 +1261,9 @@ fn call_to_unresolved_callee_with_dynamic_arg_fails() {
 
     assert_error(
         &error,
-        &expect!["CapabilityError(UseOfDynamicDouble(Span { lo: 288, hi: 295 }))"],
+        &expect![
+            "CapabilityError(UseOfDynamicDouble(PackageSpan { package: PackageId(2), span: Span { lo: 288, hi: 295 } }))"
+        ],
     );
 }
 
@@ -1316,7 +1318,9 @@ fn call_to_unresolved_callee_via_closure_with_dynamic_arg_fails() {
 
     assert_error(
         &error,
-        &expect!["CapabilityError(UseOfDynamicDouble(Span { lo: 292, hi: 299 }))"],
+        &expect![
+            "CapabilityError(UseOfDynamicDouble(PackageSpan { package: PackageId(2), span: Span { lo: 292, hi: 299 } }))"
+        ],
     );
 }
 
@@ -1410,7 +1414,9 @@ fn call_to_recursive_callable_with_unsupported_capabilities_fails() {
 
     assert_error(
         &error,
-        &expect!["CapabilityError(UseOfDynamicQubit(Span { lo: 260, hi: 325 }))"],
+        &expect![
+            "CapabilityError(UseOfDynamicQubit(PackageSpan { package: PackageId(2), span: Span { lo: 260, hi: 325 } }))"
+        ],
     );
 }
 

--- a/source/compiler/qsc_partial_eval/src/tests/qubits.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/qubits.rs
@@ -507,7 +507,9 @@ fn qubit_relabel_in_dynamic_block_triggers_capability_error() {
 
     assert_error(
         &error,
-        &expect!["CapabilityError(UseOfDynamicQubit(Span { lo: 67160, hi: 67173 }))"],
+        &expect![
+            "CapabilityError(UseOfDynamicQubit(PackageSpan { package: PackageId(1), span: Span { lo: 67160, hi: 67173 } }))"
+        ],
     );
 }
 

--- a/source/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck.rs
@@ -21,8 +21,8 @@ use qsc_data_structures::{span::Span, target::TargetCapabilityFlags};
 use qsc_fir::{
     fir::{
         Attr, Block, BlockId, CallableDecl, CallableImpl, Expr, ExprId, ExprKind, Global, Ident,
-        Item, ItemKind, LocalItemId, LocalVarId, Package, PackageLookup, Pat, PatId, PatKind, Res,
-        SpecDecl, SpecImpl, Stmt, StmtId, StmtKind,
+        Item, ItemKind, LocalItemId, LocalVarId, Package, PackageId, PackageLookup, PackageSpan,
+        Pat, PatId, PatKind, Res, SpecDecl, SpecImpl, Stmt, StmtId, StmtKind,
     },
     ty::{Prim, Ty},
     visit::{Visitor, walk_callable_decl},
@@ -56,7 +56,7 @@ pub fn lower_store(
 
 pub fn run_rca_pass(
     fir_store: &qsc_fir::fir::PackageStore,
-    package_id: qsc_fir::fir::PackageId,
+    package_id: PackageId,
     capabilities: TargetCapabilityFlags,
 ) -> Result<PackageStoreComputeProperties, Vec<crate::Error>> {
     let analyzer = Analyzer::init(fir_store, capabilities);
@@ -66,6 +66,7 @@ pub fn run_rca_pass(
     let package_compute_properties = compute_properties.get(package_id, false);
     let mut errors = check_supported_capabilities(
         fir_package,
+        package_id,
         package_compute_properties,
         capabilities,
         fir_store,
@@ -85,16 +86,18 @@ pub fn run_rca_pass(
 #[must_use]
 pub fn check_supported_capabilities(
     package: &Package,
+    package_id: PackageId,
     compute_properties: &PackageComputeProperties,
     capabilities: TargetCapabilityFlags,
     store: &qsc_fir::fir::PackageStore,
 ) -> Vec<Error> {
     let checker = Checker {
         package,
+        package_id,
         compute_properties,
         target_capabilities: capabilities,
         current_callable: None,
-        missing_features_map: FxHashMap::<Span, RuntimeFeatureFlags>::default(),
+        missing_features_map: FxHashMap::<PackageSpan, RuntimeFeatureFlags>::default(),
         store,
     };
 
@@ -109,6 +112,7 @@ pub fn check_supported_capabilities(
 #[must_use]
 pub fn check_supported_capabilities_for_callable(
     package: &Package,
+    package_id: PackageId,
     compute_properties: &PackageComputeProperties,
     callable: LocalItemId,
     capabilities: TargetCapabilityFlags,
@@ -116,10 +120,11 @@ pub fn check_supported_capabilities_for_callable(
 ) -> Vec<Error> {
     let checker = Checker {
         package,
+        package_id,
         compute_properties,
         target_capabilities: capabilities,
         current_callable: None,
-        missing_features_map: FxHashMap::<Span, RuntimeFeatureFlags>::default(),
+        missing_features_map: FxHashMap::<PackageSpan, RuntimeFeatureFlags>::default(),
         store,
     };
 
@@ -128,10 +133,11 @@ pub fn check_supported_capabilities_for_callable(
 
 struct Checker<'a> {
     package: &'a Package,
+    package_id: PackageId,
     compute_properties: &'a PackageComputeProperties,
     target_capabilities: TargetCapabilityFlags,
     current_callable: Option<LocalItemId>,
-    missing_features_map: FxHashMap<Span, RuntimeFeatureFlags>,
+    missing_features_map: FxHashMap<PackageSpan, RuntimeFeatureFlags>,
     store: &'a qsc_fir::fir::PackageStore,
 }
 
@@ -297,7 +303,7 @@ impl<'a> Checker<'a> {
         let expr = self.get_expr(expr_id);
         if !missing_features.is_empty() {
             self.missing_features_map
-                .entry(expr.span)
+                .entry(PackageSpan::new(self.package_id, expr.span))
                 .and_modify(|f| *f |= missing_features)
                 .or_insert(missing_features);
         }
@@ -377,7 +383,7 @@ impl<'a> Checker<'a> {
                 & RuntimeFeatureFlags::output_recording_flags();
         if !missing_features.is_empty() {
             self.missing_features_map
-                .entry(output_reporting_span)
+                .entry(PackageSpan::new(self.package_id, output_reporting_span))
                 .and_modify(|f| *f |= missing_features)
                 .or_insert(missing_features);
         }
@@ -390,7 +396,7 @@ impl<'a> Checker<'a> {
         ) & RuntimeFeatureFlags::output_recording_flags();
         if !missing_features.is_empty() {
             self.missing_features_map
-                .entry(callable_decl.name.span)
+                .entry(PackageSpan::new(self.package_id, callable_decl.name.span))
                 .and_modify(|f| *f |= missing_features)
                 .or_insert(missing_features);
         }

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -61,9 +61,14 @@ fn use_of_dynamic_int_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 226,
-                        hi: 251,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 251,
+                        },
                     },
                 ),
             ]
@@ -78,9 +83,14 @@ fn use_of_dynamic_pauli_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicPauli(
-                    Span {
-                        lo: 104,
-                        hi: 134,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 134,
+                        },
                     },
                 ),
             ]
@@ -95,15 +105,25 @@ fn use_of_dynamic_range_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 108,
-                        hi: 137,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 108,
+                            hi: 137,
+                        },
                     },
                 ),
                 UseOfDynamicRange(
-                    Span {
-                        lo: 108,
-                        hi: 137,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 108,
+                            hi: 137,
+                        },
                     },
                 ),
             ]
@@ -118,15 +138,25 @@ fn use_of_dynamic_double_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 226,
-                        hi: 264,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 264,
+                        },
                     },
                 ),
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 226,
-                        hi: 264,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 264,
+                        },
                     },
                 ),
             ]
@@ -141,9 +171,14 @@ fn use_of_dynamic_qubit_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicQubit(
-                    Span {
-                        lo: 142,
-                        hi: 158,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 142,
+                            hi: 158,
+                        },
                     },
                 ),
             ]
@@ -158,15 +193,25 @@ fn use_of_dynamic_big_int_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 227,
-                        hi: 265,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 227,
+                            hi: 265,
+                        },
                     },
                 ),
                 UseOfDynamicBigInt(
-                    Span {
-                        lo: 227,
-                        hi: 265,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 227,
+                            hi: 265,
+                        },
                     },
                 ),
             ]
@@ -191,15 +236,25 @@ fn use_of_dynamically_sized_array_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 104,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 136,
+                        },
                     },
                 ),
                 UseOfDynamicallySizedArray(
-                    Span {
-                        lo: 104,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 136,
+                        },
                     },
                 ),
             ]
@@ -214,21 +269,36 @@ fn use_of_dynamic_udt_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
                 UseOfDynamicUdt(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
             ]
@@ -243,9 +313,14 @@ fn use_of_dynamic_function_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 132,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 156,
+                        },
                     },
                 ),
             ]
@@ -260,9 +335,14 @@ fn use_of_dynamic_operation_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 132,
-                        hi: 152,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 152,
+                        },
                     },
                 ),
             ]
@@ -287,9 +367,14 @@ fn call_cyclic_function_with_dynamic_argument_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 211,
-                        hi: 243,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 211,
+                            hi: 243,
+                        },
                     },
                 ),
             ]
@@ -314,9 +399,14 @@ fn call_cyclic_operation_with_dynamic_argument_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 212,
-                        hi: 244,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 212,
+                            hi: 244,
+                        },
                     },
                 ),
             ]
@@ -331,27 +421,47 @@ fn call_to_dynamic_function_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 132,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 156,
+                        },
                     },
                 ),
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
                 CallToDynamicCallee(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
             ]
@@ -366,21 +476,36 @@ fn call_to_dynamic_operation_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 132,
-                        hi: 152,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 152,
+                        },
                     },
                 ),
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
                 CallToDynamicCallee(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
             ]
@@ -455,21 +580,36 @@ fn use_of_dynamic_index_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 226,
-                        hi: 251,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 251,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 299,
-                        hi: 303,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 299,
+                            hi: 303,
+                        },
                     },
                 ),
                 UseOfDynamicIndex(
-                    Span {
-                        lo: 299,
-                        hi: 303,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 299,
+                            hi: 303,
+                        },
                     },
                 ),
             ]
@@ -484,15 +624,25 @@ fn use_of_dynamic_lhs_exp_binop_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 104,
-                        hi: 124,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 124,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 138,
-                        hi: 143,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
                     },
                 ),
             ]
@@ -507,21 +657,36 @@ fn use_of_dynamic_rhs_exp_binop_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 104,
-                        hi: 124,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 124,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 138,
-                        hi: 143,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
                     },
                 ),
                 UseOfDynamicExponent(
-                    Span {
-                        lo: 138,
-                        hi: 143,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
                     },
                 ),
             ]
@@ -536,15 +701,25 @@ fn return_within_dynamic_scope_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicQubitRelease(
-                    Span {
-                        lo: 66,
-                        hi: 82,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 66,
+                            hi: 82,
+                        },
                     },
                 ),
                 ReturnWithinDynamicScope(
-                    Span {
-                        lo: 128,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 128,
+                            hi: 136,
+                        },
                     },
                 ),
             ]
@@ -559,39 +734,69 @@ fn loop_with_dynamic_condition_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 106,
-                        hi: 127,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 106,
+                            hi: 127,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 UseOfDynamicRange(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 LoopWithDynamicCondition(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 150,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 150,
+                            hi: 156,
+                        },
                     },
                 ),
                 UseOfDynamicRange(
-                    Span {
-                        lo: 150,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 150,
+                            hi: 156,
+                        },
                     },
                 ),
             ]
@@ -609,9 +814,14 @@ fn dynamic_break_in_loop_yields_loop_with_dynamic_condition() {
         &expect![[r#"
             [
                 LoopWithDynamicCondition(
-                    Span {
-                        lo: 96,
-                        hi: 200,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 96,
+                            hi: 200,
+                        },
                     },
                 ),
             ]
@@ -627,9 +837,14 @@ fn hand_written_dynamic_stop_loop_yields_loop_with_dynamic_condition() {
         &expect![[r#"
             [
                 LoopWithDynamicCondition(
-                    Span {
-                        lo: 130,
-                        hi: 244,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 130,
+                            hi: 244,
+                        },
                     },
                 ),
             ]
@@ -684,15 +899,20 @@ fn use_of_static_int_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_INT,
         &expect![[r#"
-        [
-            UseOfIntOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfIntOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -701,15 +921,20 @@ fn use_of_static_double_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_DOUBLE,
         &expect![[r#"
-        [
-            UseOfDoubleOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfDoubleOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -718,15 +943,20 @@ fn use_of_static_string_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_STRING,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -745,15 +975,20 @@ fn use_of_static_big_int_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_BIG_INT,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -762,15 +997,20 @@ fn use_of_static_pauli_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_PAULI,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -779,15 +1019,20 @@ fn use_of_static_range_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_RANGE,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -798,9 +1043,14 @@ fn use_of_static_int_in_tuple_return_from_entry_point_errors() {
         &expect![[r#"
             [
                 UseOfIntOutput(
-                    Span {
-                        lo: 63,
-                        hi: 66,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
                     },
                 ),
             ]
@@ -815,9 +1065,14 @@ fn use_of_static_sized_array_in_tuple_error() {
         &expect![[r#"
             [
                 UseOfIntOutput(
-                    Span {
-                        lo: 63,
-                        hi: 66,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
                     },
                 ),
             ]
@@ -862,9 +1117,14 @@ fn parallel_with_dynamic_branch_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBranchingInParallelExpr(
-                    Span {
-                        lo: 196,
-                        hi: 210,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 196,
+                            hi: 210,
+                        },
                     },
                 ),
             ]
@@ -879,21 +1139,36 @@ fn parallel_within_with_dynamic_limit_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicInt(
-                    Span {
-                        lo: 107,
-                        hi: 130,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 107,
+                            hi: 130,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 160,
-                        hi: 161,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 160,
+                            hi: 161,
+                        },
                     },
                 ),
                 UseOfDynamicLimitInParallelExpr(
-                    Span {
-                        lo: 160,
-                        hi: 161,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 160,
+                            hi: 161,
+                        },
                     },
                 ),
             ]
@@ -908,9 +1183,14 @@ fn parallel_with_indirect_branch_via_call_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBranchingInParallelExpr(
-                    Span {
-                        lo: 217,
-                        hi: 223,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 217,
+                            hi: 223,
+                        },
                     },
                 ),
             ]

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -76,9 +76,14 @@ fn use_of_dynamic_pauli_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicPauli(
-                    Span {
-                        lo: 104,
-                        hi: 134,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 134,
+                        },
                     },
                 ),
             ]
@@ -93,9 +98,14 @@ fn use_of_dynamic_range_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicRange(
-                    Span {
-                        lo: 108,
-                        hi: 137,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 108,
+                            hi: 137,
+                        },
                     },
                 ),
             ]
@@ -110,9 +120,14 @@ fn use_of_dynamic_double_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 226,
-                        hi: 264,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 264,
+                        },
                     },
                 ),
             ]
@@ -127,9 +142,14 @@ fn use_of_dynamic_qubit_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicQubit(
-                    Span {
-                        lo: 142,
-                        hi: 158,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 142,
+                            hi: 158,
+                        },
                     },
                 ),
             ]
@@ -144,9 +164,14 @@ fn use_of_dynamic_big_int_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBigInt(
-                    Span {
-                        lo: 227,
-                        hi: 265,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 227,
+                            hi: 265,
+                        },
                     },
                 ),
             ]
@@ -171,9 +196,14 @@ fn use_of_dynamically_sized_array_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicallySizedArray(
-                    Span {
-                        lo: 104,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 136,
+                        },
                     },
                 ),
             ]
@@ -188,15 +218,25 @@ fn use_of_dynamic_udt_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
                 UseOfDynamicUdt(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
             ]
@@ -211,9 +251,14 @@ fn use_of_dynamic_function_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 132,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 156,
+                        },
                     },
                 ),
             ]
@@ -228,9 +273,14 @@ fn use_of_dynamic_operation_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 132,
-                        hi: 152,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 152,
+                        },
                     },
                 ),
             ]
@@ -285,27 +335,47 @@ fn call_to_dynamic_function_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 132,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 156,
+                        },
                     },
                 ),
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
                 CallToDynamicCallee(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
             ]
@@ -320,21 +390,36 @@ fn call_to_dynamic_operation_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 132,
-                        hi: 152,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 152,
+                        },
                     },
                 ),
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
                 CallToDynamicCallee(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
             ]
@@ -379,9 +464,14 @@ fn use_of_dynamic_index_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicIndex(
-                    Span {
-                        lo: 299,
-                        hi: 303,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 299,
+                            hi: 303,
+                        },
                     },
                 ),
             ]
@@ -406,9 +496,14 @@ fn use_of_dynamic_rhs_exp_binop_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicExponent(
-                    Span {
-                        lo: 138,
-                        hi: 143,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
                     },
                 ),
             ]
@@ -423,15 +518,25 @@ fn return_within_dynamic_scope_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicQubitRelease(
-                    Span {
-                        lo: 66,
-                        hi: 82,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 66,
+                            hi: 82,
+                        },
                     },
                 ),
                 ReturnWithinDynamicScope(
-                    Span {
-                        lo: 128,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 128,
+                            hi: 136,
+                        },
                     },
                 ),
             ]
@@ -446,21 +551,36 @@ fn loop_with_dynamic_condition_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicRange(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 LoopWithDynamicCondition(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 UseOfDynamicRange(
-                    Span {
-                        lo: 150,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 150,
+                            hi: 156,
+                        },
                     },
                 ),
             ]
@@ -493,15 +613,20 @@ fn use_of_static_double_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_DOUBLE,
         &expect![[r#"
-        [
-            UseOfDoubleOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfDoubleOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -510,15 +635,20 @@ fn use_of_static_string_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_STRING,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -537,15 +667,20 @@ fn use_of_static_big_int_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_BIG_INT,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -554,15 +689,20 @@ fn use_of_static_pauli_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_PAULI,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -571,15 +711,20 @@ fn use_of_static_range_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_RANGE,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -630,9 +775,14 @@ fn parallel_with_dynamic_branch_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBranchingInParallelExpr(
-                    Span {
-                        lo: 196,
-                        hi: 210,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 196,
+                            hi: 210,
+                        },
                     },
                 ),
             ]
@@ -647,9 +797,14 @@ fn parallel_within_with_dynamic_limit_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicLimitInParallelExpr(
-                    Span {
-                        lo: 160,
-                        hi: 161,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 160,
+                            hi: 161,
+                        },
                     },
                 ),
             ]
@@ -664,9 +819,14 @@ fn parallel_with_indirect_branch_via_call_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBranchingInParallelExpr(
-                    Span {
-                        lo: 217,
-                        hi: 223,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 217,
+                            hi: 223,
+                        },
                     },
                 ),
             ]

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers_and_floats.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers_and_floats.rs
@@ -80,9 +80,14 @@ fn use_of_dynamic_pauli_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicPauli(
-                    Span {
-                        lo: 104,
-                        hi: 134,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 134,
+                        },
                     },
                 ),
             ]
@@ -97,9 +102,14 @@ fn use_of_dynamic_range_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicRange(
-                    Span {
-                        lo: 108,
-                        hi: 137,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 108,
+                            hi: 137,
+                        },
                     },
                 ),
             ]
@@ -124,9 +134,14 @@ fn use_of_dynamic_qubit_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicQubit(
-                    Span {
-                        lo: 142,
-                        hi: 158,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 142,
+                            hi: 158,
+                        },
                     },
                 ),
             ]
@@ -141,9 +156,14 @@ fn use_of_dynamic_big_int_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBigInt(
-                    Span {
-                        lo: 227,
-                        hi: 265,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 227,
+                            hi: 265,
+                        },
                     },
                 ),
             ]
@@ -168,9 +188,14 @@ fn use_of_dynamically_sized_array_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicallySizedArray(
-                    Span {
-                        lo: 104,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 136,
+                        },
                     },
                 ),
             ]
@@ -185,9 +210,14 @@ fn use_of_dynamic_udt_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicUdt(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
             ]
@@ -202,9 +232,14 @@ fn use_of_dynamic_function_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 132,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 156,
+                        },
                     },
                 ),
             ]
@@ -219,9 +254,14 @@ fn use_of_dynamic_operation_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 132,
-                        hi: 152,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 152,
+                        },
                     },
                 ),
             ]
@@ -276,21 +316,36 @@ fn call_to_dynamic_function_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 132,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 156,
+                        },
                     },
                 ),
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
                 CallToDynamicCallee(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
             ]
@@ -305,21 +360,36 @@ fn call_to_dynamic_operation_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 132,
-                        hi: 152,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 152,
+                        },
                     },
                 ),
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
                 CallToDynamicCallee(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
             ]
@@ -364,9 +434,14 @@ fn use_of_dynamic_index_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicIndex(
-                    Span {
-                        lo: 299,
-                        hi: 303,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 299,
+                            hi: 303,
+                        },
                     },
                 ),
             ]
@@ -391,9 +466,14 @@ fn use_of_dynamic_rhs_exp_binop_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicExponent(
-                    Span {
-                        lo: 138,
-                        hi: 143,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
                     },
                 ),
             ]
@@ -408,15 +488,25 @@ fn return_within_dynamic_scope_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicQubitRelease(
-                    Span {
-                        lo: 66,
-                        hi: 82,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 66,
+                            hi: 82,
+                        },
                     },
                 ),
                 ReturnWithinDynamicScope(
-                    Span {
-                        lo: 128,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 128,
+                            hi: 136,
+                        },
                     },
                 ),
             ]
@@ -431,21 +521,36 @@ fn loop_with_dynamic_condition_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicRange(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 LoopWithDynamicCondition(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 UseOfDynamicRange(
-                    Span {
-                        lo: 150,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 150,
+                            hi: 156,
+                        },
                     },
                 ),
             ]
@@ -488,15 +593,20 @@ fn use_of_static_string_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_STRING,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -515,15 +625,20 @@ fn use_of_static_big_int_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_BIG_INT,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -532,15 +647,20 @@ fn use_of_static_pauli_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_PAULI,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -549,15 +669,20 @@ fn use_of_static_range_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_RANGE,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -608,9 +733,14 @@ fn parallel_with_dynamic_branch_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBranchingInParallelExpr(
-                    Span {
-                        lo: 196,
-                        hi: 210,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 196,
+                            hi: 210,
+                        },
                     },
                 ),
             ]
@@ -625,9 +755,14 @@ fn parallel_within_with_dynamic_limit_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicLimitInParallelExpr(
-                    Span {
-                        lo: 160,
-                        hi: 161,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 160,
+                            hi: 161,
+                        },
                     },
                 ),
             ]
@@ -642,9 +777,14 @@ fn parallel_with_indirect_branch_via_call_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBranchingInParallelExpr(
-                    Span {
-                        lo: 217,
-                        hi: 223,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 217,
+                            hi: 223,
+                        },
                     },
                 ),
             ]

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -49,9 +49,14 @@ fn use_of_dynamic_boolean_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 104,
-                        hi: 116,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 116,
+                        },
                     },
                 ),
             ]
@@ -66,15 +71,25 @@ fn use_of_dynamic_int_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 226,
-                        hi: 251,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 251,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 226,
-                        hi: 251,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 251,
+                        },
                     },
                 ),
             ]
@@ -92,9 +107,14 @@ fn use_of_dynamic_pauli_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 104,
-                        hi: 116,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 116,
+                        },
                     },
                 ),
             ]
@@ -109,21 +129,36 @@ fn use_of_dynamic_range_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 108,
-                        hi: 137,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 108,
+                            hi: 137,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 108,
-                        hi: 137,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 108,
+                            hi: 137,
+                        },
                     },
                 ),
                 UseOfDynamicRange(
-                    Span {
-                        lo: 108,
-                        hi: 137,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 108,
+                            hi: 137,
+                        },
                     },
                 ),
             ]
@@ -138,21 +173,36 @@ fn use_of_dynamic_double_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 226,
-                        hi: 264,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 264,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 226,
-                        hi: 264,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 264,
+                        },
                     },
                 ),
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 226,
-                        hi: 264,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 264,
+                        },
                     },
                 ),
             ]
@@ -167,15 +217,25 @@ fn use_of_dynamic_qubit_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 105,
-                        hi: 123,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 105,
+                            hi: 123,
+                        },
                     },
                 ),
                 UseOfDynamicQubit(
-                    Span {
-                        lo: 142,
-                        hi: 158,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 142,
+                            hi: 158,
+                        },
                     },
                 ),
             ]
@@ -190,21 +250,36 @@ fn use_of_dynamic_big_int_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 227,
-                        hi: 265,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 227,
+                            hi: 265,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 227,
-                        hi: 265,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 227,
+                            hi: 265,
+                        },
                     },
                 ),
                 UseOfDynamicBigInt(
-                    Span {
-                        lo: 227,
-                        hi: 265,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 227,
+                            hi: 265,
+                        },
                     },
                 ),
             ]
@@ -219,9 +294,14 @@ fn use_of_dynamic_string_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 130,
-                        hi: 144,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 130,
+                            hi: 144,
+                        },
                     },
                 ),
             ]
@@ -236,21 +316,36 @@ fn use_of_dynamically_sized_array_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 104,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 136,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 104,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 136,
+                        },
                     },
                 ),
                 UseOfDynamicallySizedArray(
-                    Span {
-                        lo: 104,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 136,
+                        },
                     },
                 ),
             ]
@@ -265,27 +360,47 @@ fn use_of_dynamic_udt_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
                 UseOfDynamicUdt(
-                    Span {
-                        lo: 253,
-                        hi: 305,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 253,
+                            hi: 305,
+                        },
                     },
                 ),
             ]
@@ -303,9 +418,14 @@ fn use_of_dynamic_function_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 132,
-                        hi: 144,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 144,
+                        },
                     },
                 ),
             ]
@@ -323,9 +443,14 @@ fn use_of_dynamic_operation_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 132,
-                        hi: 144,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 144,
+                        },
                     },
                 ),
             ]
@@ -350,15 +475,25 @@ fn call_cyclic_function_with_dynamic_argument_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 211,
-                        hi: 243,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 211,
+                            hi: 243,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 211,
-                        hi: 243,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 211,
+                            hi: 243,
+                        },
                     },
                 ),
             ]
@@ -383,15 +518,25 @@ fn call_cyclic_operation_with_dynamic_argument_yields_no_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 212,
-                        hi: 244,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 212,
+                            hi: 244,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 212,
-                        hi: 244,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 212,
+                            hi: 244,
+                        },
                     },
                 ),
             ]
@@ -406,33 +551,58 @@ fn call_to_dynamic_function_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 132,
-                        hi: 144,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 144,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
                 UseOfDynamicDouble(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
                 UseOfDynamicArrowFunction(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
                 CallToDynamicCallee(
-                    Span {
-                        lo: 170,
-                        hi: 178,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 170,
+                            hi: 178,
+                        },
                     },
                 ),
             ]
@@ -447,27 +617,47 @@ fn call_to_dynamic_operation_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 132,
-                        hi: 144,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 132,
+                            hi: 144,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
                 UseOfDynamicArrowOperation(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
                 CallToDynamicCallee(
-                    Span {
-                        lo: 166,
-                        hi: 171,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 166,
+                            hi: 171,
+                        },
                     },
                 ),
             ]
@@ -492,15 +682,25 @@ fn measurement_within_dynamic_scope_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 99,
-                        hi: 110,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 99,
+                            hi: 110,
+                        },
                     },
                 ),
                 MeasurementWithinDynamicScope(
-                    Span {
-                        lo: 137,
-                        hi: 141,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 137,
+                            hi: 141,
+                        },
                     },
                 ),
             ]
@@ -515,9 +715,14 @@ fn custom_measurement_yields_errors() {
         &expect![[r#"
             [
                 CallToCustomMeasurement(
-                    Span {
-                        lo: 99,
-                        hi: 105,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 99,
+                            hi: 105,
+                        },
                     },
                 ),
             ]
@@ -532,9 +737,14 @@ fn custom_measurement_with_simulatable_intrinsic_yields_errors() {
         &expect![[r#"
             [
                 CallToCustomMeasurement(
-                    Span {
-                        lo: 99,
-                        hi: 105,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 99,
+                            hi: 105,
+                        },
                     },
                 ),
             ]
@@ -549,9 +759,14 @@ fn custom_reset_yields_errors() {
         &expect![[r#"
             [
                 CallToCustomReset(
-                    Span {
-                        lo: 145,
-                        hi: 151,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 145,
+                            hi: 151,
+                        },
                     },
                 ),
             ]
@@ -566,9 +781,14 @@ fn custom_reset_with_simulatable_intrinsic_yields_errors() {
         &expect![[r#"
             [
                 CallToCustomReset(
-                    Span {
-                        lo: 145,
-                        hi: 151,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 145,
+                            hi: 151,
+                        },
                     },
                 ),
             ]
@@ -583,33 +803,58 @@ fn use_of_dynamic_index_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 226,
-                        hi: 251,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 251,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 226,
-                        hi: 251,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 226,
+                            hi: 251,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 299,
-                        hi: 303,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 299,
+                            hi: 303,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 299,
-                        hi: 303,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 299,
+                            hi: 303,
+                        },
                     },
                 ),
                 UseOfDynamicIndex(
-                    Span {
-                        lo: 299,
-                        hi: 303,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 299,
+                            hi: 303,
+                        },
                     },
                 ),
             ]
@@ -622,27 +867,42 @@ fn use_of_dynamic_lhs_exp_binop_yields_errors() {
     check_profile(
         USE_DYNAMIC_LHS_EXP_BINOP,
         &expect![[r#"
-        [
-            UseOfDynamicBool(
-                Span {
-                    lo: 104,
-                    hi: 116,
-                },
-            ),
-            UseOfDynamicBool(
-                Span {
-                    lo: 138,
-                    hi: 143,
-                },
-            ),
-            UseOfDynamicInt(
-                Span {
-                    lo: 138,
-                    hi: 143,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfDynamicBool(
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 116,
+                        },
+                    },
+                ),
+                UseOfDynamicBool(
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
+                    },
+                ),
+                UseOfDynamicInt(
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -653,27 +913,47 @@ fn use_of_dynamic_rhs_exp_binop_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 104,
-                        hi: 116,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 104,
+                            hi: 116,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 138,
-                        hi: 143,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 138,
-                        hi: 143,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
                     },
                 ),
                 UseOfDynamicExponent(
-                    Span {
-                        lo: 138,
-                        hi: 143,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 138,
+                            hi: 143,
+                        },
                     },
                 ),
             ]
@@ -688,15 +968,25 @@ fn return_within_dynamic_scope_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 98,
-                        hi: 109,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 98,
+                            hi: 109,
+                        },
                     },
                 ),
                 ReturnWithinDynamicScope(
-                    Span {
-                        lo: 128,
-                        hi: 136,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 128,
+                            hi: 136,
+                        },
                     },
                 ),
             ]
@@ -711,51 +1001,91 @@ fn loop_with_dynamic_condition_yields_errors() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 106,
-                        hi: 118,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 106,
+                            hi: 118,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 UseOfDynamicRange(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 LoopWithDynamicCondition(
-                    Span {
-                        lo: 141,
-                        hi: 159,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 141,
+                            hi: 159,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 150,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 150,
+                            hi: 156,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 150,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 150,
+                            hi: 156,
+                        },
                     },
                 ),
                 UseOfDynamicRange(
-                    Span {
-                        lo: 150,
-                        hi: 156,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 150,
+                            hi: 156,
+                        },
                     },
                 ),
             ]
@@ -778,15 +1108,20 @@ fn use_of_static_int_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_INT,
         &expect![[r#"
-        [
-            UseOfIntOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfIntOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -795,15 +1130,20 @@ fn use_of_static_double_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_DOUBLE,
         &expect![[r#"
-        [
-            UseOfDoubleOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfDoubleOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -812,15 +1152,20 @@ fn use_of_static_string_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_STRING,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -829,15 +1174,20 @@ fn use_of_static_bool_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_BOOL,
         &expect![[r#"
-        [
-            UseOfBoolOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfBoolOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -846,15 +1196,20 @@ fn use_of_static_big_int_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_BIG_INT,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -863,15 +1218,20 @@ fn use_of_static_pauli_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_PAULI,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -880,15 +1240,20 @@ fn use_of_static_range_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_RANGE,
         &expect![[r#"
-        [
-            UseOfAdvancedOutput(
-                Span {
-                    lo: 63,
-                    hi: 66,
-                },
-            ),
-        ]
-    "#]],
+            [
+                UseOfAdvancedOutput(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
+                    },
+                ),
+            ]
+        "#]],
     );
 }
 
@@ -899,9 +1264,14 @@ fn use_of_static_int_in_tuple_return_from_entry_point_errors() {
         &expect![[r#"
             [
                 UseOfIntOutput(
-                    Span {
-                        lo: 63,
-                        hi: 66,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
                     },
                 ),
             ]
@@ -916,9 +1286,14 @@ fn use_of_static_sized_array_in_tuple_error() {
         &expect![[r#"
             [
                 UseOfIntOutput(
-                    Span {
-                        lo: 63,
-                        hi: 66,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 63,
+                            hi: 66,
+                        },
                     },
                 ),
             ]
@@ -933,9 +1308,14 @@ fn binary_op_with_dynamic_array_error() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 66,
-                        hi: 97,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 66,
+                            hi: 97,
+                        },
                     },
                 ),
             ]
@@ -1025,15 +1405,25 @@ fn parallel_with_dynamic_branch_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 107,
-                        hi: 122,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 107,
+                            hi: 122,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 199,
-                        hi: 200,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 199,
+                            hi: 200,
+                        },
                     },
                 ),
             ]
@@ -1048,27 +1438,47 @@ fn parallel_within_with_dynamic_limit_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 107,
-                        hi: 122,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 107,
+                            hi: 122,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 160,
-                        hi: 161,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 160,
+                            hi: 161,
+                        },
                     },
                 ),
                 UseOfDynamicInt(
-                    Span {
-                        lo: 160,
-                        hi: 161,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 160,
+                            hi: 161,
+                        },
                     },
                 ),
                 UseOfDynamicLimitInParallelExpr(
-                    Span {
-                        lo: 160,
-                        hi: 161,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 160,
+                            hi: 161,
+                        },
                     },
                 ),
             ]
@@ -1083,21 +1493,36 @@ fn parallel_with_indirect_branch_via_call_yields_error() {
         &expect![[r#"
             [
                 UseOfDynamicBool(
-                    Span {
-                        lo: 79,
-                        hi: 91,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 79,
+                            hi: 91,
+                        },
                     },
                 ),
                 UseOfDynamicBool(
-                    Span {
-                        lo: 217,
-                        hi: 223,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 217,
+                            hi: 223,
+                        },
                     },
                 ),
                 UseOfDynamicBranchingInParallelExpr(
-                    Span {
-                        lo: 217,
-                        hi: 223,
+                    PackageSpan {
+                        package: PackageId(
+                            3,
+                        ),
+                        span: Span {
+                            lo: 217,
+                            hi: 223,
+                        },
                     },
                 ),
             ]

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -18,6 +18,7 @@ pub fn check(source: &str, expect: &Expect, capabilities: TargetCapabilityFlags)
     let (package, compute_properties) = compilation_context.get_package_compute_properties_tuple();
     let errors = check_supported_capabilities(
         package,
+        compilation_context.package_id,
         compute_properties,
         capabilities,
         &compilation_context.fir_store,
@@ -30,6 +31,7 @@ pub fn check_for_exe(source: &str, expect: &Expect, capabilities: TargetCapabili
     let (package, compute_properties) = compilation_context.get_package_compute_properties_tuple();
     let errors = check_supported_capabilities(
         package,
+        compilation_context.package_id,
         compute_properties,
         capabilities,
         &compilation_context.fir_store,
@@ -45,6 +47,7 @@ pub fn capability_error_kinds(source: &str, capabilities: TargetCapabilityFlags)
     let (package, compute_properties) = compilation_context.get_package_compute_properties_tuple();
     let errors = check_supported_capabilities(
         package,
+        compilation_context.package_id,
         compute_properties,
         capabilities,
         &compilation_context.fir_store,

--- a/source/compiler/qsc_passes/src/lib.rs
+++ b/source/compiler/qsc_passes/src/lib.rs
@@ -25,10 +25,7 @@ mod spec_gen;
 mod test_attribute;
 
 use callable_limits::CallableLimits;
-use capabilitiesck::{
-    check_supported_capabilities, check_supported_capabilities_for_callable, lower_store,
-    run_rca_pass,
-};
+use capabilitiesck::{check_supported_capabilities_for_callable, lower_store, run_rca_pass};
 use entry_point::generate_entry_expr;
 use index_assignment::ConvertToWSlash;
 use loop_control::LoopControl;
@@ -47,7 +44,7 @@ use qsc_hir::{
     visit::Visitor,
 };
 use qsc_lowerer::map_hir_package_to_fir;
-use qsc_rca::{PackageComputeProperties, PackageStoreComputeProperties};
+use qsc_rca::PackageStoreComputeProperties;
 use replace_qubit_allocation::ReplaceQubitAllocation;
 use rustc_hash::FxHashMap;
 use std::rc::Rc;
@@ -291,20 +288,6 @@ pub fn run_core_passes(core: &mut CompileUnit) -> Vec<Error> {
         .collect()
 }
 
-pub fn run_rca(
-    package: &fir::Package,
-    compute_properties: &PackageComputeProperties,
-    capabilities: TargetCapabilityFlags,
-    store: &fir::PackageStore,
-) -> Vec<Error> {
-    let capabilities_errors =
-        check_supported_capabilities(package, compute_properties, capabilities, store);
-    capabilities_errors
-        .into_iter()
-        .map(Error::CapabilitiesCk)
-        .collect()
-}
-
 pub fn run_rca_for_callable(
     fir_store: &fir::PackageStore,
     compute_properties: &PackageStoreComputeProperties,
@@ -315,6 +298,7 @@ pub fn run_rca_for_callable(
     let package_compute_properties = compute_properties.get(callable.package, false);
     let capabilities_errors = check_supported_capabilities_for_callable(
         package,
+        callable.package,
         package_compute_properties,
         callable.item,
         capabilities,

--- a/source/compiler/qsc_rca/src/errors.rs
+++ b/source/compiler/qsc_rca/src/errors.rs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 use miette::Diagnostic;
-use qsc_data_structures::{span::Span, target::TargetCapabilityFlags};
+use qsc_data_structures::target::TargetCapabilityFlags;
+use qsc_fir::fir::PackageSpan;
 use thiserror::Error;
 
 use crate::RuntimeFeatureFlags;
@@ -15,7 +16,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-bool"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicBool"))]
-    UseOfDynamicBool(#[label] Span),
+    UseOfDynamicBool(#[label] PackageSpan),
 
     #[error("cannot use a dynamic integer value")]
     #[diagnostic(help(
@@ -23,7 +24,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-integer"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicInt"))]
-    UseOfDynamicInt(#[label] Span),
+    UseOfDynamicInt(#[label] PackageSpan),
 
     #[error("cannot use a dynamic Pauli value")]
     #[diagnostic(help(
@@ -31,7 +32,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-pauli"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicPauli"))]
-    UseOfDynamicPauli(#[label] Span),
+    UseOfDynamicPauli(#[label] PackageSpan),
 
     #[error("cannot use a dynamic Range value")]
     #[diagnostic(help(
@@ -39,7 +40,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-range"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicRange"))]
-    UseOfDynamicRange(#[label] Span),
+    UseOfDynamicRange(#[label] PackageSpan),
 
     #[error("cannot use a dynamic double value")]
     #[diagnostic(help(
@@ -47,7 +48,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-double"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicDouble"))]
-    UseOfDynamicDouble(#[label] Span),
+    UseOfDynamicDouble(#[label] PackageSpan),
 
     #[error("cannot use a dynamic qubit")]
     #[diagnostic(help(
@@ -55,7 +56,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-qubit"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicQubit"))]
-    UseOfDynamicQubit(#[label] Span),
+    UseOfDynamicQubit(#[label] PackageSpan),
 
     #[error("cannot use a dynamic Result")]
     #[diagnostic(help(
@@ -63,7 +64,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-result"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicResult"))]
-    UseOfDynamicResult(#[label] Span),
+    UseOfDynamicResult(#[label] PackageSpan),
 
     #[error("cannot use a dynamic tuple")]
     #[diagnostic(help(
@@ -71,7 +72,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-tuple"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicTuple"))]
-    UseOfDynamicTuple(#[label] Span),
+    UseOfDynamicTuple(#[label] PackageSpan),
 
     #[error("cannot use a dynamic big integer value")]
     #[diagnostic(help(
@@ -79,7 +80,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-big-integer"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicBigInt"))]
-    UseOfDynamicBigInt(#[label] Span),
+    UseOfDynamicBigInt(#[label] PackageSpan),
 
     #[error("cannot use a dynamic string value")]
     #[diagnostic(help(
@@ -87,7 +88,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-string"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicString"))]
-    UseOfDynamicString(#[label] Span),
+    UseOfDynamicString(#[label] PackageSpan),
 
     #[error("cannot use a dynamic exponent")]
     #[diagnostic(help(
@@ -95,7 +96,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-exponent"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicExponent"))]
-    UseOfDynamicExponent(#[label] Span),
+    UseOfDynamicExponent(#[label] PackageSpan),
 
     #[error("cannot use an array with dynamic contents")]
     #[diagnostic(help(
@@ -103,7 +104,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-array"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicArray"))]
-    UseOfDynamicArray(#[label] Span),
+    UseOfDynamicArray(#[label] PackageSpan),
 
     #[error("cannot use a dynamically-sized array")]
     #[diagnostic(help(
@@ -111,7 +112,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamically-sized-array"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicallySizedArray"))]
-    UseOfDynamicallySizedArray(#[label] Span),
+    UseOfDynamicallySizedArray(#[label] PackageSpan),
 
     #[error("cannot use a dynamic user-defined type")]
     #[diagnostic(help(
@@ -119,7 +120,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-user-defined-type"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicUdt"))]
-    UseOfDynamicUdt(#[label] Span),
+    UseOfDynamicUdt(#[label] PackageSpan),
 
     #[error("cannot use a dynamic function")]
     #[diagnostic(help(
@@ -127,7 +128,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-function"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicArrowFunction"))]
-    UseOfDynamicArrowFunction(#[label] Span),
+    UseOfDynamicArrowFunction(#[label] PackageSpan),
 
     #[error("cannot use a dynamic operation")]
     #[diagnostic(help(
@@ -135,7 +136,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-operation"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicArrowOperation"))]
-    UseOfDynamicArrowOperation(#[label] Span),
+    UseOfDynamicArrowOperation(#[label] PackageSpan),
 
     #[error("cannot call a function or operation whose resolution is dynamic")]
     #[diagnostic(help(
@@ -143,7 +144,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#call-to-dynamic-callee"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.CallToDynamicCallee"))]
-    CallToDynamicCallee(#[label] Span),
+    CallToDynamicCallee(#[label] PackageSpan),
 
     #[error("cannot perform a measurement within a dynamic scope")]
     #[diagnostic(help(
@@ -151,19 +152,19 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#measurement-within-a-dynamic-scope"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.MeasurementWithinDynamicScope"))]
-    MeasurementWithinDynamicScope(#[label] Span),
+    MeasurementWithinDynamicScope(#[label] PackageSpan),
 
     #[error("cannot call a custom measurement")]
     #[diagnostic(help("cannot call a custom measurement in the configured target profile"))]
     #[diagnostic(url("https://aka.ms/qdk.qir#call-to-custom-measurement"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.CallToCustomMeasurement"))]
-    CallToCustomMeasurement(#[label] Span),
+    CallToCustomMeasurement(#[label] PackageSpan),
 
     #[error("cannot call a custom reset")]
     #[diagnostic(help("cannot call a custom reset in the configured target profile"))]
     #[diagnostic(url("https://aka.ms/qdk.qir#call-to-custom-reset"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.CallToCustomReset"))]
-    CallToCustomReset(#[label] Span),
+    CallToCustomReset(#[label] PackageSpan),
 
     #[error("cannot access an array using a dynamic index")]
     #[diagnostic(help(
@@ -171,7 +172,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-array-index"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicIndex"))]
-    UseOfDynamicIndex(#[label] Span),
+    UseOfDynamicIndex(#[label] PackageSpan),
 
     #[error("cannot use a return within a dynamic scope")]
     #[diagnostic(help(
@@ -179,7 +180,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#return-within-a-dynamic-scope"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.ReturnWithinDynamicScope"))]
-    ReturnWithinDynamicScope(#[label] Span),
+    ReturnWithinDynamicScope(#[label] PackageSpan),
 
     #[error("cannot have a loop with a dynamic condition")]
     #[diagnostic(help(
@@ -187,7 +188,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#loop-with-dynamic-condition"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.LoopWithDynamicCondition"))]
-    LoopWithDynamicCondition(#[label] Span),
+    LoopWithDynamicCondition(#[label] PackageSpan),
 
     #[error("cannot use a bool value as an output")]
     #[diagnostic(help(
@@ -195,7 +196,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-bool-output"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfBoolOutput"))]
-    UseOfBoolOutput(#[label] Span),
+    UseOfBoolOutput(#[label] PackageSpan),
 
     #[error("cannot use a double value as an output")]
     #[diagnostic(help(
@@ -203,7 +204,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-double-output"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDoubleOutput"))]
-    UseOfDoubleOutput(#[label] Span),
+    UseOfDoubleOutput(#[label] PackageSpan),
 
     #[error("cannot use an integer value as an output")]
     #[diagnostic(help(
@@ -211,7 +212,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-integer-output"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfIntOutput"))]
-    UseOfIntOutput(#[label] Span),
+    UseOfIntOutput(#[label] PackageSpan),
 
     #[error("cannot use value with advanced type as an output")]
     #[diagnostic(help(
@@ -219,7 +220,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-advanced-output"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfAdvancedOutput"))]
-    UseOfAdvancedOutput(#[label] Span),
+    UseOfAdvancedOutput(#[label] PackageSpan),
 
     #[error("cannot use a dynamic generic parameter")]
     #[diagnostic(help(
@@ -227,7 +228,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-generic"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicGeneric"))]
-    UseOfDynamicGeneric(#[label] Span),
+    UseOfDynamicGeneric(#[label] PackageSpan),
 
     #[error("cannot use a dynamic qubit release")]
     #[diagnostic(help(
@@ -235,7 +236,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-qubit-release"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicQubitRelease"))]
-    UseOfDynamicQubitRelease(#[label] Span),
+    UseOfDynamicQubitRelease(#[label] PackageSpan),
 
     #[error("cannot use dynamic branching in parallel expression")]
     #[diagnostic(help(
@@ -243,7 +244,7 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-branching-in-parallel-expr"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicBranchingInParallelExpr"))]
-    UseOfDynamicBranchingInParallelExpr(#[label] Span),
+    UseOfDynamicBranchingInParallelExpr(#[label] PackageSpan),
 
     #[error("cannot use dynamic limit for a parallel expression")]
     #[diagnostic(help(
@@ -251,14 +252,53 @@ pub enum Error {
     ))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-limit-in-parallel-expr"))]
     #[diagnostic(code("Qdk.Qsc.CapabilitiesCk.UseOfDynamicLimitInParallelExpr"))]
-    UseOfDynamicLimitInParallelExpr(#[label] Span),
+    UseOfDynamicLimitInParallelExpr(#[label] PackageSpan),
+}
+
+impl Error {
+    #[must_use]
+    pub fn span(&self) -> PackageSpan {
+        match self {
+            Self::UseOfDynamicBool(span)
+            | Self::UseOfDynamicInt(span)
+            | Self::UseOfDynamicPauli(span)
+            | Self::UseOfDynamicRange(span)
+            | Self::UseOfDynamicDouble(span)
+            | Self::UseOfDynamicQubit(span)
+            | Self::UseOfDynamicResult(span)
+            | Self::UseOfDynamicTuple(span)
+            | Self::UseOfDynamicBigInt(span)
+            | Self::UseOfDynamicString(span)
+            | Self::UseOfDynamicExponent(span)
+            | Self::UseOfDynamicArray(span)
+            | Self::UseOfDynamicallySizedArray(span)
+            | Self::UseOfDynamicUdt(span)
+            | Self::UseOfDynamicArrowFunction(span)
+            | Self::UseOfDynamicArrowOperation(span)
+            | Self::CallToDynamicCallee(span)
+            | Self::MeasurementWithinDynamicScope(span)
+            | Self::CallToCustomMeasurement(span)
+            | Self::CallToCustomReset(span)
+            | Self::UseOfDynamicIndex(span)
+            | Self::ReturnWithinDynamicScope(span)
+            | Self::LoopWithDynamicCondition(span)
+            | Self::UseOfBoolOutput(span)
+            | Self::UseOfDoubleOutput(span)
+            | Self::UseOfIntOutput(span)
+            | Self::UseOfAdvancedOutput(span)
+            | Self::UseOfDynamicGeneric(span)
+            | Self::UseOfDynamicQubitRelease(span)
+            | Self::UseOfDynamicBranchingInParallelExpr(span)
+            | Self::UseOfDynamicLimitInParallelExpr(span) => *span,
+        }
+    }
 }
 
 #[allow(clippy::too_many_lines)]
 #[must_use]
 pub fn generate_errors_from_runtime_features(
     runtime_features: RuntimeFeatureFlags,
-    span: Span,
+    span: PackageSpan,
 ) -> Vec<Error> {
     let mut errors = Vec::<Error>::new();
 


### PR DESCRIPTION
Under some circumstances, the current mechanism of having the user package as the fallback package ID for spans reported from Capability Errors was wrong, causing us to try and look up a stdlib span in the user package and triggering a panic during error reporting. This updates those errors to be `PackageSpan` so that the span can be resolved to the correct source offset.