### PR TITLE
[QRE] Dollar cost calculator

### DIFF
--- a/samples/qre/dollar_cost.ipynb
+++ b/samples/qre/dollar_cost.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "89fb2f00",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>qubits</th>\n",
+       "      <th>runtime</th>\n",
+       "      <th>error</th>\n",
+       "      <th>USD cost</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32110</td>\n",
+       "      <td>0 days 00:00:00.122500</td>\n",
+       "      <td>0.003948</td>\n",
+       "      <td>122.5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   qubits                runtime     error  USD cost\n",
+       "0   32110 0 days 00:00:00.122500  0.003948     122.5"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from qdk.estimator import LogicalCounts\n",
+    "from qdk.qre import estimate\n",
+    "from qdk.qre.application import QSharpApplication\n",
+    "from qdk.qre.models import GateBased, RoundBasedFactory, SurfaceCode\n",
+    "\n",
+    "app = QSharpApplication(LogicalCounts({\"numQubits\": 100, \"tCount\": 10000, \"cczCount\": 1000, \"measurementCount\": 1000}))\n",
+    "architecture = GateBased(gate_time=50, measurement_time=1000)\n",
+    "architecture.usd_cost_per_hour = 3_600.0 * 1000\n",
+    "\n",
+    "results = estimate(\n",
+    "    app,\n",
+    "    architecture,\n",
+    "    SurfaceCode.q() * RoundBasedFactory.q(),\n",
+    "    max_error=0.01,\n",
+    ")\n",
+    "results.as_frame()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/source/qdk_package/qdk/qre/_architecture.py
+++ b/source/qdk_package/qdk/qre/_architecture.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 from abc import ABC, abstractmethod
+from decimal import Decimal
 from enum import IntEnum
 from typing import TYPE_CHECKING, cast
 
@@ -40,6 +41,11 @@ class Architecture(ABC):
 
     family: TechnologyFamily = TechnologyFamily.UNKNOWN
 
+    # Cost of running application, in USD per hour.
+    # If defined, it's assumed that the cost of running application is proportional to 
+    # the runtime.
+    usd_cost_per_hour: float | None = None
+
     @abstractmethod
     def provided_isa(self, ctx: ISAContext) -> ISA:
         """
@@ -62,6 +68,26 @@ class Architecture(ABC):
             ISAContext: A new enumeration context.
         """
         return ISAContext(self)
+
+    def cost_usd(self, qubits: int, runtime_nanos: int) -> float | None:
+        """Estimates cost, in US dollars, of running an application.
+
+        Subclasses need to define usd_`cost_per_hour` (if USD cost is proportional to 
+        runtime) or override `cost_usd`.
+
+        Args:
+            qubits: estimated number of qubits.
+            runtime_nanos: estimated runtime, in nanoseconds.
+
+        Returns:
+            If there is not enough information to estimate cost, returns None.
+            If application cannot be run on this architecture, returns Infinity.
+            Otherwise, returns estimated cost of running an applicaiton, in dollars.
+        """
+        if self.usd_cost_per_hour is not None:
+            runtime_hours = runtime_nanos / (3600 * 1e9)
+            return round(runtime_hours * self.usd_cost_per_hour, 2)
+        return None
 
     @property
     def assumptions(self) -> list[str]:
@@ -233,6 +259,7 @@ class ISAContext:
 
         self._bindings: dict[str, ISA] = {}
         self._transforms: dict[int, Architecture | ISATransform] = {0: arch}
+        self.arch = arch
 
     def _with_binding(self, name: str, isa: ISA) -> ISAContext:
         """Return a new context with an additional binding (internal use)."""

--- a/source/qdk_package/qdk/qre/_architecture.py
+++ b/source/qdk_package/qdk/qre/_architecture.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import copy
 import dataclasses
 from abc import ABC, abstractmethod
-from decimal import Decimal
 from enum import IntEnum
 from typing import TYPE_CHECKING, cast
 
@@ -42,7 +41,7 @@ class Architecture(ABC):
     family: TechnologyFamily = TechnologyFamily.UNKNOWN
 
     # Cost of running application, in USD per hour.
-    # If defined, it's assumed that the cost of running application is proportional to 
+    # If defined, it's assumed that the cost of running application is proportional to
     # the runtime.
     usd_cost_per_hour: float | None = None
 
@@ -72,7 +71,7 @@ class Architecture(ABC):
     def cost_usd(self, qubits: int, runtime_nanos: int) -> float | None:
         """Estimates cost, in US dollars, of running an application.
 
-        Subclasses need to define usd_`cost_per_hour` (if USD cost is proportional to 
+        Subclasses need to define `usd_cost_per_hour` (if USD cost is proportional to
         runtime) or override `cost_usd`.
 
         Args:
@@ -82,7 +81,7 @@ class Architecture(ABC):
         Returns:
             If there is not enough information to estimate cost, returns None.
             If application cannot be run on this architecture, returns Infinity.
-            Otherwise, returns estimated cost of running an applicaiton, in dollars.
+            Otherwise, returns estimated cost of running an application, in dollars.
         """
         if self.usd_cost_per_hour is not None:
             runtime_hours = runtime_nanos / (3600 * 1e9)

