### PR TITLE
Fix Learning notebook autosave

### DIFF
--- a/source/vscode/src/learning/commands.ts
+++ b/source/vscode/src/learning/commands.ts
@@ -294,6 +294,15 @@ async function openCourseNotebook(
       const envPath = await service.getJupyterEnvironmentPath(courseId);
       if (envPath) {
         await api.openNotebook(notebookUri, envPath);
+        const document = vscode.workspace.notebookDocuments.find(
+          (notebook) => notebook.uri.toString() === notebookUri.toString(),
+        );
+        if (document) {
+          await vscode.window.showNotebookDocument(document, {
+            viewColumn: vscode.ViewColumn.Active,
+            preview: false,
+          });
+        }
         opened = true;
       } else {
         log.info("Didn't find a course virtual environment to use in notebook");
@@ -325,15 +334,6 @@ async function openCourseNotebook(
     revealNotebookTop(notebookUri);
   } else if (cellId) {
     revealNotebookCell(notebookUri, cellId);
-  }
-
-  // The notebook may appear dirty immediately after opening (e.g. cell
-  // language adjustments). Save so the user starts with a clean state.
-  const doc = vscode.workspace.notebookDocuments.find(
-    (n) => n.uri.toString() === notebookUri.toString(),
-  );
-  if (doc?.isDirty) {
-    await doc.save();
   }
 }
 

--- a/source/vscode/src/learning/commands.ts
+++ b/source/vscode/src/learning/commands.ts
@@ -294,15 +294,6 @@ async function openCourseNotebook(
       const envPath = await service.getJupyterEnvironmentPath(courseId);
       if (envPath) {
         await api.openNotebook(notebookUri, envPath);
-        const document = vscode.workspace.notebookDocuments.find(
-          (notebook) => notebook.uri.toString() === notebookUri.toString(),
-        );
-        if (document) {
-          await vscode.window.showNotebookDocument(document, {
-            viewColumn: vscode.ViewColumn.Active,
-            preview: false,
-          });
-        }
         opened = true;
       } else {
         log.info("Didn't find a course virtual environment to use in notebook");

--- a/source/vscode/src/learning/index.ts
+++ b/source/vscode/src/learning/index.ts
@@ -43,8 +43,7 @@ export function initLearning(
   );
   context.subscriptions.push(
     vscode.workspace.onDidChangeNotebookDocument((e) => {
-      // Jupyter updates workbook metadata after selecting or starting a
-      // kernel. Save in response to the update instead of racing it on open.
+      // Save after cell execution and update exercise completion.
       if (!learningService.isCourseWorkbook(e.notebook.uri)) {
         return;
       }
@@ -70,7 +69,7 @@ export function initLearning(
           }
         }
       }
-      if (e.metadata !== undefined || hasExecutionChange) {
+      if (hasExecutionChange) {
         // Moving between notebooks is clumsy when they're unsaved.  Since this
         // is a working copy we created on the user's behalf, we're free to
         // auto-save.

--- a/source/vscode/src/learning/index.ts
+++ b/source/vscode/src/learning/index.ts
@@ -12,9 +12,7 @@ import { createNotebookCellStatusBarProvider } from "./notebookCellStatusBar.js"
 import { registerNotebookSync } from "./notebookSync.js";
 import { registerLearningProgressView } from "./progressTreeView.js";
 import { LearningService } from "./service.js";
-import { WORKBOOK_SUFFIX } from "./constants.js";
 import { registerLearningWelcomeView } from "./welcomeView.js";
-import { isNotebookCourse } from "./courseLayout.js";
 
 export function initLearning(
   context: vscode.ExtensionContext,
@@ -45,15 +43,9 @@ export function initLearning(
   );
   context.subscriptions.push(
     vscode.workspace.onDidChangeNotebookDocument((e) => {
-      // When a cell finishes executing (executionSummary changes), auto-save
-      // the notebook, check if it corresponds to an exercise in the active
-      // python-notebook course and update focus. If execution succeeded,
-      // mark complete.
-      if (
-        !learningService.initialized ||
-        !isNotebookCourse(learningService.getActiveCourseInfo()) ||
-        !e.notebook.uri.path.endsWith(WORKBOOK_SUFFIX)
-      ) {
+      // Jupyter updates workbook metadata after selecting or starting a
+      // kernel. Save in response to the update instead of racing it on open.
+      if (!learningService.isCourseWorkbook(e.notebook.uri)) {
         return;
       }
 
@@ -78,11 +70,11 @@ export function initLearning(
           }
         }
       }
-      if (hasExecutionChange) {
+      if (e.metadata !== undefined || hasExecutionChange) {
         // Moving between notebooks is clumsy when they're unsaved.  Since this
         // is a working copy we created on the user's behalf, we're free to
         // auto-save.
-        void e.notebook.save();
+        void learningService.saveCourseWorkbook(e.notebook);
       }
     }),
   );

--- a/source/vscode/src/learning/index.ts
+++ b/source/vscode/src/learning/index.ts
@@ -43,15 +43,13 @@ export function initLearning(
   );
   context.subscriptions.push(
     vscode.workspace.onDidChangeNotebookDocument((e) => {
-      // Save after cell execution and update exercise completion.
+      // Track cell execution and update exercise completion.
       if (!learningService.isCourseWorkbook(e.notebook.uri)) {
         return;
       }
 
-      let hasExecutionChange = false;
       for (const change of e.cellChanges) {
         if (change.executionSummary !== undefined) {
-          hasExecutionChange = true;
           const cellId = change.cell.metadata?.id;
           if (typeof cellId !== "string") {
             continue;
@@ -68,12 +66,6 @@ export function initLearning(
             void learningService.markActivityCompleteByCellId(cellId);
           }
         }
-      }
-      if (hasExecutionChange) {
-        // Moving between notebooks is clumsy when they're unsaved.  Since this
-        // is a working copy we created on the user's behalf, we're free to
-        // auto-save.
-        void learningService.saveCourseWorkbook(e.notebook);
       }
     }),
   );

--- a/source/vscode/src/learning/notebookSync.ts
+++ b/source/vscode/src/learning/notebookSync.ts
@@ -44,7 +44,11 @@ async function syncActiveNotebook(
     // hasn't started yet and merely opening a notebook must not materialize
     // one behind their back.
     if (await service.tryInitialize()) {
-      await service.syncToWorkbook(editor.notebook.uri);
+      if (await service.syncToWorkbook(editor.notebook.uri)) {
+        // The workbook may already be dirty when restoring a VS Code session,
+        // before the notebook-change listener had a chance to observe it.
+        await service.saveCourseWorkbook(editor.notebook);
+      }
     }
   }
 
@@ -56,7 +60,7 @@ async function syncActiveNotebook(
   void vscode.commands.executeCommand(
     "setContext",
     LEARNING_NOTEBOOK_ACTIVE_CONTEXT,
-    editor !== undefined && isCourseWorkbook(service, editor.notebook.uri),
+    editor !== undefined && service.isCourseWorkbook(editor.notebook.uri),
   );
 }
 
@@ -85,20 +89,4 @@ function isCandidateWorkbookUri(uri: vscode.Uri): boolean {
     }
   }
   return false;
-}
-
-/**
- * True when the URI is a course workbook belonging to the loaded learning
- * workspace. Scopes notebook toolbar actions to learning content rather
- * than every Jupyter notebook the user has open.
- */
-function isCourseWorkbook(service: LearningService, uri: vscode.Uri): boolean {
-  if (!service.initialized) {
-    return false;
-  }
-  const target = uri.toString();
-  return (
-    target.startsWith(service.learningContentRoot.toString()) &&
-    target.endsWith(WORKBOOK_SUFFIX)
-  );
 }

--- a/source/vscode/src/learning/notebookSync.ts
+++ b/source/vscode/src/learning/notebookSync.ts
@@ -44,11 +44,7 @@ async function syncActiveNotebook(
     // hasn't started yet and merely opening a notebook must not materialize
     // one behind their back.
     if (await service.tryInitialize()) {
-      if (await service.syncToWorkbook(editor.notebook.uri)) {
-        // The workbook may already be dirty when restoring a VS Code session,
-        // before the notebook-change listener had a chance to observe it.
-        await service.saveCourseWorkbook(editor.notebook);
-      }
+      await service.syncToWorkbook(editor.notebook.uri);
     }
   }
 

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -134,7 +134,7 @@ export class LearningService {
   private _initPromise: Promise<boolean> | undefined;
   /** Whether {@link _initPromise} was started with `createIfMissing`. */
   private _initCreates = false;
-  private readonly _workbookSaveQueues = new Map<string, Promise<void>>();
+  private _workbookSaveQueue: Promise<void> = Promise.resolve();
   private _closeStaleTabsRequest = 0;
   private readonly _disposables: vscode.Disposable[] = [];
   private _progressLoadingError: string | undefined;
@@ -517,8 +517,9 @@ export class LearningService {
       return false;
     }
 
-    const key = notebook.uri.toString();
-    const previous = this._workbookSaveQueues.get(key) ?? Promise.resolve();
+    const previous = this._workbookSaveQueue.catch((e) => {
+      log.warn(`Previous learning workbook save failed: ${String(e)}`);
+    });
     let saved = true;
     const current = previous.then(async () => {
       // VS Code updates isDirty after notebook-change listeners return.
@@ -539,12 +540,9 @@ export class LearningService {
         );
       }
     });
-    this._workbookSaveQueues.set(key, current);
+    this._workbookSaveQueue = current;
 
     await current;
-    if (this._workbookSaveQueues.get(key) === current) {
-      this._workbookSaveQueues.delete(key);
-    }
     return saved;
   }
 
@@ -1467,14 +1465,10 @@ export class LearningService {
     );
   }
 
-  /**
-   * Close every open text or notebook tab whose URI matches {@link predicate}.
-   * Tabs backed by any other input kind (diff views, webviews, terminals) are
-   * skipped, since they have no single URI to match against.
-   */
-  private async closeTabs(
+  /** Find every open text or notebook tab whose URI matches the predicate. */
+  private findTabs(
     predicate: (uri: vscode.Uri, tab: vscode.Tab) => boolean,
-  ): Promise<void> {
+  ): vscode.Tab[] {
     const matches: vscode.Tab[] = [];
     for (const group of vscode.window.tabGroups.all) {
       for (const tab of group.tabs) {
@@ -1489,6 +1483,18 @@ export class LearningService {
         }
       }
     }
+    return matches;
+  }
+
+  /**
+   * Close every open text or notebook tab whose URI matches {@link predicate}.
+   * Tabs backed by any other input kind (diff views, webviews, terminals) are
+   * skipped, since they have no single URI to match against.
+   */
+  private async closeTabs(
+    predicate: (uri: vscode.Uri, tab: vscode.Tab) => boolean,
+  ): Promise<void> {
+    const matches = this.findTabs(predicate);
     if (matches.length > 0) {
       await vscode.window.tabGroups.close(matches);
     }
@@ -1506,32 +1512,41 @@ export class LearningService {
     const request = ++this._closeStaleTabsRequest;
     const learningRoot = this.learningContentRoot.toString();
     const keepStr = keepUri?.toString();
-    const workbooksThatFailedToSave = new Set<string>();
+    const staleTabs = this.findTabs((uri) => {
+      const uriStr = uri.toString();
+      return uriStr.startsWith(learningRoot) && uriStr !== keepStr;
+    });
+    const tabsToClose: vscode.Tab[] = [];
 
-    for (const notebook of vscode.workspace.notebookDocuments) {
-      const uri = notebook.uri.toString();
+    for (const tab of staleTabs) {
+      const input = tab.input;
       if (
-        uri.startsWith(learningRoot) &&
-        uri !== keepStr &&
-        this.isCourseWorkbook(notebook.uri) &&
-        !(await this.saveCourseWorkbook(notebook))
+        input instanceof vscode.TabInputNotebook &&
+        this.isCourseWorkbook(input.uri)
       ) {
-        workbooksThatFailedToSave.add(uri);
+        const uri = input.uri.toString();
+        const notebook = vscode.workspace.notebookDocuments.find(
+          (document) => document.uri.toString() === uri,
+        );
+        if (notebook && !(await this.saveCourseWorkbook(notebook))) {
+          continue;
+        }
       }
+      tabsToClose.push(tab);
     }
 
+    // A newer navigation may have made one of these tabs current again.
     if (request !== this._closeStaleTabsRequest) {
       return;
     }
 
-    await this.closeTabs((uri) => {
-      const uriStr = uri.toString();
-      return (
-        uriStr.startsWith(learningRoot) &&
-        uriStr !== keepStr &&
-        !workbooksThatFailedToSave.has(uriStr)
-      );
-    });
+    const openTabs = new Set(
+      vscode.window.tabGroups.all.flatMap((group) => group.tabs),
+    );
+    const openTabsToClose = tabsToClose.filter((tab) => openTabs.has(tab));
+    if (openTabsToClose.length > 0) {
+      await vscode.window.tabGroups.close(openTabsToClose);
+    }
   }
 
   /** Turns a catalog activity into the typed content payload (exercise, lesson-example, or lesson-text). */

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -134,6 +134,8 @@ export class LearningService {
   private _initPromise: Promise<boolean> | undefined;
   /** Whether {@link _initPromise} was started with `createIfMissing`. */
   private _initCreates = false;
+  private readonly _workbookSaveQueues = new Map<string, Promise<void>>();
+  private _closeStaleTabsRequest = 0;
   private readonly _disposables: vscode.Disposable[] = [];
   private _progressLoadingError: string | undefined;
 
@@ -494,6 +496,56 @@ export class LearningService {
     await this.saveProgress();
     this._onDidChangeState.fire(this.getState());
     return true;
+  }
+
+  /** True when the URI is one of the loaded course's learner workbooks. */
+  isCourseWorkbook(uri: vscode.Uri): boolean {
+    return (
+      this.workspace !== undefined &&
+      this.resolveWorkbookLocation(uri) !== undefined
+    );
+  }
+
+  /**
+   * Save a course workbook after any earlier save for the same document.
+   * Returns false when the document is not a course workbook or could not save.
+   */
+  async saveCourseWorkbook(
+    notebook: vscode.NotebookDocument,
+  ): Promise<boolean> {
+    if (!this.isCourseWorkbook(notebook.uri)) {
+      return false;
+    }
+
+    const key = notebook.uri.toString();
+    const previous = this._workbookSaveQueues.get(key) ?? Promise.resolve();
+    let saved = true;
+    const current = previous.then(async () => {
+      // VS Code updates isDirty after notebook-change listeners return.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      if (!notebook.isDirty) {
+        return;
+      }
+      try {
+        const didSave = await notebook.save();
+        saved = didSave || !notebook.isDirty;
+        if (!saved) {
+          log.warn(`Could not save learning workbook ${notebook.uri.fsPath}.`);
+        }
+      } catch (e) {
+        saved = false;
+        log.warn(
+          `Could not save learning workbook ${notebook.uri.fsPath}: ${String(e)}`,
+        );
+      }
+    });
+    this._workbookSaveQueues.set(key, current);
+
+    await current;
+    if (this._workbookSaveQueues.get(key) === current) {
+      this._workbookSaveQueues.delete(key);
+    }
+    return saved;
   }
 
   /**
@@ -1451,12 +1503,34 @@ export class LearningService {
     if (!this.workspace) {
       return;
     }
+    const request = ++this._closeStaleTabsRequest;
     const learningRoot = this.learningContentRoot.toString();
     const keepStr = keepUri?.toString();
+    const workbooksThatFailedToSave = new Set<string>();
+
+    for (const notebook of vscode.workspace.notebookDocuments) {
+      const uri = notebook.uri.toString();
+      if (
+        uri.startsWith(learningRoot) &&
+        uri !== keepStr &&
+        this.isCourseWorkbook(notebook.uri) &&
+        !(await this.saveCourseWorkbook(notebook))
+      ) {
+        workbooksThatFailedToSave.add(uri);
+      }
+    }
+
+    if (request !== this._closeStaleTabsRequest) {
+      return;
+    }
 
     await this.closeTabs((uri) => {
       const uriStr = uri.toString();
-      return uriStr.startsWith(learningRoot) && uriStr !== keepStr;
+      return (
+        uriStr.startsWith(learningRoot) &&
+        uriStr !== keepStr &&
+        !workbooksThatFailedToSave.has(uriStr)
+      );
     });
   }
 

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -527,8 +527,8 @@ export class LearningService {
         return;
       }
       try {
-        const didSave = await notebook.save();
-        saved = didSave || !notebook.isDirty;
+        await notebook.save();
+        saved = !notebook.isDirty;
         if (!saved) {
           log.warn(`Could not save learning workbook ${notebook.uri.fsPath}.`);
         }

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -510,7 +510,7 @@ export class LearningService {
    * Save a course workbook after any earlier save for the same document.
    * Returns false when the document is not a course workbook or could not save.
    */
-  async saveCourseWorkbook(
+  private async saveCourseWorkbook(
     notebook: vscode.NotebookDocument,
   ): Promise<boolean> {
     if (!this.isCourseWorkbook(notebook.uri)) {


### PR DESCRIPTION
Learning notebooks are now saved after metadata changes and before moving to another unit, preventing unwanted save prompts and preserving learner edits.