### PR TITLE
Adaptive QIR emission does not properly handle negative indexing

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -5968,7 +5968,9 @@ fn array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed_emits_
           %var_9_1 = getelementptr [2 x i64], ptr %var_9, i64 0, i64 1
           store i64 %var_15, ptr %var_9_1
           %var_17 = load i64, ptr %var_8
-          %var_10 = getelementptr i64, ptr %var_9, i64 %var_17
+          %var_10_offset_chk = icmp slt i64 %var_17, 0
+          %var_10_offset = select i1 %var_10_offset_chk, i64 1, i64 0
+          %var_10 = getelementptr [2 x i64], ptr %var_9, i64 %var_10_offset, i64 %var_17
           %var_18 = load i64, ptr %var_10
           call void @__quantum__rt__int_record_output(i64 %var_18, ptr @0)
           ret i64 0
@@ -6190,9 +6192,13 @@ fn nested_array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed
           %var_19_2 = getelementptr [3 x i64], ptr %var_19, i64 0, i64 2
           store i64 %var_33, ptr %var_19_2
           %var_35 = load i64, ptr %var_17
-          %var_20 = getelementptr i64, ptr %var_18, i64 %var_35
+          %var_20_offset_chk = icmp slt i64 %var_35, 0
+          %var_20_offset = select i1 %var_20_offset_chk, i64 1, i64 0
+          %var_20 = getelementptr [2 x i64], ptr %var_18, i64 %var_20_offset, i64 %var_35
           %var_36 = load i64, ptr %var_20
-          %var_21 = getelementptr i64, ptr %var_19, i64 %var_35
+          %var_21_offset_chk = icmp slt i64 %var_35, 0
+          %var_21_offset = select i1 %var_21_offset_chk, i64 1, i64 0
+          %var_21 = getelementptr [3 x i64], ptr %var_19, i64 %var_21_offset, i64 %var_35
           %var_37 = load i64, ptr %var_21
           call void @__quantum__rt__array_record_output(i64 2, ptr @0)
           call void @__quantum__rt__int_record_output(i64 %var_36, ptr @1)

