### PR TITLE
Circuit versioning

### DIFF
--- a/source/compiler/qsc_circuit/src/circuit/tests.rs
+++ b/source/compiler/qsc_circuit/src/circuit/tests.rs
@@ -469,3 +469,25 @@ fn classical_controlled_group() {
     "#]]
     .assert_eq(&c.display_with_groups().to_string());
 }
+
+#[test]
+fn typescript_current_version_matches_rust() {
+    let typescript_circuit = include_str!("../../../../npm/qsharp/src/data-structures/circuit.ts");
+    let declaration = typescript_circuit
+        .lines()
+        .find(|line| {
+            line.trim_start()
+                .starts_with("export const CURRENT_VERSION")
+        })
+        .expect("TypeScript circuit schema should declare CURRENT_VERSION");
+    let (_, value) = declaration
+        .split_once('=')
+        .expect("TypeScript CURRENT_VERSION should have a value");
+    let typescript_current_version = value
+        .trim()
+        .trim_end_matches(';')
+        .parse::<usize>()
+        .expect("TypeScript CURRENT_VERSION should be an integer");
+
+    assert_eq!(typescript_current_version, CURRENT_VERSION);
+}

--- a/source/npm/qsharp/src/data-structures/legacyCircuitUpdate.ts
+++ b/source/npm/qsharp/src/data-structures/legacyCircuitUpdate.ts
@@ -42,6 +42,12 @@ export function toCircuitGroup(circuit: any): ToCircuitGroupResult {
 
   if (circuit?.version) {
     const version = circuit.version;
+    if (typeof version === "number" && version > CURRENT_VERSION) {
+      return {
+        ok: false,
+        error: `Circuit file version ${version} is newer than the supported version ${CURRENT_VERSION}. Update the QDK extension to render this circuit.`,
+      };
+    }
     if (isCircuitGroup(circuit)) {
       return { ok: true, circuitGroup: circuit };
     } else if (isCircuit(circuit)) {

--- a/source/npm/qsharp/test/circuit-editor/sqore.test.mjs
+++ b/source/npm/qsharp/test/circuit-editor/sqore.test.mjs
@@ -10,6 +10,7 @@
 
 import { afterEach, test } from "node:test";
 import assert from "node:assert/strict";
+import { CURRENT_VERSION } from "../../dist/ux/circuit-vis/data/circuit.js";
 import { Sqore } from "../../dist/ux/circuit-vis/sqore.js";
 import { circuit, gate, group } from "./_helpers.mjs";
 
@@ -266,4 +267,17 @@ test("updateCircuit: when circuitGroup has multiple circuits, only the first bec
   assert.equal(sqore.circuit, newGroup.circuits[0]);
   // The first circuit had 1 qubit, not 2.
   assert.equal(sqore.circuit.qubits.length, 1);
+});
+
+test("minimizeCircuits: upgrades an older circuit version for saving", () => {
+  const olderGroup = {
+    version: 0,
+    circuits: [circuit(1, [[gate("H", 0)]])],
+  };
+  sqore = new Sqore(olderGroup);
+
+  const savedGroup = sqore.minimizeCircuits(olderGroup);
+
+  assert.equal(savedGroup.version, CURRENT_VERSION);
+  assert.equal(olderGroup.version, 0, "the loaded circuit must not be mutated");
 });

--- a/source/npm/qsharp/ux/circuit-vis/sqore.ts
+++ b/source/npm/qsharp/ux/circuit-vis/sqore.ts
@@ -9,6 +9,7 @@ import {
   Circuit,
   CircuitGroup,
   ComponentGrid,
+  CURRENT_VERSION,
   Operation,
   SourceLocation,
   Qubit,
@@ -641,6 +642,7 @@ export class Sqore {
     const minimizedCircuits: CircuitGroup = JSON.parse(
       JSON.stringify(circuitGroup),
     );
+    minimizedCircuits.version = CURRENT_VERSION;
     minimizedCircuits.circuits.forEach((circuit) => {
       circuit.componentGrid.forEach((col) => {
         col.components.forEach(this.minimizeOperation);


### PR DESCRIPTION
This PR contains some code for circuit versioning:
* Check that the QDK extension annot load circuit with version newer than the circuit version that was used to build the extension. This is because circuit format updates are not forward compatible, and rendering newer circuit with older extension can produce wrong picture. For example, if newer version added additional fields, older extension will ignore them. 
  * The user will see an error message suggesting to update extension. 
  * This only applies to opening `.qsc` files, and does not affect the "Circuit" codelens.
 * Circuit editor, when saving a circuit, automatically bumps circuit version.
 * Added a test that CIRCUIT_VERSION constant is Rust and Typescript is the same.