### PR TITLE
Added lattices for 2nd nearest neighbor connections.

### DIFF
--- a/source/qdk_package/qdk/applications/magnets/geometry/__init__.py
+++ b/source/qdk_package/qdk/applications/magnets/geometry/__init__.py
@@ -9,14 +9,16 @@ and interaction graphs.
 """
 
 from .complete import CompleteBipartiteGraph, CompleteGraph
-from .lattice1d import Chain1D, Ring1D
-from .lattice2d import Patch2D, Torus2D
+from .lattice1d import Chain1D, MthNearestNeighborChain1D, Ring1D
+from .lattice2d import Patch2D, SecondNearestNeighborPatch2D, Torus2D
 
 __all__ = [
     "CompleteBipartiteGraph",
     "CompleteGraph",
     "Chain1D",
+    "MthNearestNeighborChain1D",
     "Ring1D",
     "Patch2D",
+    "SecondNearestNeighborPatch2D",
     "Torus2D",
 ]

--- a/source/qdk_package/qdk/applications/magnets/geometry/lattice1d.py
+++ b/source/qdk_package/qdk/applications/magnets/geometry/lattice1d.py
@@ -72,6 +72,58 @@ class Chain1D(Hypergraph):
         return coloring
 
 
+class MthNearestNeighborChain1D(Hypergraph):
+    """An open chain with connections through the m-th nearest neighbor.
+
+    Each edge is marked with one less than its neighbor distance. For example,
+    edges between adjacent vertices have mark 0, and next-nearest-neighbor
+    edges have mark 1.
+
+    Attributes:
+        length: Number of vertices in the chain.
+        m: Maximum neighbor distance included in the chain.
+    """
+
+    def __init__(self, length: int, m: int, self_loops: bool = False) -> None:
+        """Initialize an m-th nearest-neighbor 1D chain.
+
+        Args:
+            length: Number of vertices in the chain.
+            m: Maximum neighbor distance to connect.
+            self_loops: If True, include self-loop edges on each vertex
+                for single-site terms.
+        """
+        if self_loops:
+            _edges = [Hyperedge([i]) for i in range(length)]
+        else:
+            _edges = []
+
+        for distance in range(1, min(m, length - 1) + 1):
+            for i in range(length - distance):
+                edge = Hyperedge([i, i + distance])
+                edge.mark = distance - 1
+                _edges.append(edge)
+
+        super().__init__(_edges)
+        self.length = length
+        self.m = m
+
+    def edge_coloring(
+        self, seed: Optional[int] = 0, trials: int = 1
+    ) -> HypergraphEdgeColoring:
+        """Color each neighbor distance with two alternating colors."""
+        coloring = HypergraphEdgeColoring(self)
+        for edge in self.edges():
+            if len(edge.vertices) == 1:
+                coloring.add_edge(edge, -1)
+            else:
+                i, j = edge.vertices
+                distance = j - i
+                color = 2 * (distance - 1) + (i // distance) % 2
+                coloring.add_edge(edge, color)
+        return coloring
+
+
 class Ring1D(Hypergraph):
     """A one-dimensional ring (periodic chain) lattice.
 

--- a/source/qdk_package/qdk/applications/magnets/geometry/lattice2d.py
+++ b/source/qdk_package/qdk/applications/magnets/geometry/lattice2d.py
@@ -99,6 +99,65 @@ class Patch2D(Hypergraph):
         return coloring
 
 
