### PR TITLE
Handle binop with dynamic constant `BigInt` values

### DIFF
--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -65,6 +65,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::{collections::hash_map::Entry, mem::take, rc::Rc, result::Result};
 use thiserror::Error;
 
+use crate::Error::Unimplemented;
+
 /// Partially evaluates a program with the specified entry expression.
 pub fn partially_evaluate(
     package_store: &PackageStore,
@@ -714,6 +716,9 @@ impl<'a> PartialEvaluator<'a> {
                     )),
                 }
             }
+            Value::BigInt(lhs_bigint) => {
+                self.eval_binop_with_lhs_bigint(bin_op, lhs_bigint, rhs_expr_id)
+            }
             _ => Err(Error::Unexpected(
                 format!("unsupported LHS value: {lhs_value}"),
                 lhs_span,
@@ -1162,7 +1167,7 @@ impl<'a> PartialEvaluator<'a> {
         let rhs_operand = self.map_eval_value_to_rir_operand(&rhs_value);
         assert!(
             matches!(rhs_operand.get_type(), rir::Ty::Prim(rir::Prim::Integer)),
-            "LHS value is expected to be of integer type"
+            "RHS value is expected to be of integer type"
         );
 
         // If both operands are literals, evaluate the binary operation and return its value.
@@ -1192,6 +1197,31 @@ impl<'a> PartialEvaluator<'a> {
                 bin_op_expr_span,
             )
         })?);
+        Ok(EvalControlFlow::Continue(value))
+    }
+
+    fn eval_binop_with_lhs_bigint(
+        &mut self,
+        bin_op: BinOp,
+        lhs_bigint: BigInt,
+        rhs_expr_id: ExprId,
+    ) -> Result<EvalControlFlow, Error> {
+        // Try to evaluate the RHS expression to get its value and construct its operand.
+        let rhs_control_flow = self.try_eval_expr(rhs_expr_id)?;
+        let EvalControlFlow::Continue(rhs_val) = rhs_control_flow else {
+            return Err(Error::Unexpected(
+                "embedded return in RHS expression".to_string(),
+                self.get_expr_package_span(rhs_expr_id),
+            ));
+        };
+
+        let value = eval_bin_op_with_bigint_literals(
+            bin_op,
+            lhs_bigint,
+            rhs_val,
+            self.get_expr_package_span(rhs_expr_id),
+        )?;
+
         Ok(EvalControlFlow::Continue(value))
     }
 
@@ -5168,6 +5198,65 @@ fn eval_bin_op_with_integer_literals(
         BinOp::Shr => Ok(Value::Int(lhs_int >> rhs_int)),
         _ => panic!("invalid integer operator: {bin_op:?}"),
     }
+}
+
+fn eval_bin_op_with_bigint_literals(
+    bin_op: BinOp,
+    lhs_bigint: BigInt,
+    rhs_val: Value,
+    rhs_span: PackageSpan,
+) -> Result<Value, Error> {
+    if !matches!(rhs_val, Value::BigInt(_) | Value::Int(_)) {
+        return Err(Unimplemented(
+            "dynamic value in BigInt computation".to_string(),
+            rhs_span,
+        ));
+    }
+
+    Ok(match bin_op {
+        BinOp::Eq => Value::Bool(lhs_bigint == rhs_val.unwrap_big_int()),
+        BinOp::Neq => Value::Bool(lhs_bigint != rhs_val.unwrap_big_int()),
+        BinOp::Gt => Value::Bool(lhs_bigint > rhs_val.unwrap_big_int()),
+        BinOp::Gte => Value::Bool(lhs_bigint >= rhs_val.unwrap_big_int()),
+        BinOp::Lt => Value::Bool(lhs_bigint < rhs_val.unwrap_big_int()),
+        BinOp::Lte => Value::Bool(lhs_bigint <= rhs_val.unwrap_big_int()),
+        BinOp::Add => Value::BigInt(lhs_bigint + rhs_val.unwrap_big_int()),
+        BinOp::Sub => Value::BigInt(lhs_bigint - rhs_val.unwrap_big_int()),
+        BinOp::Mul => Value::BigInt(lhs_bigint * rhs_val.unwrap_big_int()),
+        BinOp::Div => Value::BigInt(lhs_bigint / rhs_val.unwrap_big_int()),
+        BinOp::Mod => Value::BigInt(lhs_bigint % rhs_val.unwrap_big_int()),
+        BinOp::Exp => {
+            let rhs_val = rhs_val.unwrap_int();
+            if rhs_val < 0 {
+                return Err(EvalError::InvalidNegativeInt(rhs_val, rhs_span).into());
+            }
+            let rhs_val: u32 = match rhs_val.try_into() {
+                Ok(v) => v,
+                Err(_) => return Err(EvalError::IntTooLarge(rhs_val, rhs_span).into()),
+            };
+            Value::BigInt(lhs_bigint.pow(rhs_val))
+        }
+        BinOp::AndB => Value::BigInt(lhs_bigint & rhs_val.unwrap_big_int()),
+        BinOp::OrB => Value::BigInt(lhs_bigint | rhs_val.unwrap_big_int()),
+        BinOp::XorB => Value::BigInt(lhs_bigint ^ rhs_val.unwrap_big_int()),
+        BinOp::Shl => {
+            let rhs = rhs_val.unwrap_int();
+            if rhs > 0 {
+                Value::BigInt(lhs_bigint << rhs)
+            } else {
+                Value::BigInt(lhs_bigint >> rhs.abs())
+            }
+        }
+        BinOp::Shr => {
+            let rhs = rhs_val.unwrap_int();
+            if rhs > 0 {
+                Value::BigInt(lhs_bigint >> rhs)
+            } else {
+                Value::BigInt(lhs_bigint << rhs.abs())
+            }
+        }
+        _ => panic!("invalid bigint operator: {bin_op:?}"),
+    })
 }
 
 /// Maps a runtime `FunctorApp` to the `FunctorSetValue` that identifies a specialization. This is the

--- a/source/compiler/qsc_partial_eval/src/tests/misc.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/misc.rs
@@ -1028,3 +1028,28 @@ fn test_length_and_isempty_as_loop_conditions() {
                 Return Integer(0)"#]],
     );
 }
+
+#[test]
+fn test_dynamic_expr_including_bigint_binop() {
+    let program = get_rir_program(indoc! {
+        r#"
+        operation Main() : Result {
+            use q = Qubit();
+            let _ = 1L + {X(q); 2L};
+            M(q)
+        }
+        "#,
+    });
+
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Pointer, )
+                Call id(2), args( Qubit(0), )
+                Call id(3), args( Qubit(0), Result(0), )
+                Call id(4), args( Result(0), Tag(0, 3), )
+                Return Integer(0)"#]],
+    );
+}


### PR DESCRIPTION
Partial Eval should handle operations on dynamic constant `BigInt` values rather than failing.