--- a/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
@@ -72,7 +72,9 @@ fn nested_for_over_qubit_slice_succeeds() {
           br i1 %var_6, label %block_7, label %block_8
         block_7:
           %var_22 = load i64, ptr %var_5
-          %var_7 = getelementptr ptr, ptr @array0, i64 %var_22
+          %var_7_offset_chk = icmp slt i64 %var_22, 0
+          %var_7_offset = select i1 %var_7_offset_chk, i64 1, i64 0
+          %var_7 = getelementptr [2 x ptr], ptr @array0, i64 %var_7_offset, i64 %var_22
           %var_23 = load ptr, ptr %var_7
           call void @CNOT(ptr inttoptr (i64 0 to ptr), ptr %var_23)
           %var_11 = add i64 %var_22, 1
@@ -188,7 +190,9 @@ fn constant_folding_pattern_succeeds() {
           br i1 %var_6, label %block_7, label %block_8
         block_7:
           %var_22 = load i64, ptr %var_5
-          %var_7 = getelementptr ptr, ptr @array0, i64 %var_22
+          %var_7_offset_chk = icmp slt i64 %var_22, 0
+          %var_7_offset = select i1 %var_7_offset_chk, i64 1, i64 0
+          %var_7 = getelementptr [2 x ptr], ptr @array0, i64 %var_7_offset, i64 %var_22
           %var_23 = load ptr, ptr %var_7
           call void @CNOT(ptr inttoptr (i64 0 to ptr), ptr %var_23)
           %var_11 = add i64 %var_22, 1
@@ -317,7 +321,9 @@ fn three_qubit_repetition_code_pattern_succeeds() {
           br i1 %var_6, label %block_7, label %block_8
         block_7:
           %var_34 = load i64, ptr %var_5
-          %var_7 = getelementptr ptr, ptr @array0, i64 %var_34
+          %var_7_offset_chk = icmp slt i64 %var_34, 0
+          %var_7_offset = select i1 %var_7_offset_chk, i64 1, i64 0
+          %var_7 = getelementptr [2 x ptr], ptr @array0, i64 %var_7_offset, i64 %var_34
           %var_35 = load ptr, ptr %var_7
           call void @CNOT(ptr inttoptr (i64 0 to ptr), ptr %var_35)
           %var_11 = add i64 %var_34, 1
@@ -332,7 +338,9 @@ fn three_qubit_repetition_code_pattern_succeeds() {
           br i1 %var_13, label %block_10, label %block_11
         block_10:
           %var_31 = load i64, ptr %var_12
-          %var_14 = getelementptr ptr, ptr @array1, i64 %var_31
+          %var_14_offset_chk = icmp slt i64 %var_31, 0
+          %var_14_offset = select i1 %var_14_offset_chk, i64 1, i64 0
+          %var_14 = getelementptr [3 x ptr], ptr @array1, i64 %var_14_offset, i64 %var_31
           %var_32 = load ptr, ptr %var_14
           call void @Rx(double 6.2831853, ptr %var_32)
           %var_18 = add i64 %var_31, 1
@@ -441,7 +449,9 @@ fn for_over_qubit_slice_inside_dynamic_while_succeeds() {
           br i1 %var_4, label %block_5, label %block_6
         block_5:
           %var_16 = load i64, ptr %var_3
-          %var_5 = getelementptr ptr, ptr @array0, i64 %var_16
+          %var_5_offset_chk = icmp slt i64 %var_16, 0
+          %var_5_offset = select i1 %var_5_offset_chk, i64 1, i64 0
+          %var_5 = getelementptr [2 x ptr], ptr @array0, i64 %var_5_offset, i64 %var_16
           %var_17 = load ptr, ptr %var_5
           call void @CNOT(ptr inttoptr (i64 0 to ptr), ptr %var_17)
           %var_9 = add i64 %var_16, 1
@@ -758,7 +768,9 @@ fn for_loop_over_qubits_with_reset_all_succeeds() {
           br i1 %var_2, label %block_2, label %block_3
         block_2:
           %var_20 = load i64, ptr %var_1
-          %var_3 = getelementptr ptr, ptr @array0, i64 %var_20
+          %var_3_offset_chk = icmp slt i64 %var_20, 0
+          %var_3_offset = select i1 %var_3_offset_chk, i64 1, i64 0
+          %var_3 = getelementptr [4 x ptr], ptr @array0, i64 %var_3_offset, i64 %var_20
           %var_21 = load ptr, ptr %var_3
           call void @H(ptr %var_21)
           %var_6 = add i64 %var_20, 1
@@ -774,7 +786,9 @@ fn for_loop_over_qubits_with_reset_all_succeeds() {
           br i1 %var_8, label %block_5, label %block_6
         block_5:
           %var_17 = load i64, ptr %var_7
-          %var_9 = getelementptr ptr, ptr @array1, i64 %var_17
+          %var_9_offset_chk = icmp slt i64 %var_17, 0
+          %var_9_offset = select i1 %var_9_offset_chk, i64 1, i64 0
+          %var_9 = getelementptr [3 x ptr], ptr @array1, i64 %var_9_offset, i64 %var_17
           %var_18 = load ptr, ptr %var_9
           call void @Reset(ptr %var_18)
           %var_12 = add i64 %var_17, 1
@@ -1119,7 +1133,9 @@ fn for_loop_over_qubits_with_dynamic_exit_succeeds() {
           br i1 %var_4, label %block_2, label %block_3
         block_2:
           %var_16 = load i64, ptr %var_3
-          %var_5 = getelementptr ptr, ptr @array0, i64 %var_16
+          %var_5_offset_chk = icmp slt i64 %var_16, 0
+          %var_5_offset = select i1 %var_5_offset_chk, i64 1, i64 0
+          %var_5 = getelementptr [3 x ptr], ptr @array0, i64 %var_5_offset, i64 %var_16
           %var_17 = load ptr, ptr %var_5
           call void @H(ptr %var_17)
           call void @__quantum__qis__mresetz__body(ptr %var_17, ptr inttoptr (i64 0 to ptr))

--- a/source/compiler/qsc_codegen/src/qir/v2.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2.rs
@@ -249,15 +249,41 @@ fn index_to_qir(
     result_var: &rir::Variable,
     program: &rir::Program,
 ) -> String {
-    // Only need to emit the getelementptr instruction here, as passes are expected to insert the subsequent load instruction.
-    format!(
-        "  {} = getelementptr {}, ptr {}, {} {}",
-        ToQir::<String>::to_qir(&result_var.variable_id, program),
-        ToQir::<String>::to_qir(&result_var.ty, program),
-        get_value_as_str(array_op, program),
-        get_value_ty(index_op),
-        get_value_as_str(index_op, program)
+    let mut qir = String::new();
+    let result_ty = ToQir::<String>::to_qir(&result_var.ty, program);
+    let result_var = ToQir::<String>::to_qir(&result_var.variable_id, program);
+    let index_ty = get_value_ty(index_op);
+    let index_val = get_value_as_str(index_op, program);
+    let array_size = match array_op {
+        rir::Operand::Literal(rir::Literal::Array(id)) => program
+            .array_literals
+            .get(*id)
+            .expect("array should exist")
+            .contents
+            .len(),
+        rir::Operand::Variable(rir::Variable {
+            ty: rir::Ty::Array(size, _),
+            ..
+        }) => *size,
+        _ => panic!("expected array operand to be an array literal or array variable"),
+    };
+    writeln!(
+        qir,
+        "  {result_var}_offset_chk = icmp slt {index_ty} {index_val}, 0"
     )
+    .expect("writing to string should succeed");
+    writeln!(
+        qir,
+        "  {result_var}_offset = select i1 {result_var}_offset_chk, {index_ty} 1, {index_ty} 0"
+    )
+    .expect("writing to string should succeed");
+    write!(
+        qir,
+        "  {result_var} = getelementptr [{array_size} x {result_ty}], ptr {}, {index_ty} {result_var}_offset, {index_ty} {index_val}",
+        get_value_as_str(array_op, program),
+    )
+    .expect("writing to string should succeed");
+    qir
 }
 
 fn convert_to_qir(

--- a/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/index.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/index.rs
@@ -8,54 +8,110 @@ use qsc_rir::rir;
 #[test]
 fn integer_from_variable_index() {
     let inst = rir::Instruction::Index(
-        rir::Operand::Variable(rir::Variable::new_ptr(rir::VariableId(1))),
+        rir::Operand::Variable(rir::Variable::new_array(
+            rir::VariableId(1),
+            1,
+            rir::Prim::Integer,
+        )),
         rir::Operand::Variable(rir::Variable::new_integer(rir::VariableId(0))),
         rir::Variable::new_integer(rir::VariableId(0)),
     );
-    expect!["  %var_0 = getelementptr i64, ptr %var_1, i64 %var_0"]
-        .assert_eq(&inst.to_qir(&rir::Program::default()));
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_0_offset_chk = icmp slt i64 %var_0, 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0_offset = select i1 %var_0_offset_chk, i64 1, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0 = getelementptr [1 x i64], ptr %var_1, i64 %var_0_offset, i64 %var_0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
 }
 
 #[test]
 fn integer_from_literal_index() {
     let inst = rir::Instruction::Index(
-        rir::Operand::Variable(rir::Variable::new_ptr(rir::VariableId(1))),
+        rir::Operand::Variable(rir::Variable::new_array(
+            rir::VariableId(1),
+            1,
+            rir::Prim::Integer,
+        )),
         rir::Operand::Literal(rir::Literal::Integer(0)),
         rir::Variable::new_integer(rir::VariableId(0)),
     );
-    expect!["  %var_0 = getelementptr i64, ptr %var_1, i64 0"]
-        .assert_eq(&inst.to_qir(&rir::Program::default()));
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_0_offset_chk = icmp slt i64 0, 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0_offset = select i1 %var_0_offset_chk, i64 1, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0 = getelementptr [1 x i64], ptr %var_1, i64 %var_0_offset, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
 }
 
 #[test]
 fn integer_from_literal_index_literal_array() {
+    let mut program = rir::Program::default();
+    program.array_literals.push(rir::ArrayLiteral {
+        contents: vec![rir::Literal::Integer(0)],
+        ty: rir::Prim::Integer,
+    });
     let inst = rir::Instruction::Index(
         rir::Operand::Literal(rir::Literal::Array(0)),
         rir::Operand::Literal(rir::Literal::Integer(0)),
         rir::Variable::new_integer(rir::VariableId(0)),
     );
-    expect!["  %var_0 = getelementptr i64, ptr @array0, i64 0"]
-        .assert_eq(&inst.to_qir(&rir::Program::default()));
+    let qir = inst.to_qir(&program);
+    let mut lines = qir.lines();
+    expect!["  %var_0_offset_chk = icmp slt i64 0, 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0_offset = select i1 %var_0_offset_chk, i64 1, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0 = getelementptr [1 x i64], ptr @array0, i64 %var_0_offset, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
 }
 
 #[test]
 fn double_from_variable_index() {
     let inst = rir::Instruction::Index(
-        rir::Operand::Variable(rir::Variable::new_ptr(rir::VariableId(1))),
+        rir::Operand::Variable(rir::Variable::new_array(
+            rir::VariableId(1),
+            1,
+            rir::Prim::Double,
+        )),
         rir::Operand::Variable(rir::Variable::new_integer(rir::VariableId(0))),
         rir::Variable::new_double(rir::VariableId(0)),
     );
-    expect!["  %var_0 = getelementptr double, ptr %var_1, i64 %var_0"]
-        .assert_eq(&inst.to_qir(&rir::Program::default()));
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_0_offset_chk = icmp slt i64 %var_0, 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0_offset = select i1 %var_0_offset_chk, i64 1, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0 = getelementptr [1 x double], ptr %var_1, i64 %var_0_offset, i64 %var_0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
 }
 
 #[test]
 fn double_from_literal_index() {
     let inst = rir::Instruction::Index(
-        rir::Operand::Variable(rir::Variable::new_ptr(rir::VariableId(1))),
+        rir::Operand::Variable(rir::Variable::new_array(
+            rir::VariableId(1),
+            1,
+            rir::Prim::Double,
+        )),
         rir::Operand::Literal(rir::Literal::Integer(0)),
         rir::Variable::new_double(rir::VariableId(0)),
     );
-    expect!["  %var_0 = getelementptr double, ptr %var_1, i64 0"]
-        .assert_eq(&inst.to_qir(&rir::Program::default()));
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_0_offset_chk = icmp slt i64 0, 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0_offset = select i1 %var_0_offset_chk, i64 1, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0 = getelementptr [1 x double], ptr %var_1, i64 %var_0_offset, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
 }

--- a/source/compiler/qsc_rir/src/rir.rs
+++ b/source/compiler/qsc_rir/src/rir.rs
@@ -599,6 +599,14 @@ impl Variable {
             ty: Ty::Prim(Prim::Pointer),
         }
     }
+
+    #[must_use]
+    pub fn new_array(id: VariableId, size: usize, element_ty: Prim) -> Self {
+        Self {
+            variable_id: id,
+            ty: Ty::Array(size, element_ty),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/source/qdk_package/tests-integration/resources/adaptive/input/NegativeIndexing.qs
+++ b/source/qdk_package/tests-integration/resources/adaptive/input/NegativeIndexing.qs
@@ -1,0 +1,12 @@
+namespace Test {
+    /// Demonstrates successful negative indexing as part of a loop during execution.
+    /// Because the array is iterated backwards skipping the last element, the expected
+    /// output is [One, One, Zero].
+    operation Main() : Result[] {
+        use qs = Qubit[3];
+        for i in -2..-1..-Length(qs) {
+            X(qs[i]);
+        }
+        MResetEachZ(qs)
+    }
+}

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ArithmeticOps.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ArithmeticOps.ll
@@ -26,7 +26,9 @@ block_1:
   br i1 %var_7, label %block_2, label %block_3
 block_2:
   %var_105 = load i64, ptr %var_6
-  %var_8 = getelementptr ptr, ptr @array0, i64 %var_105
+  %var_8_offset_chk = icmp slt i64 %var_105, 0
+  %var_8_offset = select i1 %var_8_offset_chk, i64 1, i64 0
+  %var_8 = getelementptr [5 x ptr], ptr @array0, i64 %var_8_offset, i64 %var_105
   %var_106 = load ptr, ptr %var_8
   call void @X(ptr %var_106)
   %var_11 = add i64 %var_105, 1
@@ -131,7 +133,9 @@ block_14:
   br i1 %var_45, label %block_15, label %block_16
 block_15:
   %var_62 = load i64, ptr %var_44
-  %var_46 = getelementptr ptr, ptr @array0, i64 %var_62
+  %var_46_offset_chk = icmp slt i64 %var_62, 0
+  %var_46_offset = select i1 %var_46_offset_chk, i64 1, i64 0
+  %var_46 = getelementptr [5 x ptr], ptr @array0, i64 %var_46_offset, i64 %var_62
   %var_63 = load ptr, ptr %var_46
   call void @Reset(ptr %var_63)
   %var_49 = add i64 %var_62, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/BernsteinVaziraniNISQ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/BernsteinVaziraniNISQ.ll
@@ -20,7 +20,9 @@ block_1:
   br i1 %var_4, label %block_2, label %block_3
 block_2:
   %var_25 = load i64, ptr %var_3
-  %var_5 = getelementptr ptr, ptr @array0, i64 %var_25
+  %var_5_offset_chk = icmp slt i64 %var_25, 0
+  %var_5_offset = select i1 %var_5_offset_chk, i64 1, i64 0
+  %var_5 = getelementptr [5 x ptr], ptr @array0, i64 %var_5_offset, i64 %var_25
   %var_26 = load ptr, ptr %var_5
   call void @H(ptr %var_26)
   %var_8 = add i64 %var_25, 1
@@ -39,7 +41,9 @@ block_4:
   br i1 %var_13, label %block_5, label %block_6
 block_5:
   %var_22 = load i64, ptr %var_12
-  %var_14 = getelementptr ptr, ptr @array0, i64 %var_22
+  %var_14_offset_chk = icmp slt i64 %var_22, 0
+  %var_14_offset = select i1 %var_14_offset_chk, i64 1, i64 0
+  %var_14 = getelementptr [5 x ptr], ptr @array0, i64 %var_14_offset, i64 %var_22
   %var_23 = load ptr, ptr %var_14
   call void @H__Adj(ptr %var_23)
   %var_17 = add i64 %var_22, -1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ConstantFolding.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ConstantFolding.ll
@@ -50,7 +50,9 @@ block_7:
   br i1 %var_20, label %block_10, label %block_11
 block_8:
   %var_49 = load i64, ptr %var_6
-  %var_8 = getelementptr ptr, ptr @array0, i64 %var_49
+  %var_8_offset_chk = icmp slt i64 %var_49, 0
+  %var_8_offset = select i1 %var_8_offset_chk, i64 1, i64 0
+  %var_8 = getelementptr [2 x ptr], ptr @array0, i64 %var_8_offset, i64 %var_49
   %var_50 = load ptr, ptr %var_8
   call void @CNOT(ptr inttoptr (i64 0 to ptr), ptr %var_50)
   %var_12 = add i64 %var_49, 1
@@ -63,7 +65,9 @@ block_9:
   br label %block_1
 block_10:
   %var_42 = load i64, ptr %var_19
-  %var_21 = getelementptr ptr, ptr @array1, i64 %var_42
+  %var_21_offset_chk = icmp slt i64 %var_42, 0
+  %var_21_offset = select i1 %var_21_offset_chk, i64 1, i64 0
+  %var_21 = getelementptr [3 x ptr], ptr @array1, i64 %var_21_offset, i64 %var_42
   %var_43 = load ptr, ptr %var_21
   call void @Reset(ptr %var_43)
   %var_24 = add i64 %var_42, 1
@@ -78,7 +82,9 @@ block_12:
   br i1 %var_26, label %block_13, label %block_14
 block_13:
   %var_39 = load i64, ptr %var_25
-  %var_27 = getelementptr ptr, ptr @array2, i64 %var_39
+  %var_27_offset_chk = icmp slt i64 %var_39, 0
+  %var_27_offset = select i1 %var_27_offset_chk, i64 1, i64 0
+  %var_27 = getelementptr [1 x ptr], ptr @array2, i64 %var_27_offset, i64 %var_39
   %var_40 = load ptr, ptr %var_27
   call void @Reset(ptr %var_40)
   %var_29 = add i64 %var_39, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/CopyAndUpdateExpressions.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/CopyAndUpdateExpressions.ll
@@ -28,7 +28,9 @@ block_1:
   br i1 %var_5, label %block_2, label %block_3
 block_2:
   %var_11 = load i64, ptr %var_4
-  %var_6 = getelementptr ptr, ptr @array0, i64 %var_11
+  %var_6_offset_chk = icmp slt i64 %var_11, 0
+  %var_6_offset = select i1 %var_6_offset_chk, i64 1, i64 0
+  %var_6 = getelementptr [2 x ptr], ptr @array0, i64 %var_6_offset, i64 %var_11
   %var_12 = load ptr, ptr %var_6
   call void @X(ptr %var_12)
   %var_8 = add i64 %var_11, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/DeutschJozsaNISQ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/DeutschJozsaNISQ.ll
@@ -30,7 +30,9 @@ block_1:
   br i1 %var_5, label %block_2, label %block_3
 block_2:
   %var_69 = load i64, ptr %var_4
-  %var_6 = getelementptr ptr, ptr @array0, i64 %var_69
+  %var_6_offset_chk = icmp slt i64 %var_69, 0
+  %var_6_offset = select i1 %var_6_offset_chk, i64 1, i64 0
+  %var_6 = getelementptr [4 x ptr], ptr @array0, i64 %var_6_offset, i64 %var_69
   %var_70 = load ptr, ptr %var_6
   call void @H(ptr %var_70)
   %var_8 = add i64 %var_69, 1
@@ -46,7 +48,9 @@ block_4:
   br i1 %var_12, label %block_5, label %block_6
 block_5:
   %var_66 = load i64, ptr %var_11
-  %var_13 = getelementptr ptr, ptr @array0, i64 %var_66
+  %var_13_offset_chk = icmp slt i64 %var_66, 0
+  %var_13_offset = select i1 %var_13_offset_chk, i64 1, i64 0
+  %var_13 = getelementptr [4 x ptr], ptr @array0, i64 %var_13_offset, i64 %var_66
   %var_67 = load ptr, ptr %var_13
   call void @H__Adj(ptr %var_67)
   %var_16 = add i64 %var_66, -1
@@ -65,7 +69,9 @@ block_7:
   br i1 %var_19, label %block_8, label %block_9
 block_8:
   %var_63 = load i64, ptr %var_18
-  %var_20 = getelementptr ptr, ptr @array0, i64 %var_63
+  %var_20_offset_chk = icmp slt i64 %var_63, 0
+  %var_20_offset = select i1 %var_20_offset_chk, i64 1, i64 0
+  %var_20 = getelementptr [4 x ptr], ptr @array0, i64 %var_20_offset, i64 %var_63
   %var_64 = load ptr, ptr %var_20
   call void @Reset(ptr %var_64)
   %var_23 = add i64 %var_63, 1
@@ -83,7 +89,9 @@ block_10:
   br i1 %var_27, label %block_11, label %block_12
 block_11:
   %var_60 = load i64, ptr %var_26
-  %var_28 = getelementptr ptr, ptr @array0, i64 %var_60
+  %var_28_offset_chk = icmp slt i64 %var_60, 0
+  %var_28_offset = select i1 %var_28_offset_chk, i64 1, i64 0
+  %var_28 = getelementptr [4 x ptr], ptr @array0, i64 %var_28_offset, i64 %var_60
   %var_61 = load ptr, ptr %var_28
   call void @H(ptr %var_61)
   %var_30 = add i64 %var_60, 1
@@ -99,7 +107,9 @@ block_13:
   br i1 %var_32, label %block_14, label %block_15
 block_14:
   %var_57 = load i64, ptr %var_31
-  %var_33 = getelementptr ptr, ptr @array0, i64 %var_57
+  %var_33_offset_chk = icmp slt i64 %var_57, 0
+  %var_33_offset = select i1 %var_33_offset_chk, i64 1, i64 0
+  %var_33 = getelementptr [4 x ptr], ptr @array0, i64 %var_33_offset, i64 %var_57
   %var_58 = load ptr, ptr %var_33
   call void @H__Adj(ptr %var_58)
   %var_35 = add i64 %var_57, -1
@@ -118,7 +128,9 @@ block_16:
   br i1 %var_38, label %block_17, label %block_18
 block_17:
   %var_54 = load i64, ptr %var_37
-  %var_39 = getelementptr ptr, ptr @array0, i64 %var_54
+  %var_39_offset_chk = icmp slt i64 %var_54, 0
+  %var_39_offset = select i1 %var_39_offset_chk, i64 1, i64 0
+  %var_39 = getelementptr [4 x ptr], ptr @array0, i64 %var_39_offset, i64 %var_54
   %var_55 = load ptr, ptr %var_39
   call void @Reset(ptr %var_55)
   %var_41 = add i64 %var_54, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ExpandedTests.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ExpandedTests.ll
@@ -26,7 +26,9 @@ block_1:
   br i1 %var_3, label %block_2, label %block_3
 block_2:
   %var_90 = load i64, ptr %var_2
-  %var_4 = getelementptr ptr, ptr @array0, i64 %var_90
+  %var_4_offset_chk = icmp slt i64 %var_90, 0
+  %var_4_offset = select i1 %var_4_offset_chk, i64 1, i64 0
+  %var_4 = getelementptr [2 x ptr], ptr @array0, i64 %var_4_offset, i64 %var_90
   %var_91 = load ptr, ptr %var_4
   call void @H(ptr %var_91)
   %var_7 = add i64 %var_90, 1
@@ -79,7 +81,9 @@ block_9:
   br i1 %var_13, label %block_10, label %block_11
 block_10:
   %var_87 = load i64, ptr %var_12
-  %var_14 = getelementptr ptr, ptr @array1, i64 %var_87
+  %var_14_offset_chk = icmp slt i64 %var_87, 0
+  %var_14_offset = select i1 %var_14_offset_chk, i64 1, i64 0
+  %var_14 = getelementptr [1 x ptr], ptr @array1, i64 %var_14_offset, i64 %var_87
   %var_88 = load ptr, ptr %var_14
   call void @X(ptr %var_88)
   %var_16 = add i64 %var_87, 1
@@ -95,7 +99,9 @@ block_12:
   br i1 %var_21, label %block_13, label %block_14
 block_13:
   %var_84 = load i64, ptr %var_20
-  %var_22 = getelementptr ptr, ptr @array1, i64 %var_84
+  %var_22_offset_chk = icmp slt i64 %var_84, 0
+  %var_22_offset = select i1 %var_22_offset_chk, i64 1, i64 0
+  %var_22 = getelementptr [1 x ptr], ptr @array1, i64 %var_22_offset, i64 %var_84
   %var_85 = load ptr, ptr %var_22
   call void @X__Adj(ptr %var_85)
   %var_25 = add i64 %var_84, -1
@@ -112,7 +118,9 @@ block_15:
   br i1 %var_28, label %block_16, label %block_17
 block_16:
   %var_81 = load i64, ptr %var_27
-  %var_29 = getelementptr ptr, ptr @array0, i64 %var_81
+  %var_29_offset_chk = icmp slt i64 %var_81, 0
+  %var_29_offset = select i1 %var_29_offset_chk, i64 1, i64 0
+  %var_29 = getelementptr [2 x ptr], ptr @array0, i64 %var_29_offset, i64 %var_81
   %var_82 = load ptr, ptr %var_29
   call void @H__Adj(ptr %var_82)
   %var_31 = add i64 %var_81, -1
@@ -127,7 +135,9 @@ block_18:
   br i1 %var_33, label %block_19, label %block_20
 block_19:
   %var_78 = load i64, ptr %var_32
-  %var_34 = getelementptr ptr, ptr @array0, i64 %var_78
+  %var_34_offset_chk = icmp slt i64 %var_78, 0
+  %var_34_offset = select i1 %var_34_offset_chk, i64 1, i64 0
+  %var_34 = getelementptr [2 x ptr], ptr @array0, i64 %var_34_offset, i64 %var_78
   %var_79 = load ptr, ptr %var_34
   call void @X(ptr %var_79)
   %var_36 = add i64 %var_78, 1
@@ -143,7 +153,9 @@ block_21:
   br i1 %var_41, label %block_22, label %block_23
 block_22:
   %var_75 = load i64, ptr %var_40
-  %var_42 = getelementptr ptr, ptr @array0, i64 %var_75
+  %var_42_offset_chk = icmp slt i64 %var_75, 0
+  %var_42_offset = select i1 %var_42_offset_chk, i64 1, i64 0
+  %var_42 = getelementptr [2 x ptr], ptr @array0, i64 %var_42_offset, i64 %var_75
   %var_76 = load ptr, ptr %var_42
   call void @X__Adj(ptr %var_76)
   %var_44 = add i64 %var_75, -1
@@ -158,7 +170,9 @@ block_24:
   br i1 %var_46, label %block_25, label %block_26
 block_25:
   %var_72 = load i64, ptr %var_45
-  %var_47 = getelementptr ptr, ptr @array0, i64 %var_72
+  %var_47_offset_chk = icmp slt i64 %var_72, 0
+  %var_47_offset = select i1 %var_47_offset_chk, i64 1, i64 0
+  %var_47 = getelementptr [2 x ptr], ptr @array0, i64 %var_47_offset, i64 %var_72
   %var_73 = load ptr, ptr %var_47
   call void @H(ptr %var_73)
   %var_49 = add i64 %var_72, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/Functors.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/Functors.ll
@@ -38,7 +38,9 @@ block_1:
   br i1 %var_11, label %block_2, label %block_3
 block_2:
   %var_132 = load i64, ptr %var_10
-  %var_12 = getelementptr ptr, ptr @array0, i64 %var_132
+  %var_12_offset_chk = icmp slt i64 %var_132, 0
+  %var_12_offset = select i1 %var_12_offset_chk, i64 1, i64 0
+  %var_12 = getelementptr [2 x ptr], ptr @array0, i64 %var_12_offset, i64 %var_132
   %var_133 = load ptr, ptr %var_12
   call void @X(ptr %var_133)
   %var_14 = add i64 %var_132, 1
@@ -56,7 +58,9 @@ block_4:
   br i1 %var_38, label %block_5, label %block_6
 block_5:
   %var_129 = load i64, ptr %var_37
-  %var_39 = getelementptr ptr, ptr @array0, i64 %var_129
+  %var_39_offset_chk = icmp slt i64 %var_129, 0
+  %var_39_offset = select i1 %var_39_offset_chk, i64 1, i64 0
+  %var_39 = getelementptr [2 x ptr], ptr @array0, i64 %var_39_offset, i64 %var_129
   %var_130 = load ptr, ptr %var_39
   call void @X__Adj(ptr %var_130)
   %var_41 = add i64 %var_129, -1
@@ -71,7 +75,9 @@ block_7:
   br i1 %var_44, label %block_8, label %block_9
 block_8:
   %var_126 = load i64, ptr %var_43
-  %var_45 = getelementptr ptr, ptr @array0, i64 %var_126
+  %var_45_offset_chk = icmp slt i64 %var_126, 0
+  %var_45_offset = select i1 %var_45_offset_chk, i64 1, i64 0
+  %var_45 = getelementptr [2 x ptr], ptr @array0, i64 %var_45_offset, i64 %var_126
   %var_127 = load ptr, ptr %var_45
   call void @X(ptr %var_127)
   %var_47 = add i64 %var_126, 1
@@ -92,7 +98,9 @@ block_10:
   br i1 %var_67, label %block_11, label %block_12
 block_11:
   %var_123 = load i64, ptr %var_66
-  %var_68 = getelementptr ptr, ptr @array0, i64 %var_123
+  %var_68_offset_chk = icmp slt i64 %var_123, 0
+  %var_68_offset = select i1 %var_68_offset_chk, i64 1, i64 0
+  %var_68 = getelementptr [2 x ptr], ptr @array0, i64 %var_68_offset, i64 %var_123
   %var_124 = load ptr, ptr %var_68
   call void @X__Adj(ptr %var_124)
   %var_70 = add i64 %var_123, -1
@@ -113,7 +121,9 @@ block_13:
   br i1 %var_75, label %block_14, label %block_15
 block_14:
   %var_120 = load i64, ptr %var_74
-  %var_76 = getelementptr ptr, ptr @array0, i64 %var_120
+  %var_76_offset_chk = icmp slt i64 %var_120, 0
+  %var_76_offset = select i1 %var_76_offset_chk, i64 1, i64 0
+  %var_76 = getelementptr [2 x ptr], ptr @array0, i64 %var_76_offset, i64 %var_120
   %var_121 = load ptr, ptr %var_76
   call void @Reset(ptr %var_121)
   %var_79 = add i64 %var_120, 1
@@ -128,7 +138,9 @@ block_16:
   br i1 %var_81, label %block_17, label %block_18
 block_17:
   %var_117 = load i64, ptr %var_80
-  %var_82 = getelementptr ptr, ptr @array1, i64 %var_117
+  %var_82_offset_chk = icmp slt i64 %var_117, 0
+  %var_82_offset = select i1 %var_82_offset_chk, i64 1, i64 0
+  %var_82 = getelementptr [2 x ptr], ptr @array1, i64 %var_82_offset, i64 %var_117
   %var_118 = load ptr, ptr %var_82
   call void @Reset(ptr %var_118)
   %var_84 = add i64 %var_117, 1
@@ -143,7 +155,9 @@ block_19:
   br i1 %var_86, label %block_20, label %block_21
 block_20:
   %var_114 = load i64, ptr %var_85
-  %var_87 = getelementptr ptr, ptr @array2, i64 %var_114
+  %var_87_offset_chk = icmp slt i64 %var_114, 0
+  %var_87_offset = select i1 %var_87_offset_chk, i64 1, i64 0
+  %var_87 = getelementptr [2 x ptr], ptr @array2, i64 %var_87_offset, i64 %var_114
   %var_115 = load ptr, ptr %var_87
   call void @Reset(ptr %var_115)
   %var_89 = add i64 %var_114, 1
@@ -158,7 +172,9 @@ block_22:
   br i1 %var_91, label %block_23, label %block_24
 block_23:
   %var_111 = load i64, ptr %var_90
-  %var_92 = getelementptr ptr, ptr @array3, i64 %var_111
+  %var_92_offset_chk = icmp slt i64 %var_111, 0
+  %var_92_offset = select i1 %var_92_offset_chk, i64 1, i64 0
+  %var_92 = getelementptr [2 x ptr], ptr @array3, i64 %var_92_offset, i64 %var_111
   %var_112 = load ptr, ptr %var_92
   call void @Reset(ptr %var_112)
   %var_94 = add i64 %var_111, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/HiddenShiftNISQ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/HiddenShiftNISQ.ll
@@ -33,7 +33,9 @@ block_1:
   br i1 %var_3, label %block_2, label %block_3
 block_2:
   %var_110 = load i64, ptr %var_2
-  %var_4 = getelementptr ptr, ptr @array0, i64 %var_110
+  %var_4_offset_chk = icmp slt i64 %var_110, 0
+  %var_4_offset = select i1 %var_4_offset_chk, i64 1, i64 0
+  %var_4 = getelementptr [6 x ptr], ptr @array0, i64 %var_4_offset, i64 %var_110
   %var_111 = load ptr, ptr %var_4
   call void @H(ptr %var_111)
   %var_7 = add i64 %var_110, 1
@@ -49,7 +51,9 @@ block_4:
   br i1 %var_10, label %block_5, label %block_6
 block_5:
   %var_101 = load i64, ptr %var_9
-  %var_11 = getelementptr ptr, ptr @array0, i64 %var_101
+  %var_11_offset_chk = icmp slt i64 %var_101, 0
+  %var_11_offset = select i1 %var_11_offset_chk, i64 1, i64 0
+  %var_11 = getelementptr [6 x ptr], ptr @array0, i64 %var_11_offset, i64 %var_101
   %var_102 = load ptr, ptr %var_11
   store ptr %var_102, ptr %var_12
   %var_104 = load i64, ptr %var_8
@@ -86,9 +90,13 @@ block_11:
   br label %block_10
 block_12:
   %var_97 = load i64, ptr %var_19
-  %var_22 = getelementptr ptr, ptr @array1, i64 %var_97
+  %var_22_offset_chk = icmp slt i64 %var_97, 0
+  %var_22_offset = select i1 %var_22_offset_chk, i64 1, i64 0
+  %var_22 = getelementptr [3 x ptr], ptr @array1, i64 %var_22_offset, i64 %var_97
   %var_98 = load ptr, ptr %var_22
-  %var_23 = getelementptr ptr, ptr @array2, i64 %var_97
+  %var_23_offset_chk = icmp slt i64 %var_97, 0
+  %var_23_offset = select i1 %var_23_offset_chk, i64 1, i64 0
+  %var_23 = getelementptr [3 x ptr], ptr @array2, i64 %var_23_offset, i64 %var_97
   %var_99 = load ptr, ptr %var_23
   call void @CZ(ptr %var_98, ptr %var_99)
   %var_26 = add i64 %var_97, 1
@@ -104,7 +112,9 @@ block_14:
   br i1 %var_29, label %block_15, label %block_16
 block_15:
   %var_88 = load i64, ptr %var_28
-  %var_30 = getelementptr ptr, ptr @array0, i64 %var_88
+  %var_30_offset_chk = icmp slt i64 %var_88, 0
+  %var_30_offset = select i1 %var_30_offset_chk, i64 1, i64 0
+  %var_30 = getelementptr [6 x ptr], ptr @array0, i64 %var_30_offset, i64 %var_88
   %var_89 = load ptr, ptr %var_30
   store ptr %var_89, ptr %var_31
   %var_91 = load i64, ptr %var_27
@@ -134,7 +144,9 @@ block_19:
   br label %block_14
 block_20:
   %var_85 = load i64, ptr %var_37
-  %var_39 = getelementptr ptr, ptr @array0, i64 %var_85
+  %var_39_offset_chk = icmp slt i64 %var_85, 0
+  %var_39_offset = select i1 %var_39_offset_chk, i64 1, i64 0
+  %var_39 = getelementptr [6 x ptr], ptr @array0, i64 %var_39_offset, i64 %var_85
   %var_86 = load ptr, ptr %var_39
   call void @H(ptr %var_86)
   %var_41 = add i64 %var_85, 1
@@ -156,9 +168,13 @@ block_24:
   br label %block_23
 block_25:
   %var_81 = load i64, ptr %var_42
-  %var_45 = getelementptr ptr, ptr @array1, i64 %var_81
+  %var_45_offset_chk = icmp slt i64 %var_81, 0
+  %var_45_offset = select i1 %var_45_offset_chk, i64 1, i64 0
+  %var_45 = getelementptr [3 x ptr], ptr @array1, i64 %var_45_offset, i64 %var_81
   %var_82 = load ptr, ptr %var_45
-  %var_46 = getelementptr ptr, ptr @array2, i64 %var_81
+  %var_46_offset_chk = icmp slt i64 %var_81, 0
+  %var_46_offset = select i1 %var_46_offset_chk, i64 1, i64 0
+  %var_46 = getelementptr [3 x ptr], ptr @array2, i64 %var_46_offset, i64 %var_81
   %var_83 = load ptr, ptr %var_46
   call void @CZ(ptr %var_82, ptr %var_83)
   %var_47 = add i64 %var_81, 1
@@ -173,7 +189,9 @@ block_27:
   br i1 %var_49, label %block_28, label %block_29
 block_28:
   %var_78 = load i64, ptr %var_48
-  %var_50 = getelementptr ptr, ptr @array0, i64 %var_78
+  %var_50_offset_chk = icmp slt i64 %var_78, 0
+  %var_50_offset = select i1 %var_50_offset_chk, i64 1, i64 0
+  %var_50 = getelementptr [6 x ptr], ptr @array0, i64 %var_50_offset, i64 %var_78
   %var_79 = load ptr, ptr %var_50
   call void @H__Adj(ptr %var_79)
   %var_53 = add i64 %var_78, -1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicCCNOT.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicCCNOT.ll
@@ -33,7 +33,9 @@ block_1:
   br i1 %var_7, label %block_2, label %block_3
 block_2:
   %var_39 = load i64, ptr %var_6
-  %var_8 = getelementptr ptr, ptr @array0, i64 %var_39
+  %var_8_offset_chk = icmp slt i64 %var_39, 0
+  %var_8_offset = select i1 %var_8_offset_chk, i64 1, i64 0
+  %var_8 = getelementptr [3 x ptr], ptr @array0, i64 %var_8_offset, i64 %var_39
   %var_40 = load ptr, ptr %var_8
   call void @Reset(ptr %var_40)
   %var_11 = add i64 %var_39, 1
@@ -53,7 +55,9 @@ block_4:
   br i1 %var_16, label %block_5, label %block_6
 block_5:
   %var_36 = load i64, ptr %var_15
-  %var_17 = getelementptr ptr, ptr @array1, i64 %var_36
+  %var_17_offset_chk = icmp slt i64 %var_36, 0
+  %var_17_offset = select i1 %var_17_offset_chk, i64 1, i64 0
+  %var_17 = getelementptr [3 x ptr], ptr @array1, i64 %var_17_offset, i64 %var_36
   %var_37 = load ptr, ptr %var_17
   call void @Reset(ptr %var_37)
   %var_19 = add i64 %var_36, 1
@@ -74,7 +78,9 @@ block_7:
   br i1 %var_23, label %block_8, label %block_9
 block_8:
   %var_33 = load i64, ptr %var_22
-  %var_24 = getelementptr ptr, ptr @array2, i64 %var_33
+  %var_24_offset_chk = icmp slt i64 %var_33, 0
+  %var_24_offset = select i1 %var_24_offset_chk, i64 1, i64 0
+  %var_24 = getelementptr [3 x ptr], ptr @array2, i64 %var_24_offset, i64 %var_33
   %var_34 = load ptr, ptr %var_24
   call void @Reset(ptr %var_34)
   %var_26 = add i64 %var_33, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicCNOT.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicCNOT.ll
@@ -24,7 +24,9 @@ block_1:
   br i1 %var_6, label %block_2, label %block_3
 block_2:
   %var_26 = load i64, ptr %var_5
-  %var_7 = getelementptr ptr, ptr @array0, i64 %var_26
+  %var_7_offset_chk = icmp slt i64 %var_26, 0
+  %var_7_offset = select i1 %var_7_offset_chk, i64 1, i64 0
+  %var_7 = getelementptr [2 x ptr], ptr @array0, i64 %var_7_offset, i64 %var_26
   %var_27 = load ptr, ptr %var_7
   call void @Reset(ptr %var_27)
   %var_10 = add i64 %var_26, 1
@@ -43,7 +45,9 @@ block_4:
   br i1 %var_15, label %block_5, label %block_6
 block_5:
   %var_23 = load i64, ptr %var_14
-  %var_16 = getelementptr ptr, ptr @array1, i64 %var_23
+  %var_16_offset_chk = icmp slt i64 %var_23, 0
+  %var_16_offset = select i1 %var_16_offset_chk, i64 1, i64 0
+  %var_16 = getelementptr [2 x ptr], ptr @array1, i64 %var_16_offset, i64 %var_23
   %var_24 = load ptr, ptr %var_16
   call void @Reset(ptr %var_24)
   %var_18 = add i64 %var_23, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicRotationsWithPeriod.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicRotationsWithPeriod.ll
@@ -28,7 +28,9 @@ block_1:
   br i1 %var_5, label %block_2, label %block_3
 block_2:
   %var_52 = load i64, ptr %var_4
-  %var_6 = getelementptr ptr, ptr @array0, i64 %var_52
+  %var_6_offset_chk = icmp slt i64 %var_52, 0
+  %var_6_offset = select i1 %var_6_offset_chk, i64 1, i64 0
+  %var_6 = getelementptr [2 x ptr], ptr @array0, i64 %var_6_offset, i64 %var_52
   %var_53 = load ptr, ptr %var_6
   call void @X(ptr %var_53)
   %var_9 = add i64 %var_52, 1
@@ -43,7 +45,9 @@ block_4:
   br i1 %var_11, label %block_5, label %block_6
 block_5:
   %var_49 = load i64, ptr %var_10
-  %var_12 = getelementptr ptr, ptr @array1, i64 %var_49
+  %var_12_offset_chk = icmp slt i64 %var_49, 0
+  %var_12_offset = select i1 %var_12_offset_chk, i64 1, i64 0
+  %var_12 = getelementptr [2 x ptr], ptr @array1, i64 %var_12_offset, i64 %var_49
   %var_50 = load ptr, ptr %var_12
   call void @Y(ptr %var_50)
   %var_15 = add i64 %var_49, 1
@@ -58,7 +62,9 @@ block_7:
   br i1 %var_17, label %block_8, label %block_9
 block_8:
   %var_46 = load i64, ptr %var_16
-  %var_18 = getelementptr ptr, ptr @array2, i64 %var_46
+  %var_18_offset_chk = icmp slt i64 %var_46, 0
+  %var_18_offset = select i1 %var_18_offset_chk, i64 1, i64 0
+  %var_18 = getelementptr [2 x ptr], ptr @array2, i64 %var_18_offset, i64 %var_46
   %var_47 = load ptr, ptr %var_18
   call void @H(ptr %var_47)
   call void @Z(ptr %var_47)

--- a/source/qdk_package/tests-integration/resources/adaptive/output/LoopOverArrays.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/LoopOverArrays.ll
@@ -18,7 +18,9 @@ block_1:
   br i1 %var_1, label %block_2, label %block_3
 block_2:
   %var_40 = load i64, ptr %var_0
-  %var_2 = getelementptr double, ptr @array0, i64 %var_40
+  %var_2_offset_chk = icmp slt i64 %var_40, 0
+  %var_2_offset = select i1 %var_2_offset_chk, i64 1, i64 0
+  %var_2 = getelementptr [3 x double], ptr @array0, i64 %var_2_offset, i64 %var_40
   %var_41 = load double, ptr %var_2
   call void @Rx(double %var_41, ptr inttoptr (i64 0 to ptr))
   %var_6 = add i64 %var_40, 1
@@ -33,7 +35,9 @@ block_4:
   br i1 %var_9, label %block_5, label %block_6
 block_5:
   %var_37 = load i64, ptr %var_8
-  %var_10 = getelementptr double, ptr @array1, i64 %var_37
+  %var_10_offset_chk = icmp slt i64 %var_37, 0
+  %var_10_offset = select i1 %var_10_offset_chk, i64 1, i64 0
+  %var_10 = getelementptr [3 x double], ptr @array1, i64 %var_10_offset, i64 %var_37
   %var_38 = load double, ptr %var_10
   call void @Rx(double %var_38, ptr inttoptr (i64 0 to ptr))
   %var_12 = add i64 %var_37, 1
@@ -48,7 +52,9 @@ block_7:
   br i1 %var_14, label %block_8, label %block_9
 block_8:
   %var_34 = load i64, ptr %var_13
-  %var_15 = getelementptr double, ptr @array0, i64 %var_34
+  %var_15_offset_chk = icmp slt i64 %var_34, 0
+  %var_15_offset = select i1 %var_15_offset_chk, i64 1, i64 0
+  %var_15 = getelementptr [3 x double], ptr @array0, i64 %var_15_offset, i64 %var_34
   %var_35 = load double, ptr %var_15
   call void @Rx(double %var_35, ptr inttoptr (i64 0 to ptr))
   %var_17 = add i64 %var_34, 1
@@ -63,7 +69,9 @@ block_10:
   br i1 %var_19, label %block_11, label %block_12
 block_11:
   %var_31 = load i64, ptr %var_18
-  %var_20 = getelementptr double, ptr @array2, i64 %var_31
+  %var_20_offset_chk = icmp slt i64 %var_31, 0
+  %var_20_offset = select i1 %var_20_offset_chk, i64 1, i64 0
+  %var_20 = getelementptr [1 x double], ptr @array2, i64 %var_20_offset, i64 %var_31
   %var_32 = load double, ptr %var_20
   call void @Rx(double %var_32, ptr inttoptr (i64 0 to ptr))
   %var_22 = add i64 %var_31, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/NegativeIndexing.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/NegativeIndexing.ll
@@ -1,0 +1,69 @@
+@0 = internal constant [4 x i8] c"0_a\00"
+@1 = internal constant [6 x i8] c"1_a0r\00"
+@2 = internal constant [6 x i8] c"2_a1r\00"
+@3 = internal constant [6 x i8] c"3_a2r\00"
+@array0 = internal constant [3 x ptr] [ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr)]
+
+define i64 @ENTRYPOINT__main() #0 {
+block_0:
+  %var_1 = alloca i64
+  call void @__quantum__rt__initialize(ptr null)
+  store i64 -2, ptr %var_1
+  br label %block_1
+block_1:
+  %var_7 = load i64, ptr %var_1
+  %var_2 = icmp sge i64 %var_7, -3
+  br i1 %var_2, label %block_2, label %block_3
+block_2:
+  %var_8 = load i64, ptr %var_1
+  %var_3_offset_chk = icmp slt i64 %var_8, 0
+  %var_3_offset = select i1 %var_3_offset_chk, i64 1, i64 0
+  %var_3 = getelementptr [3 x ptr], ptr @array0, i64 %var_3_offset, i64 %var_8
+  %var_9 = load ptr, ptr %var_3
+  call void @X(ptr %var_9)
+  %var_5 = add i64 %var_8, -1
+  store i64 %var_5, ptr %var_1
+  br label %block_1
+block_3:
+  call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+  call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+  call void @__quantum__rt__array_record_output(i64 3, ptr @0)
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr @1)
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr @2)
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr @3)
+  ret i64 0
+}
+
+declare void @__quantum__rt__initialize(ptr)
+
+define internal void @X(ptr %var_4) {
+block_4:
+  call void @__quantum__qis__x__body(ptr %var_4)
+  ret void
+}
+
+declare void @__quantum__qis__x__body(ptr)
+
+declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
+
+declare void @__quantum__rt__array_record_output(i64, ptr)
+
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
+attributes #1 = { "irreversible" }
+
+; module flags
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8}
+
+!0 = !{i32 1, !"qir_major_version", i32 2}
+!1 = !{i32 7, !"qir_minor_version", i32 1}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+!4 = !{i32 5, !"int_computations", !{!"i64"}}
+!5 = !{i32 5, !"float_computations", !{!"double"}}
+!6 = !{i32 7, !"backwards_branching", i2 3}
+!7 = !{i32 1, !"arrays", i1 true}
+!8 = !{i32 1, !"ir_functions", i1 true}

--- a/source/qdk_package/tests-integration/resources/adaptive/output/NegativeIndexing.out
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/NegativeIndexing.out
@@ -1,0 +1,11 @@
+START
+METADATA	entry_point
+METADATA	output_labeling_schema
+METADATA	qir_profiles	adaptive_profile
+METADATA	required_num_qubits	3
+METADATA	required_num_results	3
+OUTPUT	ARRAY	3	0_a
+OUTPUT	RESULT	1	1_a0r
+OUTPUT	RESULT	1	2_a1r
+OUTPUT	RESULT	0	3_a2r
+END	0

--- a/source/qdk_package/tests-integration/resources/adaptive/output/NestedBranching.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/NestedBranching.ll
@@ -131,7 +131,9 @@ block_24:
   br label %block_29
 block_25:
   %var_132 = load i64, ptr %var_37
-  %var_39 = getelementptr ptr, ptr @array0, i64 %var_132
+  %var_39_offset_chk = icmp slt i64 %var_132, 0
+  %var_39_offset = select i1 %var_39_offset_chk, i64 1, i64 0
+  %var_39 = getelementptr [3 x ptr], ptr @array0, i64 %var_39_offset, i64 %var_132
   %var_133 = load ptr, ptr %var_39
   call void @Reset(ptr %var_133)
   %var_42 = add i64 %var_132, 1
@@ -167,7 +169,9 @@ block_33:
   br label %block_38
 block_34:
   %var_123 = load i64, ptr %var_45
-  %var_47 = getelementptr ptr, ptr @array1, i64 %var_123
+  %var_47_offset_chk = icmp slt i64 %var_123, 0
+  %var_47_offset = select i1 %var_47_offset_chk, i64 1, i64 0
+  %var_47 = getelementptr [4 x ptr], ptr @array1, i64 %var_47_offset, i64 %var_123
   %var_124 = load ptr, ptr %var_47
   store ptr %var_124, ptr %var_48
   %var_126 = load i64, ptr %var_44
@@ -307,7 +311,9 @@ block_70:
   br i1 %var_87, label %block_76, label %block_77
 block_71:
   %var_118 = load i64, ptr %var_92
-  %var_94 = getelementptr ptr, ptr @array1, i64 %var_118
+  %var_94_offset_chk = icmp slt i64 %var_118, 0
+  %var_94_offset = select i1 %var_94_offset_chk, i64 1, i64 0
+  %var_94 = getelementptr [4 x ptr], ptr @array1, i64 %var_94_offset, i64 %var_118
   %var_119 = load ptr, ptr %var_94
   call void @Reset(ptr %var_119)
   %var_96 = add i64 %var_118, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/RUS.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/RUS.ll
@@ -30,7 +30,9 @@ block_4:
   br i1 %var_3, label %block_5, label %block_6
 block_5:
   %var_31 = load i64, ptr %var_2
-  %var_4 = getelementptr ptr, ptr @array0, i64 %var_31
+  %var_4_offset_chk = icmp slt i64 %var_31, 0
+  %var_4_offset = select i1 %var_4_offset_chk, i64 1, i64 0
+  %var_4 = getelementptr [2 x ptr], ptr @array0, i64 %var_4_offset, i64 %var_31
   %var_32 = load ptr, ptr %var_4
   call void @H(ptr %var_32)
   %var_7 = add i64 %var_31, 1
@@ -56,7 +58,9 @@ block_9:
   br i1 %var_15, label %block_10, label %block_11
 block_10:
   %var_28 = load i64, ptr %var_14
-  %var_16 = getelementptr ptr, ptr @array0, i64 %var_28
+  %var_16_offset_chk = icmp slt i64 %var_28, 0
+  %var_16_offset = select i1 %var_16_offset_chk, i64 1, i64 0
+  %var_16 = getelementptr [2 x ptr], ptr @array0, i64 %var_16_offset, i64 %var_28
   %var_29 = load ptr, ptr %var_16
   call void @Reset(ptr %var_29)
   %var_19 = add i64 %var_28, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/SampleTeleport.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/SampleTeleport.ll
@@ -40,7 +40,9 @@ block_5:
   br i1 %var_15, label %block_6, label %block_7
 block_6:
   %var_25 = load i64, ptr %var_14
-  %var_16 = getelementptr ptr, ptr @array0, i64 %var_25
+  %var_16_offset_chk = icmp slt i64 %var_25, 0
+  %var_16_offset = select i1 %var_16_offset_chk, i64 1, i64 0
+  %var_16 = getelementptr [2 x ptr], ptr @array0, i64 %var_16_offset, i64 %var_25
   %var_26 = load ptr, ptr %var_16
   call void @Reset(ptr %var_26)
   %var_19 = add i64 %var_25, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/Slicing.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/Slicing.ll
@@ -19,7 +19,9 @@ block_1:
   br i1 %var_3, label %block_2, label %block_3
 block_2:
   %var_21 = load i64, ptr %var_2
-  %var_4 = getelementptr ptr, ptr @array0, i64 %var_21
+  %var_4_offset_chk = icmp slt i64 %var_21, 0
+  %var_4_offset = select i1 %var_4_offset_chk, i64 1, i64 0
+  %var_4 = getelementptr [10 x ptr], ptr @array0, i64 %var_4_offset, i64 %var_21
   %var_22 = load ptr, ptr %var_4
   call void @X(ptr %var_22)
   %var_6 = add i64 %var_21, -1
@@ -39,7 +41,9 @@ block_4:
   br i1 %var_9, label %block_5, label %block_6
 block_5:
   %var_18 = load i64, ptr %var_8
-  %var_10 = getelementptr ptr, ptr @array0, i64 %var_18
+  %var_10_offset_chk = icmp slt i64 %var_18, 0
+  %var_10_offset = select i1 %var_10_offset_chk, i64 1, i64 0
+  %var_10 = getelementptr [10 x ptr], ptr @array0, i64 %var_10_offset, i64 %var_18
   %var_19 = load ptr, ptr %var_10
   call void @Reset(ptr %var_19)
   %var_13 = add i64 %var_18, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/SuperdenseCoding.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/SuperdenseCoding.ll
@@ -49,7 +49,9 @@ block_1:
   br i1 %var_35, label %block_2, label %block_3
 block_2:
   %var_52 = load i64, ptr %var_34
-  %var_36 = getelementptr ptr, ptr @array0, i64 %var_52
+  %var_36_offset_chk = icmp slt i64 %var_52, 0
+  %var_36_offset = select i1 %var_36_offset_chk, i64 1, i64 0
+  %var_36 = getelementptr [2 x ptr], ptr @array0, i64 %var_36_offset, i64 %var_52
   %var_53 = load ptr, ptr %var_36
   call void @Reset(ptr %var_53)
   %var_39 = add i64 %var_52, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/SwitchHandling.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/SwitchHandling.ll
@@ -15,7 +15,9 @@ block_1:
   br i1 %var_3, label %block_2, label %block_3
 block_2:
   %var_49 = load i64, ptr %var_2
-  %var_4 = getelementptr ptr, ptr @array0, i64 %var_49
+  %var_4_offset_chk = icmp slt i64 %var_49, 0
+  %var_4_offset = select i1 %var_4_offset_chk, i64 1, i64 0
+  %var_4 = getelementptr [2 x ptr], ptr @array0, i64 %var_4_offset, i64 %var_49
   %var_50 = load ptr, ptr %var_4
   call void @X(ptr %var_50)
   %var_7 = add i64 %var_49, 1
@@ -53,7 +55,9 @@ block_8:
   br i1 %var_19, label %block_9, label %block_10
 block_9:
   %var_42 = load i64, ptr %var_18
-  %var_20 = getelementptr ptr, ptr @array0, i64 %var_42
+  %var_20_offset_chk = icmp slt i64 %var_42, 0
+  %var_20_offset = select i1 %var_20_offset_chk, i64 1, i64 0
+  %var_20 = getelementptr [2 x ptr], ptr @array0, i64 %var_20_offset, i64 %var_42
   %var_43 = load ptr, ptr %var_20
   call void @Reset(ptr %var_43)
   %var_23 = add i64 %var_42, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ThreeQubitRepetitionCode.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ThreeQubitRepetitionCode.ll
@@ -63,7 +63,9 @@ block_9:
   br label %block_8
 block_10:
   %var_56 = load i64, ptr %var_39
-  %var_41 = getelementptr ptr, ptr @array1, i64 %var_56
+  %var_41_offset_chk = icmp slt i64 %var_56, 0
+  %var_41_offset = select i1 %var_41_offset_chk, i64 1, i64 0
+  %var_41 = getelementptr [2 x ptr], ptr @array1, i64 %var_41_offset, i64 %var_56
   %var_57 = load ptr, ptr %var_41
   call void @Reset(ptr %var_57)
   %var_44 = add i64 %var_56, 1
@@ -101,7 +103,9 @@ block_16:
   br i1 %var_29, label %block_21, label %block_22
 block_17:
   %var_75 = load i64, ptr %var_13
-  %var_15 = getelementptr ptr, ptr @array0, i64 %var_75
+  %var_15_offset_chk = icmp slt i64 %var_75, 0
+  %var_15_offset = select i1 %var_15_offset_chk, i64 1, i64 0
+  %var_15 = getelementptr [3 x ptr], ptr @array0, i64 %var_15_offset, i64 %var_75
   %var_76 = load ptr, ptr %var_15
   call void @Rx(double 1.5707963267948966, ptr %var_76)
   %var_19 = add i64 %var_75, 1

--- a/source/qdk_package/tests-integration/resources/adaptive/output/WithinApply.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/WithinApply.ll
@@ -18,7 +18,9 @@ block_1:
   br i1 %var_3, label %block_2, label %block_3
 block_2:
   %var_36 = load i64, ptr %var_2
-  %var_4 = getelementptr ptr, ptr @array0, i64 %var_36
+  %var_4_offset_chk = icmp slt i64 %var_36, 0
+  %var_4_offset = select i1 %var_4_offset_chk, i64 1, i64 0
+  %var_4 = getelementptr [2 x ptr], ptr @array0, i64 %var_4_offset, i64 %var_36
   %var_37 = load ptr, ptr %var_4
   call void @X(ptr %var_37)
   %var_7 = add i64 %var_36, 1
@@ -34,7 +36,9 @@ block_4:
   br i1 %var_12, label %block_5, label %block_6
 block_5:
   %var_33 = load i64, ptr %var_11
-  %var_13 = getelementptr ptr, ptr @array0, i64 %var_33
+  %var_13_offset_chk = icmp slt i64 %var_33, 0
+  %var_13_offset = select i1 %var_13_offset_chk, i64 1, i64 0
+  %var_13 = getelementptr [2 x ptr], ptr @array0, i64 %var_13_offset, i64 %var_33
   %var_34 = load ptr, ptr %var_13
   call void @X__Adj(ptr %var_34)
   %var_16 = add i64 %var_33, -1
@@ -52,7 +56,9 @@ block_7:
   br i1 %var_19, label %block_8, label %block_9
 block_8:
   %var_30 = load i64, ptr %var_18
-  %var_20 = getelementptr ptr, ptr @array0, i64 %var_30
+  %var_20_offset_chk = icmp slt i64 %var_30, 0
+  %var_20_offset = select i1 %var_20_offset_chk, i64 1, i64 0
+  %var_20 = getelementptr [2 x ptr], ptr @array0, i64 %var_20_offset, i64 %var_30
   %var_31 = load ptr, ptr %var_20
   call void @Reset(ptr %var_31)
   %var_23 = add i64 %var_30, 1

--- a/source/samples_test/src/tests/OpenQASM.rs
+++ b/source/samples_test/src/tests/OpenQASM.rs
@@ -22,12 +22,12 @@ pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zer
 pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4341"];
 pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 4548"];
-pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5492"];
+pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5893"];
 pub const GROVER_EXPECT: Expect = expect!["[Zero, One, Zero, One, Zero]"];
 pub const GROVER_EXPECT_DEBUG: Expect = expect!["[Zero, One, Zero, One, Zero]"];
 pub const GROVER_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 33215"];
 pub const GROVER_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 20376"];
-pub const GROVER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 17485"];
+pub const GROVER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 21865"];
 pub const RANDOMNUMBER_EXPECT: Expect = expect!["9"];
 pub const RANDOMNUMBER_EXPECT_DEBUG: Expect = expect!["9"];
 pub const RANDOMNUMBER_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 3559"];
@@ -41,7 +41,7 @@ pub const SIMPLE1DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circui
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18979"];
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 11216"];
+    expect!["generated QIR of length 12035"];
 pub const TELEPORTATION_EXPECT: Expect = expect!["Zero"];
 pub const TELEPORTATION_EXPECT_DEBUG: Expect = expect!["Zero"];
 pub const TELEPORTATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 2086"];

--- a/source/samples_test/src/tests/algorithms.rs
+++ b/source/samples_test/src/tests/algorithms.rs
@@ -11,7 +11,7 @@ pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 29822"];
 pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 20277"];
-pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 18517"];
+pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 19343"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_CIRCUIT: Expect =
@@ -19,7 +19,7 @@ pub const BERNSTEINVAZIRANINISQ_EXPECT_CIRCUIT: Expect =
 pub const BERNSTEINVAZIRANINISQ_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 4194"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 4496"];
+    expect!["generated QIR of length 4762"];
 pub const BITFLIPCODE_EXPECT: Expect = expect![[r#"
     STATE:
     |010⟩: 0.4472+0.0000𝑖
@@ -38,12 +38,12 @@ pub const BITFLIPCODE_EXPECT_DEBUG: Expect = expect![[r#"
     One"#]];
 pub const BITFLIPCODE_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 6530"];
 pub const BITFLIPCODE_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 3794"];
-pub const BITFLIPCODE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5457"];
+pub const BITFLIPCODE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5858"];
 pub const DEUTSCHJOZSA_EXPECT: Expect = expect!["[true, false, true, false]"];
 pub const DEUTSCHJOZSA_EXPECT_DEBUG: Expect = expect!["[true, false, true, false]"];
 pub const DEUTSCHJOZSA_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 197703"];
 pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 82661"];
-pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 25864"];
+pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 31414"];
 pub const DEUTSCHJOZSANISQ_EXPECT: Expect =
     expect!["([One, Zero, Zero, Zero, Zero], [Zero, Zero, Zero, Zero, Zero])"];
 pub const DEUTSCHJOZSANISQ_EXPECT_DEBUG: Expect =
@@ -51,7 +51,7 @@ pub const DEUTSCHJOZSANISQ_EXPECT_DEBUG: Expect =
 pub const DEUTSCHJOZSANISQ_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 5865"];
 pub const DEUTSCHJOZSANISQ_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 7022"];
-pub const DEUTSCHJOZSANISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 6895"];
+pub const DEUTSCHJOZSANISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7431"];
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT: Expect = expect![[r#"
     Computing inner product of vectors (cos(Θ₁/2), sin(Θ₁/2))⋅(cos(Θ₂/2), sin(Θ₂/2)) ≈ -cos(x𝝅/2ⁿ)
     Θ₁=0.4487989505128276, Θ₂=0.6283185307179586.
@@ -86,7 +86,7 @@ pub const GROVER_EXPECT_DEBUG: Expect = expect![[r#"
     [Zero, One, Zero, One, Zero]"#]];
 pub const GROVER_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 36701"];
 pub const GROVER_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 19889"];
-pub const GROVER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 15446"];
+pub const GROVER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 19685"];
 pub const HIDDENSHIFT_EXPECT: Expect = expect![[r#"
     Found 170 successfully!
     Found 512 successfully!
@@ -99,18 +99,18 @@ pub const HIDDENSHIFT_EXPECT_DEBUG: Expect = expect![[r#"
     [170, 512, 999]"#]];
 pub const HIDDENSHIFT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 42131"];
 pub const HIDDENSHIFT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 25479"];
-pub const HIDDENSHIFT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 29723"];
+pub const HIDDENSHIFT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 33470"];
 pub const HIDDENSHIFTNISQ_EXPECT: Expect = expect!["[One, Zero, Zero, Zero, Zero, One]"];
 pub const HIDDENSHIFTNISQ_EXPECT_DEBUG: Expect = expect!["[One, Zero, Zero, Zero, Zero, One]"];
 pub const HIDDENSHIFTNISQ_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4379"];
 pub const HIDDENSHIFTNISQ_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 5455"];
-pub const HIDDENSHIFTNISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 8448"];
+pub const HIDDENSHIFTNISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 9661"];
 pub const PHASEESTIMATION_EXPECT: Expect = expect!["1.0799224746714913"];
 pub const PHASEESTIMATION_EXPECT_DEBUG: Expect = expect!["1.0799224746714913"];
 pub const PHASEESTIMATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 249358"];
 pub const PHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 95778"];
-pub const PHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 15701"];
+pub const PHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 16253"];
 pub const PHASEFLIPCODE_EXPECT: Expect = expect![[r#"
     STATE:
     |000⟩: 0.4743+0.0000𝑖
@@ -153,7 +153,7 @@ pub const PHASEFLIPCODE_EXPECT_DEBUG: Expect = expect![[r#"
     One"#]];
 pub const PHASEFLIPCODE_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 8247"];
 pub const PHASEFLIPCODE_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 4734"];
-pub const PHASEFLIPCODE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7695"];
+pub const PHASEFLIPCODE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 8636"];
 pub const QRNG_EXPECT: Expect = expect!["7568811972615905454"];
 pub const QRNG_EXPECT_DEBUG: Expect = expect!["7568811972615905454"];
 pub const QRNG_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 232827"];
@@ -190,7 +190,7 @@ pub const SIMPLEPHASEESTIMATION_EXPECT_CIRCUIT: Expect =
 pub const SIMPLEPHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 39770"];
 pub const SIMPLEPHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 12224"];
+    expect!["generated QIR of length 12492"];
 pub const SIMPLEVQE_EXPECT: Expect = expect![[r#"
    Beginning descent from value 0.43300000000000005.
    Value improved to 0.35300000000000004.
@@ -219,7 +219,7 @@ pub const SUPERDENSECODING_EXPECT_DEBUG: Expect = expect!["((false, true), (fals
 pub const SUPERDENSECODING_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4291"];
 pub const SUPERDENSECODING_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 4842"];
-pub const SUPERDENSECODING_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5812"];
+pub const SUPERDENSECODING_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5947"];
 pub const TELEPORTATION_EXPECT: Expect = expect![[r#"
     Teleporting state |0〉
     STATE:
@@ -282,7 +282,7 @@ pub const TELEPORTATION_EXPECT_DEBUG: Expect = expect![[r#"
     [Zero, One, Zero, One]"#]];
 pub const TELEPORTATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 12039"];
 pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 8555"];
-pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 9085"];
+pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 9625"];
 pub const THREEQUBITREPETITIONCODE_EXPECT: Expect = expect!["(true, 0)"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_DEBUG: Expect = expect!["(true, 0)"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_CIRCUIT: Expect =
@@ -290,4 +290,4 @@ pub const THREEQUBITREPETITIONCODE_EXPECT_CIRCUIT: Expect =
 pub const THREEQUBITREPETITIONCODE_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18122"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 7159"];
+    expect!["generated QIR of length 7429"];

--- a/source/samples_test/src/tests/algorithms_Ising.rs
+++ b/source/samples_test/src/tests/algorithms_Ising.rs
@@ -14,7 +14,7 @@ pub const SIMPLE2DISINGORDER2_EXPECT_CIRCUIT: Expect = expect!["generated circui
 pub const SIMPLE2DISINGORDER2_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 20849"];
 pub const SIMPLE2DISINGORDER2_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 11739"];
+    expect!["generated QIR of length 14177"];
 pub const SIMPLE1DISINGORDER1_EXPECT: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, Zero, Zero, Zero]"];
 pub const SIMPLE1DISINGORDER1_EXPECT_DEBUG: Expect =
@@ -22,7 +22,7 @@ pub const SIMPLE1DISINGORDER1_EXPECT_DEBUG: Expect =
 pub const SIMPLE1DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 12317"];
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18408"];
-pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 6557"];
+pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7228"];
 pub const SIMPLE2DISINGORDER1_EXPECT: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, One, One, Zero]"];
 pub const SIMPLE2DISINGORDER1_EXPECT_DEBUG: Expect =
@@ -31,4 +31,4 @@ pub const SIMPLE2DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circui
 pub const SIMPLE2DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 16214"];
 pub const SIMPLE2DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 11241"];
+    expect!["generated QIR of length 13543"];

--- a/source/samples_test/src/tests/getting_started.rs
+++ b/source/samples_test/src/tests/getting_started.rs
@@ -70,7 +70,7 @@ pub const CATSTATES_EXPECT_DEBUG: Expect = expect![[r#"
     [Zero, Zero, Zero, Zero, Zero]"#]];
 pub const CATSTATES_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 1807"];
 pub const CATSTATES_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 3311"];
-pub const CATSTATES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 3274"];
+pub const CATSTATES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 3405"];
 pub const RANDOMBITS_EXPECT: Expect = expect!["[Zero, Zero, One, One, One]"];
 pub const RANDOMBITS_EXPECT_DEBUG: Expect = expect!["[Zero, Zero, One, One, One]"];
 pub const RANDOMBITS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 3486"];
@@ -89,7 +89,7 @@ pub const SIMPLETELEPORTATION_EXPECT_DEBUG: Expect = expect![[r#"
 pub const SIMPLETELEPORTATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 1463"];
 pub const SIMPLETELEPORTATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 3118"];
-pub const SIMPLETELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 4030"];
+pub const SIMPLETELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 4165"];
 pub const ENTANGLEMENT_EXPECT: Expect = expect![[r#"
     STATE:
     |00⟩: 0.7071+0.0000𝑖
@@ -130,7 +130,7 @@ pub const JOINTMEASUREMENT_EXPECT_DEBUG: Expect = expect![[r#"
 pub const JOINTMEASUREMENT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 959"];
 pub const JOINTMEASUREMENT_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 3259"];
-pub const JOINTMEASUREMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 3636"];
+pub const JOINTMEASUREMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 3767"];
 pub const MEASUREMENT_EXPECT: Expect = expect!["(One, [Zero, Zero])"];
 pub const MEASUREMENT_EXPECT_DEBUG: Expect = expect!["(One, [Zero, Zero])"];
 pub const MEASUREMENT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 613"];

--- a/source/samples_test/src/tests/language.rs
+++ b/source/samples_test/src/tests/language.rs
@@ -224,7 +224,7 @@ pub const DIAGNOSTICS_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const DIAGNOSTICS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 215"];
 pub const DIAGNOSTICS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1463"];
-pub const DIAGNOSTICS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2159"];
+pub const DIAGNOSTICS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2290"];
 pub const DOUBLE_EXPECT: Expect = expect!["0.1973269804"];
 pub const DOUBLE_EXPECT_DEBUG: Expect = expect!["0.1973269804"];
 pub const DOUBLE_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
@@ -366,7 +366,7 @@ pub const QUBIT_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const QUBIT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 449"];
 pub const QUBIT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1819"];
-pub const QUBIT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2484"];
+pub const QUBIT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2615"];
 pub const RANGE_EXPECT: Expect = expect![[r#"
     Range: 1..3
     Range: 2..2..5
@@ -432,7 +432,7 @@ pub const SPECIALIZATIONS_EXPECT: Expect = expect!["()"];
 pub const SPECIALIZATIONS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const SPECIALIZATIONS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4540"];
 pub const SPECIALIZATIONS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 3106"];
-pub const SPECIALIZATIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 6319"];
+pub const SPECIALIZATIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7939"];
 pub const STRING_EXPECT: Expect = expect![[r#"
     FooBar
     interpolated: FooBar


### PR DESCRIPTION
This changes updates the `Index` instruction from RIR to generate a sequence of instructions that checks the sign on the index and includes a corresponding offset to ensure that negative indexing works as expected in the emitted QIR. This change also adds a new integration test that validates both the QIR output and the execution time behavior of negative indexing. Fixes #3688