+class SecondNearestNeighborPatch2D(Patch2D):
+    """An open rectangular lattice with orthogonal and diagonal edges.
+
+    Orthogonal nearest-neighbor edges have mark 0. Diagonal second-nearest-
+    neighbor edges have mark 1. Vertices use the same row-major indexing as
+    :class:`Patch2D`.
+    """
+
+    def __init__(self, width: int, height: int, self_loops: bool = False) -> None:
+        """Initialize a 2D patch with first- and second-neighbor edges.
+
+        Args:
+            width: Number of vertices in the horizontal direction.
+            height: Number of vertices in the vertical direction.
+            self_loops: If True, include unmarked self-loop edges on each
+                vertex for single-site terms.
+        """
+        super().__init__(width, height, self_loops)
+
+        for edge in self.edges():
+            if len(edge.vertices) == 2:
+                edge.mark = 0
+
+        for y in range(height - 1):
+            for x in range(width - 1):
+                downward = Hyperedge([self._index(x, y), self._index(x + 1, y + 1)])
+                downward.mark = 1
+                self.add_edge(downward)
+
+                upward = Hyperedge([self._index(x + 1, y), self._index(x, y + 1)])
+                upward.mark = 1
+                self.add_edge(upward)
+
+    def edge_coloring(
+        self, seed: Optional[int] = 0, trials: int = 1
+    ) -> HypergraphEdgeColoring:
+        """Color orthogonal and diagonal edges by direction and parity."""
+        coloring = HypergraphEdgeColoring(self)
+        for edge in self.edges():
+            if len(edge.vertices) == 1:
+                coloring.add_edge(edge, -1)
+                continue
+
+            u, v = edge.vertices
+            x_u, y_u = u % self.width, u // self.width
+            x_v, y_v = v % self.width, v // self.width
+
+            if y_u == y_v:
+                color = min(x_u, x_v) % 2
+            elif x_u == x_v:
+                color = 2 + min(y_u, y_v) % 2
+            elif x_u < x_v:
+                color = 4 + x_u % 2
+            else:
+                color = 6 + x_v % 2
+            coloring.add_edge(edge, color)
+        return coloring
+
+
 class Torus2D(Hypergraph):
     """A two-dimensional toroidal (periodic) lattice.
 

--- a/source/qdk_package/qdk/applications/magnets/models/model.py
+++ b/source/qdk_package/qdk/applications/magnets/models/model.py
@@ -157,12 +157,13 @@ class IsingModel(Model):
         H = -J * Σ_{<i,j>} Z_i Z_j - h * Σ_i X_i
 
     - Single-vertex edges define X-field terms with coefficient ``-h``.
-    - Two-vertex edges define ZZ-coupling terms with coefficient ``-J``.
+        - Two-vertex edges define ZZ-coupling terms with coefficient ``-J``. If
+            ``J`` is a list, each edge's zero-based mark selects its coupling.
     - Terms are grouped into two groups: ``0`` for field terms and ``1`` for
       coupling terms.
     """
 
-    def __init__(self, geometry: Hypergraph, h: float, J: float):
+    def __init__(self, geometry: Hypergraph, h: float, J: float | list[float]):
         super().__init__(geometry)
         self.h = h
         self.J = J
@@ -177,7 +178,19 @@ class IsingModel(Model):
                 color = coloring.color(edge.vertices)
                 if color is None:
                     raise ValueError("Geometry edge coloring failed to assign a color.")
