### PR TITLE
Support write_result operation in adaptive simulators

### DIFF
--- a/source/qdk_package/qdk/_adaptive_bytecode.py
+++ b/source/qdk_package/qdk/_adaptive_bytecode.py
@@ -47,6 +47,7 @@ OP_RECORD_OUTPUT = 0x14
 OP_READ_LOSS = 0x15
 OP_PEEK_LOSS = 0x16
 OP_READOUT_NOISE = 0x17
+OP_WRITE_RESULT = 0x18
 
 # ── Integer Arithmetic ───────────────────────────────────────────────────────
 OP_ADD = 0x20

--- a/source/qdk_package/qdk/_adaptive_pass.py
+++ b/source/qdk_package/qdk/_adaptive_pass.py
@@ -852,6 +852,10 @@ class AdaptiveProfilePass:
                 dst = self._alloc_reg(call, REG_TYPE_BOOL)
                 result_reg = self._resolve_result_operand(call.args[0])
                 self._emit(OP_READ_RESULT, dst=dst, src0=result_reg)
+            case "__quantum__rt__write_result":
+                value = self._resolve_operand(call.args[0])
+                result_reg = self._resolve_result_operand(call.args[1])
+                self._emit(OP_WRITE_RESULT, src0=value, src1=result_reg)
             case "__quantum__rt__result_record_output":
                 result_reg = self._resolve_result_operand(call.args[0])
                 label_str = self._extract_label(call.args[1])

--- a/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_cpu_bytecode.py
@@ -474,6 +474,54 @@ def test_read_result_with_dynamic_result_id(sim_type):
     check_result(DYNAMIC_READ_RESULT_QIR, "11", num_results=2, sim_type=sim_type)
 
 
+WRITE_RESULT_DECL = "declare void @__quantum__rt__write_result(i1, %Result*)"
+
+
+WRITE_RESULT_QIR = """
+entry:
+  call void @__quantum__rt__write_result(i1 true, %Result* inttoptr (i64 0 to %Result*))
+"""
+
+
+WRITE_RESULT_FROM_REGISTER_QIR = """
+entry:
+  %value = icmp eq i64 1, 1
+  call void @__quantum__rt__write_result(i1 %value, %Result* inttoptr (i64 0 to %Result*))
+"""
+
+
+OVERWRITE_RESULT_QIR = """
+entry:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  call void @__quantum__rt__write_result(i1 false, %Result* inttoptr (i64 0 to %Result*))
+"""
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_write_result(sim_type):
+  check_result(
+    WRITE_RESULT_QIR, "1", extra_decls=WRITE_RESULT_DECL, sim_type=sim_type
+  )
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_write_result_from_register(sim_type):
+  check_result(
+    WRITE_RESULT_FROM_REGISTER_QIR,
+    "1",
+    extra_decls=WRITE_RESULT_DECL,
+    sim_type=sim_type,
+  )
+
+
+@pytest.mark.parametrize("sim_type", SIM_TYPES)
+def test_write_result_overwrites_existing_result(sim_type):
+  check_result(
+    OVERWRITE_RESULT_QIR, "0", extra_decls=WRITE_RESULT_DECL, sim_type=sim_type
+  )
+
+
 # =========================================================================
 # OP_RECORD_OUTPUT — output recording
 # =========================================================================

--- a/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
+++ b/source/qdk_package/tests/test_adaptive_gpu_bytecode.py
@@ -493,6 +493,47 @@ def test_read_result_with_dynamic_result_id():
     check_result(DYNAMIC_READ_RESULT_QIR, "11", num_results=2)
 
 
+WRITE_RESULT_DECL = "declare void @__quantum__rt__write_result(i1, %Result*)"
+
+
+WRITE_RESULT_QIR = """
+entry:
+  call void @__quantum__rt__write_result(i1 true, %Result* inttoptr (i64 0 to %Result*))
+"""
+
+
+WRITE_RESULT_FROM_REGISTER_QIR = """
+entry:
+  %value = icmp eq i64 1, 1
+  call void @__quantum__rt__write_result(i1 %value, %Result* inttoptr (i64 0 to %Result*))
+"""
+
+
+OVERWRITE_RESULT_QIR = """
+entry:
+  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+  call void @__quantum__rt__write_result(i1 false, %Result* inttoptr (i64 0 to %Result*))
+"""
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_write_result():
+  check_result(WRITE_RESULT_QIR, "1", extra_decls=WRITE_RESULT_DECL)
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_write_result_from_register():
+  check_result(
+    WRITE_RESULT_FROM_REGISTER_QIR, "1", extra_decls=WRITE_RESULT_DECL
+  )
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason=SKIP_REASON)
+def test_write_result_overwrites_existing_result():
+    check_result(OVERWRITE_RESULT_QIR, "0", extra_decls=WRITE_RESULT_DECL)
+
+
 # =========================================================================
 # OP_RECORD_OUTPUT — output recording
 # =========================================================================

