### PR TITLE
Pin ipykernel to 6.x to avoid Jupyter kernel startup hangs

### DIFF
--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/requirements.txt
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/requirements.txt
@@ -1,4 +1,5 @@
 qdk-chemistry[jupyter]>=2.1.0
-# ipykernel 7 can leave notebooks hanging on the first cell.
+# Pinned to 6.x: ipykernel 7 can leave notebooks hanging on the first cell.
+# Remove once https://github.com/microsoft/qdk/issues/3662 is fixed.
 ipykernel>=6.0,<7
 pyscf>=2.9.0,<2.12.1

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/requirements.txt
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/requirements.txt
@@ -1,3 +1,4 @@
 qdk-chemistry[jupyter]>=2.1.0
-ipykernel>=6.0
+# ipykernel 7 can leave notebooks hanging on the first cell.
+ipykernel>=6.0,<7
 pyscf>=2.9.0,<2.12.1

--- a/source/vscode/src/pythonEnvs.ts
+++ b/source/vscode/src/pythonEnvs.ts
@@ -59,7 +59,8 @@ const packagePickItems: vscode.QuickPickItem[] = [
     picked: false,
   },
   {
-    label: "ipykernel",
+    // ipykernel 7 can leave notebooks hanging on the first cell.
+    label: "ipykernel<7",
     description: "Jupyter kernel",
     detail: "Enable Jupyter notebook functionality in VS Code",
     picked: true,

--- a/source/vscode/src/pythonEnvs.ts
+++ b/source/vscode/src/pythonEnvs.ts
@@ -59,7 +59,8 @@ const packagePickItems: vscode.QuickPickItem[] = [
     picked: false,
   },
   {
-    // ipykernel 7 can leave notebooks hanging on the first cell.
+    // Pinned to 6.x: ipykernel 7 can leave notebooks hanging on the first cell.
+    // Remove once https://github.com/microsoft/qdk/issues/3662 is fixed.
     label: "ipykernel<7",
     description: "Jupyter kernel",
     detail: "Enable Jupyter notebook functionality in VS Code",


### PR DESCRIPTION
Resolves the notebooks hanging on the first cell ("Connecting to kernel", spinner never resolves).