### PR TITLE
Add Samples for Physical Qubit Addressing Mode

### DIFF
--- a/samples/physical_qubit_addressing/BellStatePhysical.qasm
+++ b/samples/physical_qubit_addressing/BellStatePhysical.qasm
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Physical qubit addressing in OpenQASM 3.
+//
+// This program treats QIR qubit IDs as fixed physical addresses on a target machine. The machine
+// size is specific to the hardware you target; this example assumes 256 qubits, so size the
+// register to the qubit count of the machine you target. The pattern relies on three facts:
+//   1. The source declares the entire machine-sized qubit register exactly once, so its indices
+//      map directly onto QIR qubit IDs.
+//   2. Selecting register elements by constant index names the intended physical addresses.
+//   3. A provider target must contractually preserve those IDs. Source indices and QIR IDs alone
+//      do not force a hardware layout; confirm the target's contract before relying on it.
+//
+// See README.md for the full physical-addressing guidance and the constraints below.
+
+OPENQASM 3.0;
+include "stdgates.inc";
+
+// This is the only qubit declaration. Array indices are physical addresses.
+qubit[256] machine;
+output bit[8] results;
+
+// Distinct pairs keep every physical qubit measured exactly once.
+let phiPlusA = machine[12];
+let phiPlusB = machine[173];
+let phiMinusA = machine[40];
+let phiMinusB = machine[190];
+let psiPlusA = machine[71];
+let psiPlusB = machine[205];
+let psiMinusA = machine[99];
+let psiMinusB = machine[233];
+
+// Prepare every state before measuring any qubit.
+
+// |Phi+> = (|00> + |11>) / sqrt(2)
+reset phiPlusA;
+reset phiPlusB;
+h phiPlusA;
+cx phiPlusA, phiPlusB;
+
+// |Phi-> = (|00> - |11>) / sqrt(2)
+reset phiMinusA;
+reset phiMinusB;
+h phiMinusA;
+z phiMinusA;
+cx phiMinusA, phiMinusB;
+
+// |Psi+> = (|01> + |10>) / sqrt(2)
+reset psiPlusA;
+reset psiPlusB;
+h psiPlusA;
+x psiPlusB;
+cx psiPlusA, psiPlusB;
+
+// |Psi-> = (|01> - |10>) / sqrt(2)
+reset psiMinusA;
+reset psiMinusB;
+h psiMinusA;
+z psiMinusA;
+x psiMinusB;
+cx psiMinusA, psiMinusB;
+
+// Base Profile requires measurements at the end of the program.
+results[0] = measure phiPlusA;
+results[1] = measure phiPlusB;
+results[2] = measure phiMinusA;
+results[3] = measure phiMinusB;
+results[4] = measure psiPlusA;
+results[5] = measure psiPlusB;
+results[6] = measure psiMinusA;
+results[7] = measure psiMinusB;

--- a/samples/physical_qubit_addressing/BellStatePhysical.qasm
+++ b/samples/physical_qubit_addressing/BellStatePhysical.qasm
@@ -8,7 +8,7 @@
 // register to the qubit count of the machine you target. The pattern relies on three facts:
 //   1. The source declares the entire machine-sized qubit register exactly once, so its indices
 //      map directly onto QIR qubit IDs.
-//   2. Selecting register elements by constant index names the intended physical addresses.
+//   2. Selecting register elements by explicit physical address fixes their intended QIR qubit IDs.
 //   3. A provider target must contractually preserve those IDs. Source indices and QIR IDs alone
 //      do not force a hardware layout; confirm the target's contract before relying on it.
 //

--- a/samples/physical_qubit_addressing/BellStatePhysical.qasm
+++ b/samples/physical_qubit_addressing/BellStatePhysical.qasm
@@ -61,7 +61,7 @@ z psiMinusA;
 x psiMinusB;
 cx psiMinusA, psiMinusB;
 
-// Base Profile requires measurements at the end of the program.
+// Measurements at the end of the program.
 results[0] = measure phiPlusA;
 results[1] = measure phiPlusB;
 results[2] = measure phiMinusA;

--- a/samples/physical_qubit_addressing/BellStatePhysical.qs
+++ b/samples/physical_qubit_addressing/BellStatePhysical.qs
@@ -8,7 +8,7 @@
 // to the qubit count of the machine you target. The pattern relies on three facts:
 //   1. The source allocates the entire machine-sized qubit pool exactly once, so its array
 //      indices map directly onto QIR qubit IDs.
