### PR TITLE
Fix dynamic result bugs in GPU simulator

### DIFF
--- a/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
@@ -618,6 +618,39 @@ def test_read_loss(sim_type):
     }, f"Expected all {SHOTS} shots to be 'L1', got {counts}"
 
 
+DYNAMIC_READ_LOSS_QIR = """
+entry:
+  call void @__quantum__qis__s__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  %result_id = sub i64 1, 1
+  %result = inttoptr i64 %result_id to %Result*
+  %lost = call i1 @__quantum__rt__read_loss(%Result* %result)
+  br i1 %lost, label %then, label %end
+
+then:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+  br label %end
+
+end:
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_read_loss_with_dynamic_result_id(sim_type):
+    qir = format_qir(
+        DYNAMIC_READ_LOSS_QIR,
+        extra_decls=READ_LOSS_DECLS,
+        num_qubits=2,
+        num_results=2,
+    )
+    noise = NoiseConfig()
+    noise.s.loss = 1.0
+    results = run_qir(qir, SHOTS, noise, seed=42, type=sim_type)
+    counts = Counter(map_result_list_to_str(result) for result in results)
+    assert counts == {"L1": SHOTS}
+
+
 # =========================================================================
 # OP_PEEK_LOSS — read whether a qubit is lost without collapsing
 # =========================================================================

--- a/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
@@ -451,6 +451,29 @@ def test_read_result(sim_type):
     check_result(READ_RESULT_QIR, "11", num_results=2, sim_type=sim_type)
 
 
+DYNAMIC_READ_RESULT_QIR = """
+entry:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  %result_id = sub i64 1, 1
+  %result = inttoptr i64 %result_id to %Result*
+  %one = call i1 @__quantum__qis__read_result__body(%Result* %result)
+  br i1 %one, label %then, label %end
+
+then:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  br label %end
+
+end:
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_read_result_with_dynamic_result_id(sim_type):
+    check_result(DYNAMIC_READ_RESULT_QIR, "11", num_results=2, sim_type=sim_type)
+
+
 # =========================================================================
 # OP_RECORD_OUTPUT — output recording
 # =========================================================================
@@ -470,6 +493,34 @@ def test_record_output_ordering(sim_type):
     check_result(
         RECORD_OUTPUT_QIR, "10", num_qubits=2, num_results=2, sim_type=sim_type
     )
+
+
+DYNAMIC_RECORD_OUTPUT_QIR = f"""\
+%Result = type opaque
+%Qubit = type opaque
+
+define i64 @ENTRYPOINT__main() #0 {{
+entry:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  %result_id = sub i64 1, 1
+  %result = inttoptr i64 %result_id to %Result*
+  call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
+  call void @__quantum__rt__result_record_output(%Result* %result, i8* null)
+  ret i64 0
+}}
+
+{_DECLS}
+attributes #0 = {{ "entry_point" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="2" }}
+attributes #1 = {{ "irreversible" }}
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_record_output_with_dynamic_result_id(sim_type):
+    results = run_qir(DYNAMIC_RECORD_OUTPUT_QIR, SHOTS, seed=42, type=sim_type)
+    counts = Counter(map_result_list_to_str(result) for result in results)
+    assert counts == {"1": SHOTS}
 
 
 # =========================================================================
@@ -1804,6 +1855,29 @@ def test_call_with_return_value(sim_type):
         CALL_WITH_RETVAL_QIR,
         "1",
         extra_decls=CALL_WITH_RETVAL_QIR_FN,
+        sim_type=sim_type,
+    )
+
+
+CALL_WITH_IMMEDIATE_RETVAL_QIR = """
+  %result = call i64 @get_seven()
+  %flag = icmp eq i64 %result, 7
+"""
+
+CALL_WITH_IMMEDIATE_RETVAL_QIR_FN = """
+define i64 @get_seven() {
+entry:
+  ret i64 7
+}
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_call_with_immediate_return_value(sim_type):
+    check_result(
+        build_arith_body(CALL_WITH_IMMEDIATE_RETVAL_QIR),
+        "1",
+        extra_decls=CALL_WITH_IMMEDIATE_RETVAL_QIR_FN,
         sim_type=sim_type,
     )
 