--- a/source/qdk_package/qdk/qre/_architecture.py
+++ b/source/qdk_package/qdk/qre/_architecture.py
@@ -85,7 +85,7 @@ class Architecture(ABC):
         """
         if self.usd_cost_per_hour is not None:
             runtime_hours = runtime_nanos / (3600 * 1e9)
-            return round(runtime_hours * self.usd_cost_per_hour, 2)
+            return runtime_hours * self.usd_cost_per_hour
         return None
 
     @property

--- a/source/qdk_package/qdk/qre/_estimation.py
+++ b/source/qdk_package/qdk/qre/_estimation.py
@@ -301,7 +301,12 @@ def estimate(
     )
 
     if any(e.cost_usd is not None for e in table):
-        table.add_column("USD cost", lambda entry: entry.cost_usd)
+        table.add_column(
+            "USD cost",
+            lambda entry: (
+                round(entry.cost_usd, 2) if entry.cost_usd is not None else None
+            ),
+        )
 
     # Fill in the stats for this estimation run
     table.stats.num_traces = num_traces

--- a/source/qdk_package/qdk/qre/_estimation.py
+++ b/source/qdk_package/qdk/qre/_estimation.py
@@ -300,6 +300,9 @@ def estimate(
         EstimationTableEntry.from_result(result, arch_ctx) for result in collection
     )
 
+    if any(e.cost_usd is not None for e in table):
+        table.add_column("USD cost", lambda entry: entry.cost_usd)
+
     # Fill in the stats for this estimation run
     table.stats.num_traces = num_traces
     table.stats.num_isas = num_isas

--- a/source/qdk_package/qdk/qre/_estimation.py
+++ b/source/qdk_package/qdk/qre/_estimation.py
@@ -303,9 +303,8 @@ def estimate(
     if any(e.cost_usd is not None for e in table):
         table.add_column(
             "USD cost",
-            lambda entry: (
-                round(entry.cost_usd, 2) if entry.cost_usd is not None else None
-            ),
+            lambda entry: entry.cost_usd,
+            formatter=lambda x: round(x, 2) if x is not None else None,
         )
 
     # Fill in the stats for this estimation run

--- a/source/qdk_package/qdk/qre/_results.py
+++ b/source/qdk_package/qdk/qre/_results.py
@@ -213,6 +213,7 @@ class EstimationTableEntry:
             and the number of copies required.
         properties: Additional key-value properties attached to the
             estimation result.
+        cost_usd: Cost of running application, in US dollars.
     """
 
     qubits: int

--- a/source/qdk_package/qdk/qre/_results.py
+++ b/source/qdk_package/qdk/qre/_results.py
@@ -221,6 +221,7 @@ class EstimationTableEntry:
     source: InstructionSource
     factories: dict[int, FactoryResult] = field(default_factory=dict)
     properties: dict[int, int | float | bool | str] = field(default_factory=dict)
+    cost_usd: float | None = None
 
     @classmethod
     def from_result(
@@ -242,6 +243,7 @@ class EstimationTableEntry:
             source=InstructionSource.from_isa(ctx, result.isa),
             factories=result.factories.copy(),
             properties=result.properties.copy(),
+            cost_usd=ctx.arch.cost_usd(result.qubits, result.runtime),
         )
 
 

--- a/source/qdk_package/tests/qre/test_estimation.py
+++ b/source/qdk_package/tests/qre/test_estimation.py
@@ -91,6 +91,23 @@ def test_estimation_max_error():
         assert next(iter(results)).error <= max_error
 
 
+def test_estimation_includes_usd_cost():
+    app = QSharpApplication(LogicalCounts({"numQubits": 1, "measurementCount": 1}))
+    arch = GateBased(gate_time=50, measurement_time=100)
+    arch.usd_cost_per_hour = 3.6e12  # One USD per nanosecond.
+
+    results = estimate(
+        app,
+        arch,
+        SurfaceCode.q() * ExampleFactory.q(),
+        PSSPC.q() * LatticeSurgery.q(),
+    )
+
+    frame = results.as_frame()
+    assert "USD cost" in frame.columns
+    assert frame["USD cost"].tolist() == [results[0].runtime]
+
+
 @pytest.mark.skipif(
     "SLOW_TESTS" not in os.environ,
     reason="turn on slow tests by setting SLOW_TESTS=1 in the environment",

--- a/source/qdk_package/tests/qre/test_estimation.py
+++ b/source/qdk_package/tests/qre/test_estimation.py
@@ -94,7 +94,7 @@ def test_estimation_max_error():
 def test_estimation_includes_usd_cost():
     app = QSharpApplication(LogicalCounts({"numQubits": 1, "measurementCount": 1}))
     arch = GateBased(gate_time=50, measurement_time=100)
-    arch.usd_cost_per_hour = 3.6e12  # One USD per nanosecond.
+    arch.usd_cost_per_hour = 2 * 3600 * 1e9  # 2 USD per nanosecond.
 
     results = estimate(
         app,
@@ -102,10 +102,11 @@ def test_estimation_includes_usd_cost():
         SurfaceCode.q() * ExampleFactory.q(),
         PSSPC.q() * LatticeSurgery.q(),
     )
+    assert results[0].runtime == 1050
 
     frame = results.as_frame()
     assert "USD cost" in frame.columns
-    assert frame["USD cost"].tolist() == [results[0].runtime]
+    assert frame["USD cost"].tolist() == [2100.0]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR adds capability to Quantum Resource Estimator to compute monetary cost (in USD) of running an application.

User needs to specify how to compute USD cost for a specific Architecture, as a function of qubits and runtime. This can be done in multiple ways:
* Setting field `usd_cost_per_hour` on Architecture object (see demo notebook). In this case it's assumed that the cost is proportional to runtime.
* When using `@qubit` decorator, adding `usd_cost_per_hour = ...`.
* Overriding function `cost_usd` on subclass of `Architecture`.

In the resource estimator, if cost can be computed for at least one of estimates in the table, the table will have an additional column "USD cost", with estimated cost of running the application, rounded to 2 decimal digits.