-//   2. Selecting pool elements by constant index names the intended physical addresses.
+//   2. Selecting pool elements by explicit physical address fixes their intended QIR qubit IDs.
 //   3. A provider target must contractually preserve those IDs. Q# indices and QIR IDs alone do
 //      not force a hardware layout; confirm the target's contract before relying on it.
 //

--- a/samples/physical_qubit_addressing/BellStatePhysical.qs
+++ b/samples/physical_qubit_addressing/BellStatePhysical.qs
@@ -15,6 +15,7 @@
 // See README.md for the full physical-addressing guidance and the constraints below.
 
 // Prepares four Bell states on separate address pairs, then measures them at the end.
+@EntryPoint(Base)
 operation Main() : (Result, Result)[] {
     // This is the only allocation. Array indices are physical addresses.
     use machine = Qubit[256];

--- a/samples/physical_qubit_addressing/BellStatePhysical.qs
+++ b/samples/physical_qubit_addressing/BellStatePhysical.qs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Physical qubit addressing in Q#.
+//
+// This program treats QIR qubit IDs as fixed physical addresses on a target machine. The machine
+// size is specific to the hardware you target; this example assumes 256 qubits, so size the pool
+// to the qubit count of the machine you target. The pattern relies on three facts:
+//   1. The source allocates the entire machine-sized qubit pool exactly once, so its array
+//      indices map directly onto QIR qubit IDs.
+//   2. Selecting pool elements by constant index names the intended physical addresses.
+//   3. A provider target must contractually preserve those IDs. Q# indices and QIR IDs alone do
+//      not force a hardware layout; confirm the target's contract before relying on it.
+//
+// See README.md for the full physical-addressing guidance and the constraints below.
+
+// Prepares four Bell states on separate address pairs, then measures them at the end.
+operation Main() : (Result, Result)[] {
+    // This is the only allocation. Array indices are physical addresses.
+    use machine = Qubit[256];
+
+    // Distinct pairs keep every physical qubit measured exactly once.
+    let phiPlus = (machine[12], machine[173]);
+    let phiMinus = (machine[40], machine[190]);
+    let psiPlus = (machine[71], machine[205]);
+    let psiMinus = (machine[99], machine[233]);
+
+    // Prepare every state before measuring any qubit.
+    PreparePhiPlus(phiPlus);
+    PreparePhiMinus(phiMinus);
+    PreparePsiPlus(psiPlus);
+    PreparePsiMinus(psiMinus);
+
+    // Base Profile requires measurements at the end of the program.
+    [
+        MeasurePair(phiPlus),
+        MeasurePair(phiMinus),
+        MeasurePair(psiPlus),
+        MeasurePair(psiMinus)
+    ]
+}
+
+// Measures each physical qubit independently.
+operation MeasurePair(alice : Qubit, bob : Qubit) : (Result, Result) {
+    (MResetZ(alice), MResetZ(bob))
+}
+
+// These helpers operate only on qubits from the fixed pool and allocate no ancillas.
+
+// |Phi+> = (|00> + |11>) / sqrt(2)
+operation PreparePhiPlus(alice : Qubit, bob : Qubit) : Unit {
+    H(alice);
+    CNOT(alice, bob);
+}
+
+// |Phi-> = (|00> - |11>) / sqrt(2)
+operation PreparePhiMinus(alice : Qubit, bob : Qubit) : Unit {
+    H(alice);
+    Z(alice);
+    CNOT(alice, bob);
+}
+
+// |Psi+> = (|01> + |10>) / sqrt(2)
+operation PreparePsiPlus(alice : Qubit, bob : Qubit) : Unit {
+    H(alice);
+    X(bob);
+    CNOT(alice, bob);
+}
+
+// |Psi-> = (|01> - |10>) / sqrt(2)
+operation PreparePsiMinus(alice : Qubit, bob : Qubit) : Unit {
+    H(alice);
+    Z(alice);
+    X(bob);
+    CNOT(alice, bob);
+}

--- a/samples/physical_qubit_addressing/README.md
+++ b/samples/physical_qubit_addressing/README.md
@@ -23,7 +23,7 @@ That behavior is only meaningful when three facts hold together:
    uses 256 qubits, so indices `0..255` map to QIR qubit IDs `0..255`; size the pool to match your
    target machine.
 2. **Qubits are selected by explicit physical address.** Picking an element such as `machine[12]`
-   selects physical address 12 in the generated QIR. Indices, and therefore addresses, but be known
+   selects physical address 12 in the generated QIR. Indices, and therefore addresses, must be known
    at compile-time and can't be dependent on the outcome of a measurement.
 3. **The provider target preserves those IDs.** Source indices and QIR IDs do not by themselves
    force a hardware layout. A target may perform further gate decomposition, routing, scheduling,
@@ -73,8 +73,8 @@ Every program written for physical qubit addressing must follow these constraint
 5. **Check the compiled artifact.** When you compile to QIR, confirm that the entry point declares
    `required_num_qubits` equal to your machine size (`256` in this example) and that the quantum
    instructions reference the intended QIR qubit IDs (12, 40, 71, 99, 173, 190, 205, and 233 here).
-   Re-run these checks whenever the program, compiler, or target profile changes. This validates the
-   generated QIR—not the provider's post-submission layout.
+   Re-run these checks whenever the program, compiler, or target profile changes. Note that this
+   validates the generated QIR and not the provider's post-submission layout.
 6. **Confirm provider behavior.** Source indices and QIR IDs do not by themselves force a provider
    to preserve a hardware layout. Use only a target whose documented contract supplies the needed
    physical-address semantics. A target that accepts the QIR but freely remaps its qubit IDs does

--- a/samples/physical_qubit_addressing/README.md
+++ b/samples/physical_qubit_addressing/README.md
@@ -22,8 +22,9 @@ That behavior is only meaningful when three facts hold together:
    the whole machine makes its array indices correspond one-to-one with QIR qubit IDs. This example
    uses 256 qubits, so indices `0..255` map to QIR qubit IDs `0..255`; size the pool to match your
    target machine.
-2. **Addresses are selected by constant index.** Picking an element such as `machine[12]` names the
-   intended physical address in the generated QIR.
+2. **Qubits are selected by explicit physical address.** Picking an element such as `machine[12]`
+   selects physical address 12 in the generated QIR. Indices, and therefore addresses, but be known
+   at compile-time and can't be dependent on the outcome of a measurement.
 3. **The provider target preserves those IDs.** Source indices and QIR IDs do not by themselves
    force a hardware layout. A target may perform further gate decomposition, routing, scheduling,
    or qubit remapping after it receives the QIR.

--- a/samples/physical_qubit_addressing/README.md
+++ b/samples/physical_qubit_addressing/README.md
@@ -1,0 +1,80 @@
+# Physical qubit addressing
+
+This sample demonstrates a *physical qubit addressing* pattern: it treats QIR qubit IDs as fixed
+physical addresses on the target machine. The machine size is specific to the hardware you target;
+these examples assume a 256-qubit machine, so when you adapt the pattern, set the pool size to the
+qubit count of the machine you target. Two equivalent programs prepare all four Bell states on four
+pairs of physical addresses:
+
+- [BellStatePhysical.qs](BellStatePhysical.qs) — Q#.
+- [BellStatePhysical.qasm](BellStatePhysical.qasm) — OpenQASM 3.
+
+## What "physical addressing" means here
+
+In the usual programming model, a qubit variable is an opaque handle. The runtime and the target
+provider are free to place it on any physical qubit and to remap it during compilation. Physical
+addressing instead assumes a fixed mapping: the array index you choose in source becomes the QIR
+qubit ID, and that QIR qubit ID lands on the corresponding physical site on the machine.
+
+That behavior is only meaningful when three facts hold together:
+
+1. **The source represents the complete machine exactly once.** Allocating one qubit pool sized to
+   the whole machine makes its array indices correspond one-to-one with QIR qubit IDs. This example
+   uses 256 qubits, so indices `0..255` map to QIR qubit IDs `0..255`; size the pool to match your
+   target machine.
+2. **Addresses are selected by constant index.** Picking an element such as `machine[12]` names the
+   intended physical address in the generated QIR.
+3. **The provider target preserves those IDs.** Source indices and QIR IDs do not by themselves
+   force a hardware layout. A target may perform further gate decomposition, routing, scheduling,
+   or qubit remapping after it receives the QIR.
+
+The first two facts are visible in the source. The third must be confirmed with the hardware
+provider. Use this pattern only with a target whose documented contract exposes the full set of
+addressable qubits and preserves the meaning of the QIR qubit IDs you select.
+
+## The programs
+
+Each program prepares the four Bell states on these address pairs:
+
+- $|\Phi^+\rangle$ on addresses 12 and 173;
+- $|\Phi^-\rangle$ on addresses 40 and 190;
+- $|\Psi^+\rangle$ on addresses 71 and 205; and
+- $|\Psi^-\rangle$ on addresses 99 and 233.
+
+The programs allocate or declare the entire 256-qubit machine once and use no other qubits. Each
+Bell state has its own address pair, so every qubit is measured exactly once. All four states are
+prepared before any measurement occurs, then each address is measured independently at the end of
+the program. This ordering is required by the Base Profile and is also valid for other profiles.
+
+In the computational basis, the $|\Phi^+\rangle$ and $|\Phi^-\rangle$ pairs produce the correlated
+outcomes `00` or `11`, while the $|\Psi^+\rangle$ and $|\Psi^-\rangle$ pairs produce the
+anti-correlated outcomes `01` or `10`. The relative phase is not visible in these measurements.
+Result formatting and bit ordering can vary by provider.
+
+## Physical-addressing checklist
+
+Every program written for physical qubit addressing must follow these constraints:
+
+1. **Represent the complete machine once.** Allocate one machine-sized `Qubit[]` in Q#, or declare
+   one machine-sized `qubit[]` in OpenQASM. Do not allocate or declare qubits anywhere else. A
+   second allocation, or a helper that allocates workspace/ancilla qubits, breaks the fixed layout.
+2. **Audit helper implementations.** QIR generation for operations from `Std.Intrinsic` and
+   `Std.Canon` does not add ancillary qubits. Review operations from other libraries and custom
+   decompositions before using them; an implementation can allocate workspace qubits even if its
+   call site does not.
+3. **Restrict controlled operations.** Avoid operations with multiple controls. CCX/Toffoli is the
+   supported exception when its ancilla-free decomposition and the target gate set are suitable.
+   Do not assume that arbitrary multi-controlled operations preserve the fixed address space.
+4. **Measure separately and at the end.** Complete every quantum operation before performing any
+   measurement. For Base Profile Q#, use independent terminal `MResetZ` calls and avoid joint
+   Pauli-product measurements. In OpenQASM, use separate terminal measurement statements. Giving
+   each output its own physical qubit avoids measuring and then reusing an address.
+5. **Check the compiled artifact.** When you compile to QIR, confirm that the entry point declares
+   `required_num_qubits` equal to your machine size (`256` in this example) and that the quantum
+   instructions reference the intended QIR qubit IDs (12, 40, 71, 99, 173, 190, 205, and 233 here).
+   Re-run these checks whenever the program, compiler, or target profile changes. This validates the
+   generated QIR—not the provider's post-submission layout.
+6. **Confirm provider behavior.** Source indices and QIR IDs do not by themselves force a provider
+   to preserve a hardware layout. Use only a target whose documented contract supplies the needed
+   physical-address semantics. A target that accepts the QIR but freely remaps its qubit IDs does
+   not provide the addressing semantics demonstrated by this sample.

--- a/samples/physical_qubit_addressing/README.md
+++ b/samples/physical_qubit_addressing/README.md
@@ -63,9 +63,10 @@ Every program written for physical qubit addressing must follow these constraint
    `Std.Canon` does not add ancillary qubits. Review operations from other libraries and custom
    decompositions before using them; an implementation can allocate workspace qubits even if its
    call site does not.
-3. **Restrict controlled operations.** Avoid operations with multiple controls. CCX/Toffoli is the
-   supported exception when its ancilla-free decomposition and the target gate set are suitable.
-   Do not assume that arbitrary multi-controlled operations preserve the fixed address space.
+3. **Restrict controlled operations.** Use operations with at most one control. The exception is
+    an X operation with exactly two controls, which is the CCX/Toffoli gate, which the QDK lowers
+    without allocating additional qubits. Do not generalize this exception to other multiply
+    controlled operations.
 4. **Measure separately and at the end.** Complete every quantum operation before performing any
    measurement. For Base Profile Q#, use independent terminal `MResetZ` calls and avoid joint
    Pauli-product measurements. In OpenQASM, use separate terminal measurement statements. Giving


### PR DESCRIPTION
Adds Q# and OpenQASM samples of simple Bell-State preparation programs using constraints needed for physical qubit addressing mode. A read-me is provided that goes into the details of the constraints needed for programs where physical qubits are meant to be addressing, and outlines the limitations of these efforts.