--- a/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
@@ -544,6 +544,39 @@ def test_read_loss():
     }, f"Expected all {SHOTS} shots to be 'L1', got {counts}"
 
 
+DYNAMIC_READ_LOSS_QIR = """
+entry:
+  call void @__quantum__qis__s__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  %result_id = sub i64 1, 1
+  %result = inttoptr i64 %result_id to %Result*
+  %lost = call i1 @__quantum__rt__read_loss(%Result* %result)
+  br i1 %lost, label %then, label %end
+
+then:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+  br label %end
+
+end:
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_read_loss_with_dynamic_result_id():
+    qir = format_qir(
+        DYNAMIC_READ_LOSS_QIR,
+        extra_decls=READ_LOSS_DECLS,
+        num_qubits=2,
+        num_results=2,
+    )
+    noise = NoiseConfig()
+    noise.s.loss = 1.0
+    results = run_qir(qir, SHOTS, noise, seed=42, type="gpu")
+    counts = Counter(map_result_list_to_str(result) for result in results)
+    assert counts == {"L1": SHOTS}
+
+
 # =========================================================================
 # OP_PEEK_LOSS — read whether a qubit is lost without collapsing
 # =========================================================================

--- a/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
@@ -470,6 +470,29 @@ def test_read_result():
     check_result(READ_RESULT_QIR, "11", num_results=2)
 
 
+DYNAMIC_READ_RESULT_QIR = """
+entry:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  %result_id = sub i64 1, 1
+  %result = inttoptr i64 %result_id to %Result*
+  %one = call i1 @__quantum__qis__read_result__body(%Result* %result)
+  br i1 %one, label %then, label %end
+
+then:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  br label %end
+
+end:
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_read_result_with_dynamic_result_id():
+    check_result(DYNAMIC_READ_RESULT_QIR, "11", num_results=2)
+
+
 # =========================================================================
 # OP_RECORD_OUTPUT — output recording
 # =========================================================================
@@ -488,6 +511,34 @@ entry:
 def test_record_output_ordering():
     """Two results recorded: result0=1, result1=0 → '10'."""
     check_result(RECORD_OUTPUT_QIR, "10", num_qubits=2, num_results=2)
+
+
+DYNAMIC_RECORD_OUTPUT_QIR = f"""\
+%Result = type opaque
+%Qubit = type opaque
+
+define i64 @ENTRYPOINT__main() #0 {{
+entry:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  %result_id = sub i64 1, 1
+  %result = inttoptr i64 %result_id to %Result*
+  call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
+  call void @__quantum__rt__result_record_output(%Result* %result, i8* null)
+  ret i64 0
+}}
+
+{_DECLS}
+attributes #0 = {{ "entry_point" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="2" }}
+attributes #1 = {{ "irreversible" }}
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_record_output_with_dynamic_result_id():
+    results = run_qir(DYNAMIC_RECORD_OUTPUT_QIR, SHOTS, seed=42, type="gpu")
+    counts = Counter(map_result_list_to_str(result) for result in results)
+    assert counts == {"1": SHOTS}
 
 
 # =========================================================================
@@ -2088,6 +2139,28 @@ entry:
 def test_call_with_return_value():
     """Call a function returning i64, use result in comparison."""
     check_result(CALL_WITH_RETVAL_QIR, "1", extra_decls=CALL_WITH_RETVAL_QIR_FN)
+
+
+CALL_WITH_IMMEDIATE_RETVAL_QIR = """
+  %result = call i64 @get_seven()
+  %flag = icmp eq i64 %result, 7
+"""
+
+CALL_WITH_IMMEDIATE_RETVAL_QIR_FN = """
+define i64 @get_seven() {
+entry:
+  ret i64 7
+}
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_call_with_immediate_return_value():
+    check_result(
+        build_arith_body(CALL_WITH_IMMEDIATE_RETVAL_QIR),
+        "1",
+        extra_decls=CALL_WITH_IMMEDIATE_RETVAL_QIR_FN,
+    )
 
 
 # =========================================================================