-                self.add_interaction(edge, "ZZ", -J, term=1, color=color)
+                if isinstance(J, list):
+                    if edge.mark is None:
+                        raise ValueError(
+                            "All coupling edges must be marked when J is a list."
+                        )
+                    if edge.mark < 0 or edge.mark >= len(J):
+                        raise ValueError(
+                            f"Edge mark {edge.mark} is outside the range of J."
+                        )
+                    coupling = J[edge.mark]
+                else:
+                    coupling = J
+                self.add_interaction(edge, "ZZ", -coupling, term=1, color=color)
 
     def __str__(self) -> str:
         return (
@@ -198,11 +211,13 @@ class HeisenbergModel(Model):
     The Hamiltonian is:
         H = -J * Σ_{<i,j>} (X_i X_j + Y_i Y_j + Z_i Z_j)
 
-    - Two-vertex edges define XX, YY, and ZZ coupling terms with coefficient ``-J``.
+        - Two-vertex edges define XX, YY, and ZZ coupling terms with coefficient
+            ``-J``. If ``J`` is a list, each edge's zero-based mark selects its
+            coupling.
     - Terms are grouped into three parts: ``0`` for XX, ``1`` for YY, and ``2`` for ZZ.
     """
 
-    def __init__(self, geometry: Hypergraph, J: float):
+    def __init__(self, geometry: Hypergraph, J: float | list[float]):
         super().__init__(geometry)
         self.J = J
         self.coloring: HypergraphEdgeColoring = geometry.edge_coloring()
@@ -213,9 +228,21 @@ class HeisenbergModel(Model):
                 color = self.coloring.color(edge.vertices)
                 if color is None:
                     raise ValueError("Geometry edge coloring failed to assign a color.")
-                self.add_interaction(edge, "XX", -J, term=0, color=color)
-                self.add_interaction(edge, "YY", -J, term=1, color=color)
-                self.add_interaction(edge, "ZZ", -J, term=2, color=color)
+                if isinstance(J, list):
+                    if edge.mark is None:
+                        raise ValueError(
+                            "All coupling edges must be marked when J is a list."
+                        )
+                    if edge.mark < 0 or edge.mark >= len(J):
+                        raise ValueError(
+                            f"Edge mark {edge.mark} is outside the range of J."
+                        )
+                    coupling = J[edge.mark]
+                else:
+                    coupling = J
+                self.add_interaction(edge, "XX", -coupling, term=0, color=color)
+                self.add_interaction(edge, "YY", -coupling, term=1, color=color)
+                self.add_interaction(edge, "ZZ", -coupling, term=2, color=color)
 
     def __str__(self) -> str:
         return (

--- a/source/qdk_package/qdk/applications/magnets/utilities/hypergraph.py
+++ b/source/qdk_package/qdk/applications/magnets/utilities/hypergraph.py
@@ -27,6 +27,7 @@ class Hyperedge:
 
     Attributes:
         vertices: Sorted tuple of vertex indices connected by this hyperedge.
+        mark: Optional marker or label for the hyperedge, can be used for coloring or other annotations.
 
     Example:
 
@@ -43,6 +44,7 @@ class Hyperedge:
             vertices: List of vertex indices. Will be sorted internally.
         """
         self.vertices: tuple[int, ...] = tuple(sorted(set(vertices)))
+        self.mark: Optional[int] = None
 
     def __str__(self) -> str:
         return str(self.vertices)

--- a/source/qdk_package/tests/applications/magnets/test_hypergraph.py
+++ b/source/qdk_package/tests/applications/magnets/test_hypergraph.py
@@ -24,6 +24,19 @@ def test_hyperedge_init_basic():
     assert edge.vertices == (0, 1)
 
 
+def test_hyperedge_mark_defaults_to_none():
+    """Test that a hyperedge is unmarked by default."""
+    edge = Hyperedge([0, 1])
+    assert edge.mark is None
+
+
+def test_hyperedge_mark_can_be_set_to_integer():
+    """Test assigning an integer mark to a hyperedge."""
+    edge = Hyperedge([0, 1])
+    edge.mark = 0
+    assert edge.mark == 0
+
+
 def test_hyperedge_vertices_sorted():
     """Test that vertices are automatically sorted."""
     edge = Hyperedge([3, 1, 2])

--- a/source/qdk_package/tests/applications/magnets/test_lattice1d.py
+++ b/source/qdk_package/tests/applications/magnets/test_lattice1d.py
@@ -11,6 +11,7 @@ from qdk.applications.magnets import (
     Chain1D,
     Hypergraph,
     HypergraphEdgeColoring,
+    MthNearestNeighborChain1D,
     Ring1D,
 )
 
@@ -128,6 +129,112 @@ def test_chain1d_str():
     chain = Chain1D(4)
     assert "4 vertices" in str(chain)
     assert "3 edges" in str(chain)
+
+
+# MthNearestNeighborChain1D tests
+
+
+def test_mth_nearest_neighbor_chain1d_init_basic():
+    """Test basic m-th nearest-neighbor chain initialization."""
+    chain = MthNearestNeighborChain1D(5, 2)
+    assert chain.nvertices == 5
+    assert chain.nedges == 7
+    assert chain.length == 5
+    assert chain.m == 2
+
+
+def test_mth_nearest_neighbor_chain1d_edges_and_marks():
+    """Test that edges through distance m are created and marked."""
+    chain = MthNearestNeighborChain1D(5, 2)
+    edge_marks = {edge.vertices: edge.mark for edge in chain.edges()}
+    assert edge_marks == {
+        (0, 1): 0,
+        (1, 2): 0,
+        (2, 3): 0,
+        (3, 4): 0,
+        (0, 2): 1,
+        (1, 3): 1,
+        (2, 4): 1,
+    }
+
+
+def test_mth_nearest_neighbor_chain1d_m_one_matches_chain1d():
+    """Test that range one has the same edges as a nearest-neighbor chain."""
+    chain = MthNearestNeighborChain1D(4, 1)
+    edge_vertices = {edge.vertices for edge in chain.edges()}
+    assert edge_vertices == {(0, 1), (1, 2), (2, 3)}
+    assert all(edge.mark == 0 for edge in chain.edges())
+
+
+def test_mth_nearest_neighbor_chain1d_with_self_loops():
+    """Test that optional self-loops remain unmarked."""
+    chain = MthNearestNeighborChain1D(4, 2, self_loops=True)
+    self_loops = {
+        edge.vertices: edge.mark for edge in chain.edges() if len(edge.vertices) == 1
+    }
+    assert self_loops == {(0,): None, (1,): None, (2,): None, (3,): None}
+    assert chain.nedges == 9
+
+
+def test_mth_nearest_neighbor_chain1d_m_exceeds_length():
+    """Test that the interaction range is limited by the chain length."""
+    chain = MthNearestNeighborChain1D(4, 10)
+    edge_vertices = {edge.vertices for edge in chain.edges()}
+    assert edge_vertices == {
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (1, 2),
+        (1, 3),
+        (2, 3),
+    }
+
+
+def test_mth_nearest_neighbor_chain1d_coloring():
+    """Test that each distance uses two alternating colors."""
+    chain = MthNearestNeighborChain1D(7, 3)
+    assert isinstance(chain, Hypergraph)
+    coloring = chain.edge_coloring()
+    assert isinstance(coloring, HypergraphEdgeColoring)
+    assert _vertex_color_map(chain) == {
+        (0, 1): 0,
+        (1, 2): 1,
+        (2, 3): 0,
+        (3, 4): 1,
+        (4, 5): 0,
+        (5, 6): 1,
+        (0, 2): 2,
+        (1, 3): 2,
+        (2, 4): 3,
+        (3, 5): 3,
+        (4, 6): 2,
+        (0, 3): 4,
+        (1, 4): 4,
+        (2, 5): 4,
+        (3, 6): 5,
+    }
+
+
+def test_mth_nearest_neighbor_chain1d_coloring_is_valid():
+    """Test that same-color range-neighbor edges do not overlap."""
+    chain = MthNearestNeighborChain1D(8, 3)
+    coloring = chain.edge_coloring()
+    for color in coloring.colors():
+        used_vertices = set()
+        for edge in coloring.edges_of_color(color):
+            assert used_vertices.isdisjoint(edge.vertices)
+            used_vertices.update(edge.vertices)
+
+
+def test_mth_nearest_neighbor_chain1d_coloring_with_self_loops():
+    """Test that self-loops use the special negative color."""
+    chain = MthNearestNeighborChain1D(4, 2, self_loops=True)
+    coloring = chain.edge_coloring()
+    assert all(
+        coloring.color(edge.vertices) == -1
+        for edge in chain.edges()
+        if len(edge.vertices) == 1
+    )
 
 
 # Ring1D tests

--- a/source/qdk_package/tests/applications/magnets/test_lattice2d.py
+++ b/source/qdk_package/tests/applications/magnets/test_lattice2d.py
@@ -11,6 +11,7 @@ from qdk.applications.magnets import (
     Hypergraph,
     HypergraphEdgeColoring,
     Patch2D,
+    SecondNearestNeighborPatch2D,
     Torus2D,
 )
 
@@ -143,6 +144,54 @@ def test_patch2d_str():
     """Test string representation."""
     patch = Patch2D(3, 2)
     assert str(patch) == "3x2 lattice patch with 6 vertices and 7 edges"
+
+
+# SecondNearestNeighborPatch2D tests
+
+
+def test_second_nearest_neighbor_patch2d_edges_and_marks():
+    """Test orthogonal and diagonal edges and their marks."""
+    patch = SecondNearestNeighborPatch2D(2, 2)
+    edge_marks = {edge.vertices: edge.mark for edge in patch.edges()}
+    assert edge_marks == {
+        (0, 1): 0,
+        (0, 2): 0,
+        (1, 3): 0,
+        (2, 3): 0,
+        (0, 3): 1,
+        (1, 2): 1,
+    }
+
+
+def test_second_nearest_neighbor_patch2d_edge_count():
+    """Test that every cell contributes two diagonal edges."""
+    patch = SecondNearestNeighborPatch2D(4, 3)
+    assert patch.nvertices == 12
+    assert patch.nedges == 29
+    assert patch.width == 4
+    assert patch.height == 3
+
+
+def test_second_nearest_neighbor_patch2d_with_self_loops():
+    """Test that optional self-loops remain unmarked."""
+    patch = SecondNearestNeighborPatch2D(2, 2, self_loops=True)
+    self_loops = {
+        edge.vertices: edge.mark for edge in patch.edges() if len(edge.vertices) == 1
+    }
+    assert self_loops == {(0,): None, (1,): None, (2,): None, (3,): None}
+    assert patch.nedges == 10
+
+
+def test_second_nearest_neighbor_patch2d_coloring_is_valid():
+    """Test that same-color orthogonal and diagonal edges do not overlap."""
+    patch = SecondNearestNeighborPatch2D(5, 4)
+    coloring = patch.edge_coloring()
+    assert coloring.ncolors == 8
+    for color in coloring.colors():
+        used_vertices = set()
+        for edge in coloring.edges_of_color(color):
+            assert used_vertices.isdisjoint(edge.vertices)
+            used_vertices.update(edge.vertices)
 
 
 # Torus2D tests

--- a/source/qdk_package/tests/applications/magnets/test_model.py
+++ b/source/qdk_package/tests/applications/magnets/test_model.py
@@ -16,6 +16,7 @@ from qdk.applications.magnets import (
     Hyperedge,
     Hypergraph,
     IsingModel,
+    MthNearestNeighborChain1D,
     Model,
     PauliString,
 )
@@ -198,6 +199,35 @@ def test_ising_model_coefficients_and_paulis():
     assert ops_by_qubits[(2,)] == PauliString.from_qubits((2,), "X", -0.5)
 
 
+def test_ising_model_uses_edge_marks_to_select_couplings():
+    geometry = MthNearestNeighborChain1D(4, 2, self_loops=True)
+    model = IsingModel(geometry, h=0.5, J=[2.0, 0.75])
+
+    ops_by_qubits = {tuple(sorted(op.qubits)): op for op in model._ops}
+
+    assert ops_by_qubits[(0, 1)].coefficient == -2.0
+    assert ops_by_qubits[(1, 2)].coefficient == -2.0
+    assert ops_by_qubits[(2, 3)].coefficient == -2.0
+    assert ops_by_qubits[(0, 2)].coefficient == -0.75
+    assert ops_by_qubits[(1, 3)].coefficient == -0.75
+
+
+def test_ising_model_rejects_unmarked_edges_with_coupling_list():
+    geometry = make_chain(2)
+
+    with pytest.raises(ValueError, match="coupling edges must be marked"):
+        IsingModel(geometry, h=1.0, J=[2.0])
+
+
+def test_ising_model_rejects_edge_mark_outside_coupling_list():
+    edge = Hyperedge([0, 1])
+    edge.mark = 1
+    geometry = Hypergraph([edge])
+
+    with pytest.raises(ValueError, match="Edge mark 1 is outside the range of J"):
+        IsingModel(geometry, h=1.0, J=[2.0])
+
+
 def test_ising_model_term_grouping_indices():
     geometry = make_chain_with_vertices(4)
     model = IsingModel(geometry, h=1.0, J=1.0)
@@ -239,6 +269,33 @@ def test_heisenberg_model_coefficients_and_paulis():
     ]
     for pauli in expected:
         assert pauli in model._ops
