### PR TITLE
Sanitize HTML in our VS Code panels

### DIFF
--- a/katas/content/linear_algebra/index.md
+++ b/katas/content/linear_algebra/index.md
@@ -219,7 +219,7 @@ A square matrix has a property called the **determinant**, with the determinant 
 
 For a $2 \times 2$ matrix $A$, the determinant is defined as $|A| = A_{0,0} \cdot A_{1,1} - A_{0,1} \cdot A_{1,0}$.
 
-For larger matrices, the determinant is defined through determinants of sub-matrices. You can learn more about the determinant of matrices from [Wikipedia](https://en.wikipedia.org/wiki/Determinant) or from [Wolfram MathWorld](http://mathworld.wolfram.com/Determinant.html).
+For larger matrices, the determinant is defined through determinants of sub-matrices. You can learn more about the determinant of matrices from [Wikipedia](https://en.wikipedia.org/wiki/Determinant) or from [Wolfram MathWorld](https://mathworld.wolfram.com/Determinant.html).
 
 @[exercise]({ 
     "id": "linear_algebra__inverse_matrix_ex", 

--- a/source/playground/src/main.tsx
+++ b/source/playground/src/main.tsx
@@ -58,12 +58,13 @@ import {
   decodeGatesUrl,
 } from "qsharp-lang/ux";
 
-const md = markdownIt("commonmark");
+import DOMPurify from "dompurify";
+const md = markdownIt("commonmark", { html: false });
 md.use((mk as any).default, {
   enableMathBlockInHtml: true,
   enableMathInlineInHtml: true,
 }); // Not sure why it's not using the default export automatically :-/
-setRenderer((input: string) => md.render(input));
+setRenderer((input: string) => DOMPurify.sanitize(md.render(input)));
 
 export type ActiveTab =
   | "results-tab"

--- a/source/playground/src/main.tsx
+++ b/source/playground/src/main.tsx
@@ -64,7 +64,12 @@ md.use((mk as any).default, {
   enableMathBlockInHtml: true,
   enableMathInlineInHtml: true,
 }); // Not sure why it's not using the default export automatically :-/
-setRenderer((input: string) => DOMPurify.sanitize(md.render(input)));
+// Allow only the protocols used in doc/kata/estimator content
+// Borrowed from DOMPurify and filtered to our protocols
+const ALLOWED_URI = /^(?:(?:https|xref):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i;
+setRenderer((input: string) =>
+  DOMPurify.sanitize(md.render(input), { ALLOWED_URI_REGEXP: ALLOWED_URI }),
+);
 
 export type ActiveTab =
   | "results-tab"

--- a/source/playground/src/main.tsx
+++ b/source/playground/src/main.tsx
@@ -59,7 +59,7 @@ import {
 } from "qsharp-lang/ux";
 
 import DOMPurify from "dompurify";
-const md = markdownIt("commonmark", { html: false });
+const md = markdownIt("commonmark");
 md.use((mk as any).default, {
   enableMathBlockInHtml: true,
   enableMathInlineInHtml: true,

--- a/source/vscode/src/webview/help.tsx
+++ b/source/vscode/src/webview/help.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef } from "preact/hooks";
 
-declare const resourcesUri: string; // Set by the HTML in the window
+const resourcesUri = document.body.dataset.resourcesUri ?? "";
 
 let svgPromise: Promise<Response>;
 

--- a/source/vscode/src/webview/help.tsx
+++ b/source/vscode/src/webview/help.tsx
@@ -3,8 +3,6 @@
 
 import { useEffect, useRef } from "preact/hooks";
 
-const resourcesUri = document.body.dataset.resourcesUri ?? "";
-
 let svgPromise: Promise<Response>;
 
 export function HelpPage() {
@@ -14,6 +12,7 @@ export function HelpPage() {
 
   // Ensure that the fetch is kicked off once for the module
   if (!svgPromise) {
+    const resourcesUri = document.body.dataset.resourcesUri ?? "";
     svgPromise = fetch(`${resourcesUri}/DebugDropDown.svg`);
   }
 

--- a/source/vscode/src/webview/webview.tsx
+++ b/source/vscode/src/webview/webview.tsx
@@ -20,16 +20,17 @@ import { HelpPage } from "./help";
 import { DocumentationView, IDocFile } from "./docview";
 import "./webview.css";
 
+import DOMPurify from "dompurify";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - there are no types for this
 import mk from "@vscode/markdown-it-katex";
 import markdownIt from "markdown-it";
-const md = markdownIt("commonmark");
+const md = markdownIt("commonmark", { html: false });
 md.use(mk, {
   enableMathBlockInHtml: true,
   enableMathInlineInHtml: true,
 });
-setRenderer((input: string) => md.render(input));
+setRenderer((input: string) => DOMPurify.sanitize(md.render(input)));
 
 window.addEventListener("message", onMessage);
 window.addEventListener("load", main);

--- a/source/vscode/src/webview/webview.tsx
+++ b/source/vscode/src/webview/webview.tsx
@@ -30,7 +30,12 @@ md.use(mk, {
   enableMathBlockInHtml: true,
   enableMathInlineInHtml: true,
 });
-setRenderer((input: string) => DOMPurify.sanitize(md.render(input)));
+// Allow only the protocols used in doc/kata/estimator content
+// Borrowed from DOMPurify and filtered to our protocols
+const ALLOWED_URI = /^(?:(?:https|xref):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i;
+setRenderer((input: string) =>
+  DOMPurify.sanitize(md.render(input), { ALLOWED_URI_REGEXP: ALLOWED_URI }),
+);
 
 window.addEventListener("message", onMessage);
 window.addEventListener("load", main);

--- a/source/vscode/src/webviewPanel.ts
+++ b/source/vscode/src/webviewPanel.ts
@@ -344,7 +344,7 @@ export class QSharpWebViewPanel {
     <head>
       <meta charset="UTF-8">
       <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; img-src ${cspSource}; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource}; script-src ${cspSource};" />
+        content="default-src 'none'; img-src ${cspSource}; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource}; script-src ${cspSource}; connect-src ${cspSource};" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Q#</title>
       <link rel="stylesheet" href="${githubCss}" />

--- a/source/vscode/src/webviewPanel.ts
+++ b/source/vscode/src/webviewPanel.ts
@@ -336,23 +336,24 @@ export class QSharpWebViewPanel {
     const webviewCss = getUri(["out", "webview", "webview.css"]);
     const webviewJs = getUri(["out", "webview", "webview.js"]);
     const resourcesUri = getUri(["resources"]);
+    const cspSource = webview.cspSource;
 
     return /*html*/ `
   <!DOCTYPE html>
   <html lang="en">
     <head>
       <meta charset="UTF-8">
+      <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; img-src ${cspSource}; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource}; script-src ${cspSource};" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Q#</title>
       <link rel="stylesheet" href="${githubCss}" />
       <link rel="stylesheet" href="${katexCss}" />
       <link rel="stylesheet" href="${webviewCss}" />
       <script src="${webviewJs}"></script>
-      <script>
-        window.resourcesUri = "${resourcesUri.toString()}";
-      </script>
     </head>
-    <body>
+    <!-- Share this URI with the help panel via attribute so we don't need a script (which would be blocked) -->
+    <body data-resources-uri="${resourcesUri.toString()}">
     </body>
   </html>
 `;


### PR DESCRIPTION
We don't expect our extension to be activated unless the user has explicitly trusted the workspace, but it's good defence in depth to sanitize the HTML anyway.  The affected panels are:
- API Documentation
- Estimates
- Histogram
- Circuit
- Help

Bonus: sanitize in the playground too.  It only loads content we've authored, but it seemed preferable to be consistent (and may protect us from automated security scans in the future).