--- a/source/simulators/src/gpu_full_state_simulator/gpu_statevector_shaders.wgsl
+++ b/source/simulators/src/gpu_full_state_simulator/gpu_statevector_shaders.wgsl
@@ -2172,7 +2172,7 @@ fn is_rotation_gate(id: u32) -> bool {
 fn is_dynamic_angle(shot_idx: u32) -> bool {
     let state = shots[shot_idx].interp;
     let instr = fetch_instr(state.pc - 1);
-    return (instr.opcode | FLAG_SRC0_IMM) != 0;
+    return (instr.opcode & FLAG_SRC0_IMM) == 0u;
 }
 
 // Commit a sampled qubit loss on an explicitly given qubit (measure + reset to

--- a/source/simulators/src/gpu_full_state_simulator/gpu_statevector_shaders.wgsl
+++ b/source/simulators/src/gpu_full_state_simulator/gpu_statevector_shaders.wgsl
@@ -2788,7 +2788,7 @@ fn interpret_classical(@builtin(global_invocation_id) gid: vec3<u32>) {
                 pc = shots[shot_idx].interp.call_stack_frames[sp].return_pc;
                 let return_reg = shots[shot_idx].interp.call_stack_frames[sp].return_reg;
                 if return_reg != VOID_RETURN {
-                    write_reg(shot_idx, return_reg, read_reg(shot_idx, instr.src0));
+                    write_reg(shot_idx, return_reg, resolve_u32(shot_idx, instr.src0, flags, 0u));
                 }
             }
 
@@ -2866,7 +2866,7 @@ fn interpret_classical(@builtin(global_invocation_id) gid: vec3<u32>) {
             // register, allowing classical code to branch on measurement
             // outcomes.
             case OP_READ_RESULT {
-                let result_id = instr.src0;
+                let result_id = resolve_u32(shot_idx, instr.src0, flags, 0u);
                 let result_val = read_measurement_result(shot_idx, result_id);
                 write_reg(shot_idx, instr.dst, select(0u, 1u, result_val));
                 pc++;
@@ -2882,7 +2882,7 @@ fn interpret_classical(@builtin(global_invocation_id) gid: vec3<u32>) {
             // structural and reconstructed by the host, so they remain no-ops.
             case OP_RECORD_OUTPUT {
                 if instr.aux1 == 0u {
-                    let result_id = instr.src0;
+                    let result_id = resolve_u32(shot_idx, instr.src0, flags, 0u);
                     let rec_val = atomicLoad(&results[shot_idx * RESULT_COUNT + result_id]);
                     atomicStore(&results[output_record_base(shot_idx) + instr.aux2], rec_val);
                 } else if instr.aux1 >= 3u {
@@ -2898,7 +2898,7 @@ fn interpret_classical(@builtin(global_invocation_id) gid: vec3<u32>) {
             // so we compare against 2u and write 1u when the result was a loss,
             // else 0u.
             case OP_READ_LOSS {
-                let result_id = instr.src0;
+                let result_id = resolve_u32(shot_idx, instr.src0, flags, 0u);
                 let val = atomicLoad(&results[shot_idx * RESULT_COUNT + result_id]);
                 write_reg(shot_idx, instr.dst, select(0u, 1u, val == 2u));
                 pc++;


### PR DESCRIPTION
This change fixes several GPU adaptive bytecode instructions that did not handle dynamic values correctly. It also corrects how dynamic rotation angles are detected, as the previous check would always return true.

### GPU Adaptive Runtime

- Handle function returns and dynamic result IDs correctly.
- Fix result reads, output recording, and loss reads.
- Fix a flag check that treated every rotation angle as dynamic, including immediate values.

### Tests

- Add CPU and GPU tests that compute a result ID at runtime, then use it to read a measurement, record output, and detect qubit loss.
- Dynamic rotation angles already have CPU and GPU coverage. No new angle test was added because immediate angles still produced correct results; they were only being recomputed unnecessarily at runtime.