+
+
+def test_heisenberg_model_uses_edge_marks_to_select_couplings():
+    geometry = MthNearestNeighborChain1D(4, 2)
+    model = HeisenbergModel(geometry, J=[2.0, 0.75])
+
+    for pauli in ("XX", "YY", "ZZ"):
+        for vertices in ((0, 1), (1, 2), (2, 3)):
+            assert PauliString.from_qubits(vertices, pauli, -2.0) in model._ops
+        for vertices in ((0, 2), (1, 3)):
+            assert PauliString.from_qubits(vertices, pauli, -0.75) in model._ops
+
+
+def test_heisenberg_model_rejects_unmarked_edges_with_coupling_list():
+    geometry = make_chain(2)
+
+    with pytest.raises(ValueError, match="coupling edges must be marked"):
+        HeisenbergModel(geometry, J=[2.0])
+
+
+def test_heisenberg_model_rejects_edge_mark_outside_coupling_list():
+    edge = Hyperedge([0, 1])
+    edge.mark = 1
+    geometry = Hypergraph([edge])
+
+    with pytest.raises(ValueError, match="Edge mark 1 is outside the range of J"):
+        HeisenbergModel(geometry, J=[2.0])
 
 
 def test_heisenberg_model_term_grouping_colors_and_paulis():


### PR DESCRIPTION
Added two classes extending Chain1D and Patch1D to nearest neighbor connections.

- Added edge marking in Hypergraph library for additional functionality (distance of vertices in this case)
- In one dimension the user can specify m-th nearest neighbor connections for any m.
- In two dimension only second nearest neighbor connections are supported (across the diagonal of the 2d grid).
- Deterministic edge coloring is supported on both classes.
- Expanded IsingModel class and HeisenbergModel class to accept different interaction strengths according to distance.
- Unit tests added.