--- a/source/simulators/src/bytecode/runtime.rs
+++ b/source/simulators/src/bytecode/runtime.rs
@@ -51,6 +51,7 @@ const OP_RECORD_OUTPUT: u8 = 0x14;
 const OP_READ_LOSS: u8 = 0x15;
 const OP_PEEK_LOSS: u8 = 0x16;
 const OP_READOUT_NOISE: u8 = 0x17;
+const OP_WRITE_RESULT: u8 = 0x18;
 
 // Integer arithmetic
 const OP_ADD: u8 = 0x20;
@@ -457,6 +458,17 @@ pub fn run_shot<S: Simulator>(program: &AdaptiveProgram<u64>, sim: &mut S) -> Ve
                     0u64
                 };
                 rt.write_reg(instr.dst, val);
+                rt.pc += 1;
+            }
+
+            OP_WRITE_RESULT => {
+                let value = match rt.resolve_u64(instr.src0, flags, 0) {
+                    0 => false,
+                    1 => true,
+                    invalid => panic!("Invalid value for write_result: {invalid}"),
+                };
+                let result_id = rt.resolve_u64(instr.src1, flags, 1) as ResultID;
+                sim.write_result(value, result_id);
                 rt.pc += 1;
             }
 

--- a/source/simulators/src/cpu_full_state_simulator.rs
+++ b/source/simulators/src/cpu_full_state_simulator.rs
@@ -835,4 +835,12 @@ impl Simulator for FullStateSimulator {
         };
         self.measurements[result_id] = new_measurement;
     }
+
+    fn write_result(&mut self, value: bool, result_id: ResultID) {
+        self.measurements[result_id] = if value {
+            MeasurementResult::One
+        } else {
+            MeasurementResult::Zero
+        };
+    }
 }

--- a/source/simulators/src/gpu_full_state_simulator/gpu_statevector_shaders.wgsl
+++ b/source/simulators/src/gpu_full_state_simulator/gpu_statevector_shaders.wgsl
@@ -184,6 +184,7 @@ const OP_RECORD_OUTPUT: u32 = 0x14;
 const OP_READ_LOSS:     u32 = 0x15;
 const OP_PEEK_LOSS:     u32 = 0x16;
 const OP_READOUT_NOISE: u32 = 0x17;
+const OP_WRITE_RESULT:  u32 = 0x18;
 
 // -- Integer Arithmetic -------------------------------------------------------
 const OP_ADD:           u32 = 0x20;
@@ -2869,6 +2870,14 @@ fn interpret_classical(@builtin(global_invocation_id) gid: vec3<u32>) {
                 let result_id = resolve_u32(shot_idx, instr.src0, flags, 0u);
                 let result_val = read_measurement_result(shot_idx, result_id);
                 write_reg(shot_idx, instr.dst, select(0u, 1u, result_val));
+                pc++;
+            }
+
+            // WRITE_RESULT: Writes a boolean value to the result with the given `result_id`.
+            case OP_WRITE_RESULT {
+                let value = resolve_u32(shot_idx, instr.src0, flags, 0u); // value is i1, so it can only be 0 or 1
+                let result_id = resolve_u32(shot_idx, instr.src1, flags, 1u);
+                atomicStore(&results[shot_idx * RESULT_COUNT + result_id], value);
                 pc++;
             }
 

--- a/source/simulators/src/lib.rs
+++ b/source/simulators/src/lib.rs
@@ -137,4 +137,7 @@ pub trait Simulator {
     /// Applies readout noise to the measurement result with the given `result_id`.
     /// The probabilities of flipping a 0 to a 1 and a 1 to a 0 are given by `p_zero_as_one` and `p_one_as_zero`, respectively.
     fn apply_readout_noise(&mut self, p_zero_as_one: f64, p_one_as_zero: f64, result_id: ResultID);
+
+    /// Writes a boolean value to the result with the given `result_id`.
+    fn write_result(&mut self, value: bool, result_id: ResultID);
 }

--- a/source/simulators/src/stabilizer_simulator.rs
+++ b/source/simulators/src/stabilizer_simulator.rs
@@ -793,6 +793,14 @@ impl Simulator for StabilizerSimulator {
         };
         self.measurements[result_id] = new_measurement;
     }
+
+    fn write_result(&mut self, value: bool, result_id: ResultID) {
+        self.measurements[result_id] = if value {
+            MeasurementResult::One
+        } else {
+            MeasurementResult::Zero
+        };
+    }
 }
 
 fn unitary_from_normalized_angle(


### PR DESCRIPTION
Adds adaptive simulator support for `void @__quantum__rt__write_result(i1, ptr)`, following the design proposed in [qir-alliance/qir-spec#65](https://github.com/qir-alliance/qir-spec/issues/65). The operation initializes or overwrites a result identifier with a Boolean value that subsequent reads and output recording observe.

This implementation will be used in a follow-up PR for the STIM compiler, in order to support certain operations that involve writing arbitrary boolean values to measurement records.

## Implementation

- Adds Python, Rust, and GPU bytecode handling for the intrinsic, including dynamically computed Boolean values.
- Implements result writes for the CPU full-state, Clifford, and GPU adaptive simulators.

## Tests

Adds CPU, Clifford, and GPU coverage for constant writes, overwrites, and dynamically computed Boolean values.