### PR TITLE
Add a notebook renderer for QDK Learning multiple-choice questions

### DIFF
--- a/source/npm/qsharp/ux/qdk-theme.css
+++ b/source/npm/qsharp/ux/qdk-theme.css
@@ -121,6 +121,14 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
   --qdk-atom-fill: #0078d4;
   --qdk-atom-trail: #fa0;
 
+  /* Use to mark a self-check question. The chemistry tutorial styles its
+     collapsible questions with this burnt orange, so anything that asks the
+     reader something should share it. Paired with a foreground because the
+     accent is a filled band: the two must be picked together to stay legible,
+     and which one is the dark half flips between light and dark themes. */
+  --qdk-quiz-accent: #8c4a00;
+  --qdk-quiz-accent-foreground: #ffffff;
+
   /* Circuit diagram: unitary gate box colors */
   --qdk-circuit-unitary-fill: #ffffff;
   --qdk-circuit-unitary-text: #3b3b3b;
@@ -192,6 +200,11 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
   --qdk-gate-reset: #8e8;
   --qdk-atom-fill: #9df;
   --qdk-atom-trail: #fa0;
+
+  /* Same hue as the light theme's quiz accent, lightened until it separates
+     from a dark editor background; the band's text goes dark to match. */
+  --qdk-quiz-accent: #e0a15e;
+  --qdk-quiz-accent-foreground: #2b1a05;
 
   /* Chord diagram: 3-stop colormaps (low → mid → high) */
   --qdk-chord-node-lo: #3a3a3a;

--- a/source/vscode/authoring-courses.md
+++ b/source/vscode/authoring-courses.md
@@ -118,6 +118,67 @@ Use `register_exercise(name, validate, ...)` when a unit needs its own checking;
 When validation fails, `_course_lib` shows the message and raises, so the cell errors out.
 Once the cell runs successfully, the exercise will be considered to be complete.
 
+## Quizzes
+
+A quiz is a multiple-choice question the learner answers in the cell output.
+Unlike an exercise, it is a self-check: answering doesn't record progress, so a quiz is a place to think rather than something to complete.
+
+Register the question in the unit's `_unit.py`, next to the exercise registrations:
+
+```python
+from _learning_output import quiz, register_quiz  # noqa: E402, F401
+
+register_quiz(
+    "grid-spacing",
+    "Which control changes the energy-grid spacing?",
+    [
+        ("bits", "The number of phase bits", True, "It sets how finely the interval is discretized."),
+        ("shots", "The number of shots per bit", False, "More shots stabilize each bit; spacing is untouched."),
+        ("space", "The size of the active space", False, "That changes the Hamiltonian itself."),
+    ],
+)
+```
+
+Each option is `(id, text, correct, explanation)`.
+The explanation is shown after the learner commits to a choice, so write it as the reason that option is right or wrong rather than as a hint.
+A single-select question needs exactly one correct option, and ids must be unique; anything else raises when the cell runs, so mistakes surface while you're authoring.
+
+For a question with several right answers, pass `multi_select=True`:
+
+```python
+register_quiz(
+    "ancilla-traits",
+    "Which of these are true of the readout ancilla?",
+    [
+        ("h-gates", "It receives the H gates and the feedback rotation", True, "That is what puts it in superposition."),
+        ("controls", "It controls the Hamiltonian evolution", True, "The controlled-unitary hangs off this wire."),
+        ("state", "It holds the prepared molecular state", False, "The compute register does that."),
+    ],
+    multi_select=True,
+)
+```
+
+The learner then gets checkboxes and an explicit "Select all that apply", and has to find every correct option to pass.
+A multi-select question needs at least two correct options and at least one incorrect one — a "select all that apply" with a single answer teaches learners to distrust the instruction, and one where everything applies can't be answered wrongly.
+
+Options are shuffled, seeded from the quiz id.
+It's natural to write the correct answer first, which would otherwise make "always pick A" a winning strategy across a unit.
+The order is stable, so re-running the notebook doesn't reshuffle or produce a spurious diff.
+
+The notebook cell then just names the quiz, and is tagged `quiz` the same way exercise cells are tagged:
+
+```python
+quiz("grid-spacing")
+```
+
+The tag keeps the cell out of the progress tree, and lets the cell below it still find the section heading above.
+One call can name several quizzes (`quiz("a", "b")`) when a section asks two questions in a row - the progress tree names a code cell after the heading above it, so two adjacent quiz cells would appear under the same name.
+
+Run the cell once and save, so the question ships with the notebook and a learner sees it on opening rather than after running.
+
+The answers are in the saved cell output, because grading happens in the renderer without a kernel.
+This keeps them out of the cell source the learner reads, which is the same protection the collapsible-answer style gave; it isn't a guarantee against a determined learner opening the `.ipynb`.
+
 ## Editing a published course
 
 Progress is tracked per cell, using the notebook's nbformat cell IDs.

--- a/source/vscode/authoring-courses.md
+++ b/source/vscode/authoring-courses.md
@@ -174,7 +174,19 @@ quiz("grid-spacing")
 The tag keeps the cell out of the progress tree, and lets the cell below it still find the section heading above.
 One call can name several quizzes (`quiz("a", "b")`) when a section asks two questions in a row - the progress tree names a code cell after the heading above it, so two adjacent quiz cells would appear under the same name.
 
+Quiz ids are lowercase letters, digits and hyphens, up to 64 characters.
+Registering one that isn't fails when you run the cell: the id is the only thing the renderer's Copilot action sends to the extension, so a shape it can't accept would leave that button doing less than it should.
+
 Run the cell once and save, so the question ships with the notebook and a learner sees it on opening rather than after running.
+
+For the chemistry course, `utils/chemistry-qpe/details_to_quiz.py` does that baking for a whole chapter, and re-bakes it when a question's wording or options change:
+
+```
+python details_to_quiz.py 06-iterative-phase-estimation --check   # report drift, write nothing
+python details_to_quiz.py 06-iterative-phase-estimation           # re-bake what changed
+```
+
+`--check` is what catches a `_unit.py` edit that never reached the notebook, including a question deleted from a cell that still shows it.
 
 The answers are in the saved cell output, because grading happens in the renderer without a kernel.
 This keeps them out of the cell source the learner reads, which is the same protection the collapsible-answer style gave; it isn't a guarantee against a determined learner opening the `.ipynb`.

--- a/source/vscode/build.mjs
+++ b/source/vscode/build.mjs
@@ -3,7 +3,7 @@
 
 //@ts-check
 
-import { copyFileSync, mkdirSync, readdirSync } from "node:fs";
+import { copyFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build as esbuildBuild, context } from "esbuild";
@@ -84,6 +84,22 @@ const platformBuildOptions = {
       __PLATFORM__: JSON.stringify("node"),
     },
   },
+  renderer: {
+    ...commonBuildOptions,
+    external: [],
+    platform: "browser",
+    format: "esm",
+    entryPoints: [join(thisDir, "src", "notebookRenderer", "index.ts")],
+    outfile: join(thisDir, "out", "renderer", "qdkLearning.js"),
+    // A notebook renderer is loaded as a single JS module — VS Code won't pick
+    // up a sibling stylesheet — so CSS is bundled as text and injected at
+    // activation instead of emitted as a separate file.
+    loader: { ".css": "text" },
+    define: {
+      "import.meta.url": "undefined",
+      __PLATFORM__: JSON.stringify("browser"),
+    },
+  },
 };
 
 // ── Inline worker plugin ────────────────────────────────────────────
@@ -127,6 +143,134 @@ const inlineStateComputeWorkerPlugin = {
     );
   },
 };
+
+// ── Renderer/emitter contract check ─────────────────────────────────
+
+/**
+ * Fail the build if the renderer's schema and the Python emitter have drifted.
+ *
+ * The payload contract is written twice — TypeScript types the renderer
+ * validates against, and the dicts `_learning_output.py` builds — and nothing
+ * in either type system spans that gap. Checks the values whose disagreement
+ * breaks a learner: MIME type, payload kinds, schema version, and the field
+ * names the renderer reads.
+ */
+export function checkRendererContract() {
+  const schemaPath = join(thisDir, "src", "notebookRenderer", "schema.ts");
+  const rendererPath = join(
+    thisDir,
+    "src",
+    "notebookRenderer",
+    "multipleChoice.ts",
+  );
+  const emitterPath = join(
+    thisDir,
+    "resources",
+    "qdk-learning",
+    "courses",
+    "chemistry-qpe",
+    "_learning_output.py",
+  );
+
+  const schema = readFileSync(schemaPath, "utf8");
+  const renderer = readFileSync(rendererPath, "utf8");
+  const emitter = readFileSync(emitterPath, "utf8");
+
+  const mismatches = [];
+  const required = (label, value) => {
+    if (value === undefined) {
+      throw new Error(`Could not read ${label} while checking the contract.`);
+    }
+    return value;
+  };
+
+  const tsMime = required(
+    "MIME_TYPE in schema.ts",
+    /^export const MIME_TYPE = "([^"]+)"/m.exec(schema)?.[1],
+  );
+  const pyMime = required(
+    "MIME_TYPE in _learning_output.py",
+    /^MIME_TYPE = "([^"]+)"/m.exec(emitter)?.[1],
+  );
+  if (tsMime !== pyMime) {
+    mismatches.push(`MIME type differs: "${tsMime}" vs "${pyMime}".`);
+  }
+
+  // Every payload the emitter builds must name a kind the renderer handles.
+  const tsKinds = [...schema.matchAll(/^\s+kind: "([a-z-]+)";/gm)].map(
+    (m) => m[1],
+  );
+  const pyKinds = [...emitter.matchAll(/"kind": "([a-z-]+)"/g)].map(
+    (m) => m[1],
+  );
+  const unknown = pyKinds.filter((k) => !tsKinds.includes(k));
+  if (unknown.length > 0) {
+    mismatches.push(
+      `Python emits kinds the renderer does not handle: ${[...new Set(unknown)].join(", ")}.`,
+    );
+  }
+
+  const tsVersion = required(
+    "SUPPORTED_SCHEMA_VERSION",
+    /const SUPPORTED_SCHEMA_VERSION = (\d+)/.exec(
+      readFileSync(
+        join(thisDir, "src", "notebookRenderer", "index.ts"),
+        "utf8",
+      ),
+    )?.[1],
+  );
+  const pyVersion = required(
+    '"schemaVersion" in _learning_output.py',
+    /"schemaVersion": (\d+)/.exec(emitter)?.[1],
+  );
+  if (tsVersion !== pyVersion) {
+    mismatches.push(
+      `Schema version differs: renderer accepts ${tsVersion}, emitter writes ${pyVersion}.`,
+    );
+  }
+
+  // Field names the renderer reads off a multiple-choice payload. Renaming one
+  // on either side leaves the question blank rather than failing loudly — or,
+  // for `multiSelect`, silently builds a radio group for a question with
+  // several correct answers, which then cannot be answered at all.
+  //
+  // The emitter writes most fields as dict literal keys (`"prompt": ...`) but
+  // sets optional ones by assignment (`payload["multiSelect"] = True`), so the
+  // Python probe has to accept both spellings.
+  const payloadFields = ["prompt", "options", "multiSelect"];
+  const optionFields = ["id", "text", "correct", "explanation"];
+  for (const field of payloadFields) {
+    const inTs = new RegExp(`payload\\.${field}\\b`).test(renderer);
+    const inPy = new RegExp(`"${field}"\\s*(?::|\\])`).test(emitter);
+    if (inTs !== inPy) {
+      mismatches.push(
+        `Payload field "${field}" is ${inTs ? "read by the renderer but never written by the emitter" : "written by the emitter but never read by the renderer"}.`,
+      );
+    }
+  }
+  for (const field of optionFields) {
+    const inTs = new RegExp(`option\\.${field}\\b`).test(renderer);
+    const inPy = new RegExp(`"${field}"`).test(emitter);
+    if (inTs !== inPy) {
+      mismatches.push(
+        `Option field "${field}" is ${inTs ? "read by the renderer but never written by the emitter" : "written by the emitter but never read by the renderer"}.`,
+      );
+    }
+  }
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `QDK learning renderer contract mismatch:\n  - ${mismatches.join("\n  - ")}\n` +
+        `Update both ${schemaPath} and ${emitterPath} together.`,
+    );
+  }
+
+  const kinds = new Set(tsKinds).size;
+  console.log(
+    `Renderer contract OK (v${tsVersion}, ${kinds} payload kind${kinds === 1 ? "" : "s"}, ` +
+      `${payloadFields.length + optionFields.length} fields).`,
+  );
+}
 
 // ── Asset copy helpers ──────────────────────────────────────────────
 
@@ -217,7 +361,7 @@ async function buildPlatform(platform) {
 
   console.log(`Running esbuild for platform: ${platform}`);
   await esbuildBuild(options);
-  console.log(`Built bundle to ${options.outdir}`);
+  console.log(`Built bundle to ${options.outdir ?? options.outfile}`);
 }
 
 function getTimeStr() {
@@ -268,7 +412,16 @@ export async function watchVsCode() {
     },
   });
 
+  // The notebook renderer is a separate bundle with its own format and CSS
+  // loader, so it needs its own watcher rather than another entry point above.
+  const rendererCtx = await context({
+    ...platformBuildOptions.renderer,
+    plugins: [buildPlugin],
+    color: false,
+  });
+
   ctx.watch();
+  rendererCtx.watch();
 }
 
 (async () => {
@@ -281,12 +434,14 @@ export async function watchVsCode() {
     } else {
       copyKatex();
       copyWasmToVsCode();
+      checkRendererContract();
 
       await Promise.all([
         buildPlatform("ui"),
         buildPlatform("browser"),
         buildPlatform("node"),
         buildPlatform("node-worker"),
+        buildPlatform("renderer"),
       ]);
     }
   }

--- a/source/vscode/build.mjs
+++ b/source/vscode/build.mjs
@@ -197,12 +197,17 @@ export function checkRendererContract() {
   }
 
   // Every payload the emitter builds must name a kind the renderer handles.
+  // Both sides go through `required()`: an empty list on either side would
+  // otherwise make this comparison vacuous, and the banner below would still
+  // report a kind count read from TypeScript alone.
   const tsKinds = [...schema.matchAll(/^\s+kind: "([a-z-]+)";/gm)].map(
     (m) => m[1],
   );
   const pyKinds = [...emitter.matchAll(/"kind": "([a-z-]+)"/g)].map(
     (m) => m[1],
   );
+  required("a payload kind in schema.ts", tsKinds[0]);
+  required('a "kind" in _learning_output.py', pyKinds[0]);
   const unknown = pyKinds.filter((k) => !tsKinds.includes(k));
   if (unknown.length > 0) {
     mismatches.push(
@@ -236,11 +241,18 @@ export function checkRendererContract() {
   //
   // The emitter writes most fields as dict literal keys (`"prompt": ...`) but
   // sets optional ones by assignment (`payload["multiSelect"] = True`), so the
-  // Python probe has to accept both spellings.
-  const payloadFields = ["prompt", "options", "multiSelect"];
+  // Python probe has to accept both spellings. The TypeScript side is searched
+  // across both files that touch a payload: the validator and the view read
+  // different fields, and looking at only one would let a field go unchecked
+  // the moment it moved between them.
+  const rendererSources = `${renderer}\n${readFileSync(
+    join(thisDir, "src", "notebookRenderer", "index.ts"),
+    "utf8",
+  )}`;
+  const payloadFields = ["prompt", "options", "multiSelect", "cellId"];
   const optionFields = ["id", "text", "correct", "explanation"];
   for (const field of payloadFields) {
-    const inTs = new RegExp(`payload\\.${field}\\b`).test(renderer);
+    const inTs = new RegExp(`payload\\.${field}\\b`).test(rendererSources);
     const inPy = new RegExp(`"${field}"\\s*(?::|\\])`).test(emitter);
     if (inTs !== inPy) {
       mismatches.push(
@@ -249,7 +261,7 @@ export function checkRendererContract() {
     }
   }
   for (const field of optionFields) {
-    const inTs = new RegExp(`option\\.${field}\\b`).test(renderer);
+    const inTs = new RegExp(`option\\.${field}\\b`).test(rendererSources);
     const inPy = new RegExp(`"${field}"`).test(emitter);
     if (inTs !== inPy) {
       mismatches.push(

--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -35,6 +35,17 @@
     "ui"
   ],
   "contributes": {
+    "notebookRenderer": [
+      {
+        "id": "qsharp-vscode.qdkLearningRenderer",
+        "displayName": "QDK Learning",
+        "entrypoint": "./out/renderer/qdkLearning.js",
+        "requiresMessaging": "optional",
+        "mimeTypes": [
+          "application/vnd.qdk.learning+json"
+        ]
+      }
+    ],
     "walkthroughs": [
       {
         "id": "qsharp-vscode.welcome",
@@ -1708,7 +1719,8 @@
     "tsc:check:main": "node ../../node_modules/typescript/bin/tsc -p ./tsconfig.json",
     "tsc:check:view": "node ../../node_modules/typescript/bin/tsc -p ./src/webview/tsconfig.json",
     "tsc:check:learning": "node ../../node_modules/typescript/bin/tsc -p ./src/learning/webview/tsconfig.json",
-    "tsc:check": "npm run tsc:check:main && npm run tsc:check:view && npm run tsc:check:learning",
+    "tsc:check:renderer": "node ../../node_modules/typescript/bin/tsc -p ./src/notebookRenderer/tsconfig.json",
+    "tsc:check": "npm run tsc:check:main && npm run tsc:check:view && npm run tsc:check:learning && npm run tsc:check:renderer",
     "tsc:watch": "node ../../node_modules/typescript/bin/tsc -p ./tsconfig.json --watch --preserveWatchOutput",
     "tsc:watch:view": "node ../../node_modules/typescript/bin/tsc -p ./src/webview/tsconfig.json --watch --preserveWatchOutput"
   },

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/06-iterative-phase-estimation/_unit.py
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/06-iterative-phase-estimation/_unit.py
@@ -13,6 +13,7 @@ from _course_lib import (  # noqa: E402, F401
     register_exercise,
     register_value_exercise,
 )
+from _learning_output import quiz, register_quiz  # noqa: E402, F401
 
 # The selected grid point 010000 is k=16 on the 64-point six-bit grid.
 MEASURED_PHASE = register_value_exercise("measured_phase", expected=0.25)
@@ -46,4 +47,465 @@ VALIDATE_CIRCUIT = register_exercise(
         "Correct. Twelve compute qubits plus one readout ancilla, "
         "rebuilt for each of the six iterations."
     ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Self-check questions
+# ---------------------------------------------------------------------------
+
+# The chapter's collapsible questions, registered so the notebook cell can show
+# them as answerable ones. They live here rather than inline because a quiz in
+# the notebook would put the answers into the cell source.
+
+register_quiz(
+    "iqpe-grid-target",
+    "Why does six-bit phase estimation meet a 1 mEh target here, even though "
+    "adjacent grid points are much farther apart than that?",
+    [
+        (
+            "tuned",
+            "The evolution time was tuned using the classically known reference "
+            "energy, so the target lands almost exactly on one six-bit grid point.",
+            True,
+            "The alignment is deliberate. Six bits do not give mEh resolution "
+            "for an arbitrary energy at this evolution time.",
+        ),
+        (
+            "six-bits-enough",
+            "Six phase bits are enough to resolve any energy to 1 mEh.",
+            False,
+            "They are not. At this evolution time the grid spacing is far "
+            "coarser than 1 mEh; the agreement comes from where the target sits.",
+        ),
+        (
+            "shots-interpolate",
+            "Averaging over the 20 shots interpolates between neighbouring grid points.",
+            False,
+            "Shots make the selected grid point more reliable. They never "
+            "produce an energy that lies between two grid points.",
+        ),
+        (
+            "trotter-cancels",
+            "Trotter approximation error happens to cancel the grid spacing error.",
+            False,
+            "Trotter error is a separate contribution and is not controlled "
+            "here, so it cannot be relied on to offset discretization.",
+        ),
+    ],
+)
+
+register_quiz(
+    "iqpe-state-prep",
+    "Why is trial-state preparation included in every IQPE iteration circuit?",
+    [
+        (
+            "fresh-qubits",
+            "Each phase bit is measured by a separate circuit, and every shot "
+            "begins with newly allocated qubits in the all-zero state.",
+            True,
+            "So the state-preparation logical circuit has to reload the trial "
+            "state before each controlled evolution.",
+        ),
+        (
+            "measurement-collapse",
+            "Measuring the readout ancilla collapses the compute register, so "
+            "the trial state has to be rebuilt.",
+            False,
+            "Only the ancilla is measured. The register is gone anyway, but "
+            "because each iteration is its own circuit starting from all zeros.",
+        ),
+        (
+            "average-trotter",
+            "Repeating it suppresses Trotter error by averaging over preparations.",
+            False,
+            "State preparation is not the source of Trotter error, and "
+            "repeating it does not reduce the error in the evolution unitary.",
+        ),
+        (
+            "feedback-destroys",
+            "The classical feedback rotation destroys the trial state each iteration.",
+            False,
+            "The feedback rotation acts on the readout ancilla, not on the "
+            "compute register holding the molecular state.",
+        ),
+    ],
+)
+
+register_quiz(
+    "iqpe-grid-control",
+    "Which controls change the spacing of the energy grid?",
+    [
+        (
+            "phase-bits",
+            "The number of phase bits.",
+            True,
+            "It sets how finely the phase interval is discretized, and changes "
+            "nothing else.",
+        ),
+        (
+            "evolution-time",
+            "The evolution time.",
+            True,
+            "It rescales the grid in energy units — but unlike the bit count it "
+            "also changes the unaliased interval and the simulated evolution, so "
+            "it is the blunter of the two controls.",
+        ),
+        (
+            "shots",
+            "The number of shots per bit.",
+            False,
+            "More shots make each bit majority more stable. Grid spacing is untouched.",
+        ),
+        (
+            "active-space",
+            "The size of the active space.",
+            False,
+            "That changes the Hamiltonian being measured, not how finely the "
+            "phase is resolved.",
+        ),
+    ],
+    multi_select=True,
+)
+
+register_quiz(
+    "iqpe-readout-ancilla",
+    "Which of these are true of the readout ancilla in the rendered circuit?",
+    [
+        (
+            "h-gates",
+            "It receives the H gates and the feedback rotation.",
+            True,
+            "That pair is what puts it in superposition and applies the phase "
+            "learned from earlier iterations.",
+        ),
+        (
+            "controls",
+            "It controls the Hamiltonian evolution.",
+            True,
+            "The controlled-unitary hangs off this wire, which is how the phase "
+            "is kicked back onto it.",
+        ),
+        (
+            "measured",
+            "It is measured to obtain the phase bit.",
+            True,
+            "One measurement per iteration, and that bit feeds the next one.",
+        ),
+        (
+            "molecular-state",
+            "It holds the prepared molecular state.",
+            False,
+            "The other twelve wires do that — they are the compute register. "
+            "The ancilla is algorithm workspace.",
+        ),
+    ],
+    multi_select=True,
+)
+
+register_quiz(
+    "iqpe-circuit-shape",
+    "Why do all six iteration circuits have the same width but different lengths?",
+    [
+        (
+            "power-varies",
+            "Every iteration uses the same twelve-qubit compute register and one "
+            "readout ancilla, while different controlled powers repeat the "
+            "evolution unitary different numbers of times.",
+            True,
+            "Width is register size, thirteen logical qubits every time. Length "
+            "is logical gate count, which the controlled power sets.",
+        ),
+        (
+            "more-qubits",
+            "Later iterations act on more qubits, because they resolve more "
+            "significant bits.",
+            False,
+            "The register is fixed at thirteen qubits. Resolving a different "
+            "bit changes the controlled power, not the width.",
+        ),
+        (
+            "feedback-ancilla",
+            "Each iteration adds another ancilla to carry the feedback.",
+            False,
+            "The feedback is classical. It changes a rotation angle, not the "
+            "number of qubits.",
+        ),
+        (
+            "growing-space",
+            "The Trotter step count grows with the active-space size across iterations.",
+            False,
+            "The active space is fixed for the whole run. What varies between "
+            "iterations is the controlled power.",
+        ),
+    ],
+)
+
+register_quiz(
+    "iqpe-bit-feedback",
+    "How does IQPE turn the result of each iteration into the final bitstring "
+    "and phase fraction?",
+    [
+        (
+            "feedback-chain",
+            "The majority measurement for each iteration selects a phase bit, "
+            "which updates the classical phase feedback used by the next "
+            "iteration; after six iterations the feedback calculation combines "
+            "the bits into one fraction.",
+            True,
+            "The script writes that fraction as a conventional six-bit string, "
+            "with the most significant bit first.",
+        ),
+        (
+            "one-circuit",
+            "All six bits are measured together in a single circuit and read off "
+            "at the end.",
+            False,
+            "That is textbook QPE. The iterative variant deliberately measures "
+            "one bit per circuit, which is what keeps the register small.",
+        ),
+        (
+            "independent-bits",
+            "The bits are independent, so they can be measured in any order and "
+            "concatenated.",
+            False,
+            "They are not independent. Each measured bit updates the phase "
+            "feedback for the next iteration, so the order is fixed.",
+        ),
+        (
+            "average-estimates",
+            "The phase fraction is the average of the six per-iteration phase "
+            "estimates.",
+            False,
+            "Each iteration yields a single bit, not a phase estimate. "
+            "Averaging them would throw away each bit's place value.",
+        ),
+    ],
+)
+
+register_quiz(
+    "iqpe-aggregation",
+    "Why should the final aggregation use complete bitstrings rather than vote "
+    "on each bit across complete runs?",
+    [
+        (
+            "joint",
+            "Each complete bitstring is one phase-grid point with a corresponding "
+            "energy, and voting per bit could assemble a bitstring that no run "
+            "ever produced.",
+            True,
+            "Voting bit by bit also discards the joint distribution that was "
+            "actually observed.",
+        ),
+        (
+            "slower",
+            "Per-bit voting gives the same answer but takes longer to compute.",
+            False,
+            "It does not give the same answer: it can synthesize a result that "
+            "never occurred in any run.",
+        ),
+        (
+            "simultaneous",
+            "Complete bitstrings are required because the bits are measured "
+            "simultaneously.",
+            False,
+            "They are measured one per iteration. The reason is that a "
+            "bitstring is only meaningful as a whole grid point.",
+        ),
+        (
+            "msb-bias",
+            "Per-bit voting would bias the result toward the most significant bit.",
+            False,
+            "The problem is not bias toward one bit. It is that the assembled "
+            "string may correspond to no observed run at all.",
+        ),
+    ],
+)
+
+register_quiz(
+    "iqpe-energy-comparison",
+    "Which energy comparison determines whether the IQPE workflow meets the "
+    "teaching target?",
+    [
+        (
+            "casci-same-space",
+            "The reconstructed IQPE total energy against the CASCI energy of the "
+            "same selected active-space Hamiltonian.",
+            True,
+            "The same Hamiltonian sits on both sides, so the difference isolates "
+            "algorithmic error.",
+        ),
+        (
+            "experiment",
+            "The reconstructed IQPE total energy against an experimental "
+            "measurement for the molecule.",
+            False,
+            "That would mix algorithmic error with molecular-model error and "
+            "could not tell you which one you were looking at.",
+        ),
+        (
+            "larger-space",
+            "The reconstructed IQPE total energy against a CASCI energy computed "
+            "in a larger active space.",
+            False,
+            "Changing the space changes the Hamiltonian, so the comparison would "
+            "no longer isolate the algorithm.",
+        ),
+        (
+            "hartree-fock",
+            "The active-space energy against the Hartree-Fock energy.",
+            False,
+            "That measures how much correlation energy was recovered, not "
+            "whether phase estimation reached its target.",
+        ),
+    ],
+)
+
+register_quiz(
+    "iqpe-observed-result",
+    "What bitstring distribution did the script produce?",
+    [
+        (
+            "19-1",
+            "`010000` appeared 19 times and `001111` once, so `010000` is the "
+            "most frequent result.",
+            True,
+            "It gives an active-space energy of -9.652276065987 Eh and a "
+            "reconstructed total of -108.770051792909 Eh once the core energy "
+            "is added back.",
+        ),
+        (
+            "reversed",
+            "`001111` appeared 19 times and `010000` once.",
+            False,
+            "Reversed. `010000` is the majority result; `001111` is the "
+            "neighbouring grid point that turned up once.",
+        ),
+        (
+            "unanimous",
+            "All 20 runs produced `010000`.",
+            False,
+            "Close, but one run landed on the adjacent grid point `001111`. "
+            "Finite sampling and Trotter error still move the outcome sometimes.",
+        ),
+        (
+            "spread",
+            "The 20 runs were spread across six different bitstrings, one per "
+            "phase bit.",
+            False,
+            "The distribution is far tighter: two grid points in total, one of "
+            "them nineteen times.",
+        ),
+    ],
+)
+
+register_quiz(
+    "iqpe-target-met",
+    "Does the result meet the teaching target, and what does that establish?",
+    [
+        (
+            "boundary",
+            "Yes, at the boundary: the reconstructed total is 1 mEh above the "
+            "selected-space CASCI reference, which validates this configured "
+            "teaching workflow.",
+            True,
+            "It does not remove molecular-model error or establish agreement "
+            "with experiment. The offset itself was set by the reference-guided "
+            "phase-grid alignment.",
+        ),
+        (
+            "matches-experiment",
+            "Yes, and it establishes that the workflow reproduces the "
+            "experimental energy of the molecule to 1 mEh.",
+            False,
+            "Nothing here is compared against experiment. The reference is a "
+            "CASCI energy in the same active space.",
+        ),
+        (
+            "misses",
+            "No, a 1 mEh offset is outside the teaching target.",
+            False,
+            "The target is 1 mEh, so this meets it, though only exactly at the "
+            "boundary.",
+        ),
+        (
+            "errors-negligible",
+            "Yes, and it shows that Trotter and sampling error are negligible.",
+            False,
+            "Both can still affect which bitstring is selected. The agreement "
+            "comes from the deliberate grid alignment, not from those errors "
+            "vanishing.",
+        ),
+    ],
+)
+
+register_quiz(
+    "iqpe-more-bits",
+    "What happens if the number of phase bits increases while the repeated-power "
+    "strategy stays fixed?",
+    [
+        (
+            "finer-grid",
+            "The phase grid becomes finer.",
+            True,
+            "That is the point of adding a bit — the interval is divided more finely.",
+        ),
+        (
+            "extra-circuit",
+            "One more iteration circuit is needed.",
+            True,
+            "One circuit per bit, so an extra bit is an extra circuit to run.",
+        ),
+        (
+            "power-doubles",
+            "The largest controlled-unitary power doubles.",
+            True,
+            "For repeated-power Trotter evolution that is the expensive part: it "
+            "increases circuit size and simulator runtime substantially.",
+        ),
+        (
+            "shorter",
+            "The circuits get shorter, because each bit carries less information.",
+            False,
+            "The opposite — the longest circuit grows, because the largest "
+            "controlled power doubles.",
+        ),
+    ],
+    multi_select=True,
+)
+
+register_quiz(
+    "iqpe-more-shots",
+    "Would increasing the number of shots per bit make the phase grid finer?",
+    [
+        (
+            "no-spacing-fixed",
+            "No. More shots can make each bit majority more stable, but grid "
+            "spacing is set by the evolution time and the number of phase bits.",
+            True,
+            "Shots change how confidently one grid point is selected, never the "
+            "spacing between grid points.",
+        ),
+        (
+            "yes-interpolate",
+            "Yes, averaging more shots interpolates between grid points.",
+            False,
+            "The majority vote selects one grid point. It never produces a value "
+            "between two of them.",
+        ),
+        (
+            "yes-trotter",
+            "Yes, more shots reduce Trotter error, which is what sets the spacing.",
+            False,
+            "Trotter error is not what sets grid spacing, and repeating shots "
+            "does not reduce it.",
+        ),
+        (
+            "no-active-space",
+            "No, because the grid is fixed by the size of the active space.",
+            False,
+            "The right verdict for the wrong reason. Spacing comes from the "
+            "evolution time and the number of phase bits.",
+        ),
+    ],
 )

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/06-iterative-phase-estimation/iterative_phase_estimation.ipynb
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/06-iterative-phase-estimation/iterative_phase_estimation.ipynb
@@ -32,7 +32,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# If packages are missing, first select a dedicated Python environment/kernel,\n# then uncomment the next line and run this cell again.\n# %pip install -r ../requirements.txt\n\nfrom _unit import check_env\n\ncheck_env()"
+   "source": [
+    "# If packages are missing, first select a dedicated Python environment/kernel,\n",
+    "# then uncomment the next line and run this cell again.\n",
+    "# %pip install -r ../requirements.txt\n",
+    "\n",
+    "from _unit import check_env, quiz\n",
+    "\n",
+    "check_env()"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -70,7 +78,192 @@
      "section:energy-to-phase-encoding"
     ]
    },
-   "source": "## Energy-to-phase encoding\n\nLet $\\vert\\Psi_j\\rangle$ be an eigenstate of the qubit Hamiltonian with active-space energy $E_j$:\n\n$$\n\\hat H_{\\mathrm{qubit}}\\vert\\Psi_j\\rangle\n= E_j\\vert\\Psi_j\\rangle.\n$$\n\nIn atomic units, the evolution time $t$ is expressed in inverse Hartree, $E_{\\mathrm{h}}^{-1}$, so the product $E_jt$ is dimensionless.\nThe time-evolution unitary is\n\n$$\nU(t)=e^{-i\\hat H_{\\mathrm{qubit}}t}.\n$$\n\nBecause every power of the Hamiltonian acting on $\\vert\\Psi_j\\rangle$ contributes the corresponding power of $E_j$, the exponential acts on that eigenstate as\n\n$$\nU(t)\\vert\\Psi_j\\rangle\n=e^{-i\\hat H_{\\mathrm{qubit}}t}\\vert\\Psi_j\\rangle\n=e^{-iE_jt}\\vert\\Psi_j\\rangle.\n$$\n\nThe physical eigenphase in the exponential is therefore $-E_jt$ modulo $2\\pi$.\nThe phase fraction reported by QPE is\n\n$$\n\\varphi_j\n=\\left(\\frac{-E_jt}{2\\pi}\\right)\\bmod 1.\n$$\n\nThe QDK/Chemistry result object handles the modulo wrapping automatically.\nIt converts the measured phase fraction to a signed angle $\\alpha\\in(-\\pi,\\pi]$ and returns $-\\alpha/t$.\nThe tutorial script uses this value directly rather than manually applying a sign conversion.\nTo avoid aliasing, the active-space Hamiltonian energy eigenvalue $E_j$ being estimated must lie in the signed interval $[-\\pi/t,\\pi/t)$; energies outside that interval can produce the same measured phase.\nThe two boundary energies differ by one complete phase turn and therefore represent the same measured phase; QDK/Chemistry assigns that boundary to $-\\pi/t$.\n\nThe next figure shows how to read this wrapping convention.\nFollow the upper axis from $\\varphi=0$ toward $\\varphi=1$.\nFrom zero through one half, the signed angle is nonnegative, so $E=-\\alpha/t$ runs from zero down to $-\\pi/t$ along the green branch.\nImmediately above one half, the signed angle wraps from $+\\pi$ to just above $-\\pi$; the corresponding energy jumps to just below $+\\pi/t$ and then returns toward zero along the purple branch.\nAt $\\varphi=1/2$, the lower filled point includes $-\\pi/t$, while the upper open point excludes the equivalent $+\\pi/t$ representation.\n\n<div style=\"text-align:center;\">\n\n<svg xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"656.39952pt\" height=\"339.59952pt\" viewBox=\"0 0 656.39952 339.59952\" xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" class=\"qdk-chemistry-phase-wrapping\" role=\"img\" data-asset=\"tutorial_qpe_phase_wrapping.svg\" aria-label=\"Signed reconstructed energy plotted against phase fraction from zero to one. Phase fractions from zero through one half map from zero down to minus pi over t. Immediately above one half, the signed branch wraps to just below plus pi over t and returns toward zero as the phase approaches one. A neutral dashed guide connects the included minus pi over t point and excluded plus pi over t point at phase one half. A red bracket beside the plot spans their energy difference of two pi over t. Phase one wraps to phase zero.\" style=\"max-width:100%;height:auto\"> <metadata> <rdf:RDF xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"> <cc:Work> <dc:type rdf:resource=\"http://purl.org/dc/dcmitype/StillImage\"/> <dc:format>image/svg+xml</dc:format> <dc:creator> <cc:Agent> <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title> </cc:Agent> </dc:creator> </cc:Work> </rdf:RDF> </metadata> <defs> <style type=\"text/css\"> .qdk-chemistry-phase-wrapping { --qdk-host-foreground: var( --vscode-editor-foreground, var(--jp-widgets-color, currentColor) ); --diagram-foreground: var(--qdk-host-foreground); --diagram-grid: var( --vscode-panel-border, var(--jp-border-color2, #888888) ); } .qdk-chemistry-phase-wrapping text { fill: var(--diagram-foreground) !important; } </style>  <style type=\"text/css\">.qdk-chemistry-phase-wrapping *{stroke-linejoin: round; stroke-linecap: butt}</style> </defs> <g id=\"figure_1\"> <g id=\"patch_1\"> <path d=\"M 0 339.59952 L 656.39952 339.59952 L 656.39952 0 L 0 0 L 0 339.59952 z \" style=\"fill: none\"/> </g> <g id=\"axes_1\"> <g id=\"patch_2\"> <path d=\"M 64.055469 301.398739 L 649.19952 301.398739 L 649.19952 7.2 L 64.055469 7.2 L 64.055469 301.398739 z \" style=\"fill: none\"/> </g> <g id=\"matplotlib.axis_1\"> <g id=\"xtick_1\"> <g id=\"line2d_1\"> <path d=\"M 74.694452 301.398739 L 74.694452 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_2\"> <defs> <path id=\"mda624babe4\" d=\"M 0 0 L 0 3.5 \" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </defs> <g> <use xlink:href=\"#mda624babe4\" x=\"74.694452\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_1\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"74.694452\" y=\"315.996395\" transform=\"rotate(-0 74.694452 315.996395)\">0</text> </g> </g> <g id=\"xtick_2\"> <g id=\"line2d_3\"> <path d=\"M 207.681736 301.398739 L 207.681736 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_4\"> <g> <use xlink:href=\"#mda624babe4\" x=\"207.681736\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_2\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"207.681736\" y=\"315.996395\" transform=\"rotate(-0 207.681736 315.996395)\">1/4</text> </g> </g> <g id=\"xtick_3\"> <g id=\"line2d_5\"> <path d=\"M 340.66902 301.398739 L 340.66902 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_6\"> <g> <use xlink:href=\"#mda624babe4\" x=\"340.66902\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_3\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"340.66902\" y=\"315.996395\" transform=\"rotate(-0 340.66902 315.996395)\">1/2</text> </g> </g> <g id=\"xtick_4\"> <g id=\"line2d_7\"> <path d=\"M 473.656305 301.398739 L 473.656305 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_8\"> <g> <use xlink:href=\"#mda624babe4\" x=\"473.656305\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_4\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"473.656305\" y=\"315.996395\" transform=\"rotate(-0 473.656305 315.996395)\">3/4</text> </g> </g> <g id=\"xtick_5\"> <g id=\"line2d_9\"> <path d=\"M 606.643589 301.398739 L 606.643589 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_10\"> <g> <use xlink:href=\"#mda624babe4\" x=\"606.643589\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_5\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"606.643589\" y=\"315.996395\" transform=\"rotate(-0 606.643589 315.996395)\">1 → 0</text> </g> </g> <g id=\"text_6\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"356.627494\" y=\"329.997176\" transform=\"rotate(-0 356.627494 329.997176)\">Reported phase fraction φ ∈ [0, 1)</text> </g> </g> <g id=\"matplotlib.axis_2\"> <g id=\"ytick_1\"> <g id=\"line2d_11\"> <path d=\"M 64.055469 29.638887 L 649.19952 29.638887 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_12\"> <defs> <path id=\"medb564f5fd\" d=\"M 0 0 L -3.5 0 \" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </defs> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"29.638887\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_7\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"33.437715\" transform=\"rotate(-0 57.055469 33.437715)\">+π/t</text> </g> </g> <g id=\"ytick_2\"> <g id=\"line2d_13\"> <path d=\"M 64.055469 91.969128 L 649.19952 91.969128 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_14\"> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"91.969128\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_8\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"95.767956\" transform=\"rotate(-0 57.055469 95.767956)\">+π/(2t)</text> </g> </g> <g id=\"ytick_3\"> <g id=\"line2d_15\"> <path d=\"M 64.055469 154.299369 L 649.19952 154.299369 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_16\"> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"154.299369\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_9\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"158.098197\" transform=\"rotate(-0 57.055469 158.098197)\">0</text> </g> </g> <g id=\"ytick_4\"> <g id=\"line2d_17\"> <path d=\"M 64.055469 216.629611 L 649.19952 216.629611 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_18\"> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"216.629611\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_10\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"220.428439\" transform=\"rotate(-0 57.055469 220.428439)\">−π/(2t)</text> </g> </g> <g id=\"ytick_5\"> <g id=\"line2d_19\"> <path d=\"M 64.055469 278.959852 L 649.19952 278.959852 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_20\"> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"278.959852\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_11\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"282.75868\" transform=\"rotate(-0 57.055469 282.75868)\">−π/t</text> </g> </g> <g id=\"text_12\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"14.798438\" y=\"154.299369\" transform=\"rotate(-90 14.798438 154.299369)\">Signed reconstructed energy</text> </g> </g> <g id=\"line2d_21\"> <path d=\"M 74.694452 154.299369 L 340.66902 278.959852 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: #00796b; stroke-width: 3; stroke-linecap: square\"/> </g> <g id=\"line2d_22\"> <path d=\"M 340.66902 29.638887 L 606.643589 154.299369 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: #7b1fa2; stroke-width: 3; stroke-linecap: square\"/> </g> <g id=\"line2d_23\"> <path d=\"M 340.66902 301.398739 L 340.66902 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #78909c; stroke-width: 1.5\"/> </g> <g id=\"patch_3\"> <path d=\"M 64.055469 301.398739 L 64.055469 7.2 \" style=\"fill: none; stroke: var(--diagram-foreground); stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square\"/> </g> <g id=\"patch_4\"> <path d=\"M 64.055469 301.398739 L 649.19952 301.398739 \" style=\"fill: none; stroke: var(--diagram-foreground); stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square\"/> </g> <g id=\"PathCollection_1\"> <defs> <path id=\"m92b30d0e14\" d=\"M 0 4.609772 C 1.222526 4.609772 2.395145 4.124058 3.259601 3.259601 C 4.124058 2.395145 4.609772 1.222526 4.609772 0 C 4.609772 -1.222526 4.124058 -2.395145 3.259601 -3.259601 C 2.395145 -4.124058 1.222526 -4.609772 0 -4.609772 C -1.222526 -4.609772 -2.395145 -4.124058 -3.259601 -3.259601 C -4.124058 -2.395145 -4.609772 -1.222526 -4.609772 0 C -4.609772 1.222526 -4.124058 2.395145 -3.259601 3.259601 C -2.395145 4.124058 -1.222526 4.609772 0 4.609772 z \" style=\"stroke: #00796b\"/> </defs> <g clip-path=\"url(#pc895b022ad)\"> <use xlink:href=\"#m92b30d0e14\" x=\"340.66902\" y=\"278.959852\" style=\"fill: #00796b; stroke: #00796b\"/> </g> </g> <g id=\"PathCollection_2\"> <path d=\"M 340.66902 34.248659 C 341.891546 34.248659 343.064165 33.762944 343.928621 32.898488 C 344.793078 32.034032 345.278792 30.861413 345.278792 29.638887 C 345.278792 28.416361 344.793078 27.243742 343.928621 26.379286 C 343.064165 25.514829 341.891546 25.029115 340.66902 25.029115 C 339.446494 25.029115 338.273875 25.514829 337.409419 26.379286 C 336.544963 27.243742 336.059248 28.416361 336.059248 29.638887 C 336.059248 30.861413 336.544963 32.034032 337.409419 32.898488 C 338.273875 33.762944 339.446494 34.248659 340.66902 34.248659 L 340.66902 34.248659 z \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: #7b1fa2; stroke-width: 2.5\"/> </g> <g id=\"text_13\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #00796b\" x=\"325.66902\" y=\"296.959852\" transform=\"rotate(-0 325.66902 296.959852)\">included boundary</text> </g> <g id=\"text_14\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #7b1fa2\" x=\"354.66902\" y=\"17.638887\" transform=\"rotate(-0 354.66902 17.638887)\">excluded boundary</text> </g> <g id=\"patch_5\"> <path d=\"M 630.5813 265.311469 Q 630.5813 154.301072 630.5813 43.290675 \" style=\"fill: none; stroke: #c62828; stroke-width: 1.5; stroke-linecap: round\"/> <path d=\"M 632.5813 261.311469 L 630.5813 265.311469 L 628.5813 261.311469 \" style=\"fill: none; stroke: #c62828; stroke-width: 1.5; stroke-linecap: round\"/> <path d=\"M 628.5813 47.290675 L 630.5813 43.290675 L 632.5813 47.290675 \" style=\"fill: none; stroke: #c62828; stroke-width: 1.5; stroke-linecap: round\"/> </g> </g> </g> <defs> <clipPath id=\"pc895b022ad\"> <rect x=\"64.055469\" y=\"7.2\" width=\"585.144051\" height=\"294.198739\"/> </clipPath> </defs> </svg>\n\n*QDK/Chemistry converts the wrapped phase fraction to one signed energy branch. The neutral dashed guide marks the shared phase $\\varphi=1/2$; the red bracket spans the $2\\pi/t$ energy difference between its included and excluded boundary representations. Energies separated by that amount alias to the same reported phase.*\n\n</div>\n\nWith $m$ measured phase bits, the representable fractions are multiples of $2^{-m}$, so adjacent energy-grid points are separated by\n\n$$\n\\Delta E_{\\mathrm{grid}}=\\frac{2\\pi}{t2^m}.\n$$\n\nWith $m$ measured phase bits, the largest controlled power is $U^{2^{m-1}}$.\nIncreasing $m$ from six to ten therefore raises the largest power from $U^{32}$ to $U^{512}$, increasing the size and runtime cost of the largest iteration circuit by a factor of sixteen for this repeated-power strategy.\nThis tutorial uses six bits to keep the simulation tractable; that choice does not by itself provide $\\mathrm{m}E_{\\mathrm{h}}$ resolution.\n\nThe evolution time is computed from quantities already produced by the classically tractable example chosen for this tutorial.\nIf we write the mapped Hamiltonian as $\\hat H_{\\mathrm{qubit}}=\\sum_\\ell h_\\ell P_\\ell$ and define\n\n$$\n\\lambda=\\sum_\\ell\\lvert h_\\ell\\rvert.\n$$\n\nThe QDK/Chemistry application programming interface (API) exposes this coefficient 1-norm as `qubit_hamiltonian.schatten_norm`; the tutorial script uses it to choose the evolution time and reports it in the pre-simulation settings.\nFor this Hamiltonian, the reported value is $\\lambda=19.610172748837\\ E_{\\mathrm{h}}$.\nBecause $\\lambda$ bounds the magnitudes of the Hamiltonian eigenvalues, the initial choice\n\n$$\nt_{\\mathrm{bound}}=\\frac{\\pi}{\\lambda}\n=0.160202191680\\ E_{\\mathrm{h}}^{-1}\n$$\n\nkeeps the spectrum within the signed, unaliased phase interval.\nThe script reports this value as the `Initial unaliased time bound` in its pre-simulation settings.\nUsing the active-space reference from the chapter *Mapping the problem to qubits*, $E_{\\mathrm{ref}}=-9.653276065987\\ E_{\\mathrm{h}}$, this initial time gives the implementation phase fraction\n\n$$\n\\varphi_{\\mathrm{bound}}\n=\\left(\\frac{-t_{\\mathrm{bound}}E_{\\mathrm{ref}}}{2\\pi}\\right)\\bmod 1\n\\approx0.246129297014.\n$$\n\nThe script reports this value as the `Reference phase at initial time bound`.\nThe nearest six-bit fraction is $16/64=0.25$, represented by `010000`.\nIts signed angle is $2\\pi(16/64)=+\\pi/2$.\nFinally, we can choose the evolution time so that this grid point reconstructs an energy $\\delta=0.001\\ E_{\\mathrm{h}}$ above the known reference:\n\n$$\nt\n=\\frac{-\\pi/2}{E_{\\mathrm{ref}}+\\delta}\n=0.162738437655\\ E_{\\mathrm{h}}^{-1}.\n$$\n\nThe script reports this adjusted value as the `Selected evolution time`.\nUsing this time, the reference phase fraction is approximately $0.250025901$, only about $2.59\\times10^{-5}$ above the selected grid point.\nThe grid point therefore reconstructs an active energy exactly $1\\ \\mathrm{m}E_{\\mathrm{h}}$ above the classical reference to the displayed precision.\n\nThe table below compares the selected point with its neighboring six-bit grid energies and the known reference.\nThe rows are ordered by energy rather than by grid index, so the more negative $k=17$ energy appears before $k=16$.\nThe reference row has no grid index or bitstring because the reference does not lie exactly on the six-bit grid.\n\n<div style=\"display:flex;flex-direction:column;align-items:center;\">\n\n| Grid point | Bitstring | Active energy ($E_{\\mathrm{h}}$) |\n|---|---|---|\n| $k=17$ | `010001` | $-10.255543320111$ |\n| Known reference (not a grid point) | Not applicable | $-9.653276065987$ |\n| $k=16$ (selected) | `010000` | $-9.652276065987$ |\n| $k=15$ | `001111` | $-9.049008811863$ |\n\n*Six-bit active-energy grid near the reference. Here $k$ is the integer grid index, so $\\varphi_k=k/2^6=k/64$; its six-bit binary representation is the measured bitstring.*\n\n</div>\n\nThe neighboring grid energies differ by approximately $0.6033\\ E_{\\mathrm{h}}$.\nBy contrast, selected grid point $k=16$ is only $0.001\\ E_{\\mathrm{h}}$ above the known reference.\nThis small offset is possible because the evolution time was tuned using that reference; it is not the general resolution of the six-bit grid.\n\n**Please note**: this use of the already known classical energy is circular.\nIt is useful for this tutorial, but it is not a generally available strategy when the target energy is unknown.\nFor the chosen $t$, adjacent energies represented by the six-bit phase grid differ by approximately $0.6033\\ E_{\\mathrm{h}}$, not $0.001\\ E_{\\mathrm{h}}$.\nThe smaller value, $0.001\\ E_{\\mathrm{h}}$ or $1\\ \\mathrm{m}E_{\\mathrm{h}}$, is the accuracy target adopted for this tutorial.\nThe question below asks why one grid point can nevertheless reconstruct this particular reference energy within that target.\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;Why does six-bit phase estimation meet a 1&nbsp;m<i>E</i><sub>h</sub> target here even though adjacent grid points are much farther apart?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nThe classically known reference energy was used to tune the evolution time so the target lies almost exactly on one six-bit grid point.\nSix bits do not provide $\\mathrm{m}E_{\\mathrm{h}}$ resolution for arbitrary energies with this evolution time.\n\n</div>\n\n</details></div>"
+   "source": [
+    "## Energy-to-phase encoding\n",
+    "\n",
+    "Let $\\vert\\Psi_j\\rangle$ be an eigenstate of the qubit Hamiltonian with active-space energy $E_j$:\n",
+    "\n",
+    "$$\n",
+    "\\hat H_{\\mathrm{qubit}}\\vert\\Psi_j\\rangle\n",
+    "= E_j\\vert\\Psi_j\\rangle.\n",
+    "$$\n",
+    "\n",
+    "In atomic units, the evolution time $t$ is expressed in inverse Hartree, $E_{\\mathrm{h}}^{-1}$, so the product $E_jt$ is dimensionless.\n",
+    "The time-evolution unitary is\n",
+    "\n",
+    "$$\n",
+    "U(t)=e^{-i\\hat H_{\\mathrm{qubit}}t}.\n",
+    "$$\n",
+    "\n",
+    "Because every power of the Hamiltonian acting on $\\vert\\Psi_j\\rangle$ contributes the corresponding power of $E_j$, the exponential acts on that eigenstate as\n",
+    "\n",
+    "$$\n",
+    "U(t)\\vert\\Psi_j\\rangle\n",
+    "=e^{-i\\hat H_{\\mathrm{qubit}}t}\\vert\\Psi_j\\rangle\n",
+    "=e^{-iE_jt}\\vert\\Psi_j\\rangle.\n",
+    "$$\n",
+    "\n",
+    "The physical eigenphase in the exponential is therefore $-E_jt$ modulo $2\\pi$.\n",
+    "The phase fraction reported by QPE is\n",
+    "\n",
+    "$$\n",
+    "\\varphi_j\n",
+    "=\\left(\\frac{-E_jt}{2\\pi}\\right)\\bmod 1.\n",
+    "$$\n",
+    "\n",
+    "The QDK/Chemistry result object handles the modulo wrapping automatically.\n",
+    "It converts the measured phase fraction to a signed angle $\\alpha\\in(-\\pi,\\pi]$ and returns $-\\alpha/t$.\n",
+    "The tutorial script uses this value directly rather than manually applying a sign conversion.\n",
+    "To avoid aliasing, the active-space Hamiltonian energy eigenvalue $E_j$ being estimated must lie in the signed interval $[-\\pi/t,\\pi/t)$; energies outside that interval can produce the same measured phase.\n",
+    "The two boundary energies differ by one complete phase turn and therefore represent the same measured phase; QDK/Chemistry assigns that boundary to $-\\pi/t$.\n",
+    "\n",
+    "The next figure shows how to read this wrapping convention.\n",
+    "Follow the upper axis from $\\varphi=0$ toward $\\varphi=1$.\n",
+    "From zero through one half, the signed angle is nonnegative, so $E=-\\alpha/t$ runs from zero down to $-\\pi/t$ along the green branch.\n",
+    "Immediately above one half, the signed angle wraps from $+\\pi$ to just above $-\\pi$; the corresponding energy jumps to just below $+\\pi/t$ and then returns toward zero along the purple branch.\n",
+    "At $\\varphi=1/2$, the lower filled point includes $-\\pi/t$, while the upper open point excludes the equivalent $+\\pi/t$ representation.\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "\n",
+    "<svg xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"656.39952pt\" height=\"339.59952pt\" viewBox=\"0 0 656.39952 339.59952\" xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" class=\"qdk-chemistry-phase-wrapping\" role=\"img\" data-asset=\"tutorial_qpe_phase_wrapping.svg\" aria-label=\"Signed reconstructed energy plotted against phase fraction from zero to one. Phase fractions from zero through one half map from zero down to minus pi over t. Immediately above one half, the signed branch wraps to just below plus pi over t and returns toward zero as the phase approaches one. A neutral dashed guide connects the included minus pi over t point and excluded plus pi over t point at phase one half. A red bracket beside the plot spans their energy difference of two pi over t. Phase one wraps to phase zero.\" style=\"max-width:100%;height:auto\"> <metadata> <rdf:RDF xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"> <cc:Work> <dc:type rdf:resource=\"http://purl.org/dc/dcmitype/StillImage\"/> <dc:format>image/svg+xml</dc:format> <dc:creator> <cc:Agent> <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title> </cc:Agent> </dc:creator> </cc:Work> </rdf:RDF> </metadata> <defs> <style type=\"text/css\"> .qdk-chemistry-phase-wrapping { --qdk-host-foreground: var( --vscode-editor-foreground, var(--jp-widgets-color, currentColor) ); --diagram-foreground: var(--qdk-host-foreground); --diagram-grid: var( --vscode-panel-border, var(--jp-border-color2, #888888) ); } .qdk-chemistry-phase-wrapping text { fill: var(--diagram-foreground) !important; } </style>  <style type=\"text/css\">.qdk-chemistry-phase-wrapping *{stroke-linejoin: round; stroke-linecap: butt}</style> </defs> <g id=\"figure_1\"> <g id=\"patch_1\"> <path d=\"M 0 339.59952 L 656.39952 339.59952 L 656.39952 0 L 0 0 L 0 339.59952 z \" style=\"fill: none\"/> </g> <g id=\"axes_1\"> <g id=\"patch_2\"> <path d=\"M 64.055469 301.398739 L 649.19952 301.398739 L 649.19952 7.2 L 64.055469 7.2 L 64.055469 301.398739 z \" style=\"fill: none\"/> </g> <g id=\"matplotlib.axis_1\"> <g id=\"xtick_1\"> <g id=\"line2d_1\"> <path d=\"M 74.694452 301.398739 L 74.694452 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_2\"> <defs> <path id=\"mda624babe4\" d=\"M 0 0 L 0 3.5 \" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </defs> <g> <use xlink:href=\"#mda624babe4\" x=\"74.694452\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_1\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"74.694452\" y=\"315.996395\" transform=\"rotate(-0 74.694452 315.996395)\">0</text> </g> </g> <g id=\"xtick_2\"> <g id=\"line2d_3\"> <path d=\"M 207.681736 301.398739 L 207.681736 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_4\"> <g> <use xlink:href=\"#mda624babe4\" x=\"207.681736\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_2\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"207.681736\" y=\"315.996395\" transform=\"rotate(-0 207.681736 315.996395)\">1/4</text> </g> </g> <g id=\"xtick_3\"> <g id=\"line2d_5\"> <path d=\"M 340.66902 301.398739 L 340.66902 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_6\"> <g> <use xlink:href=\"#mda624babe4\" x=\"340.66902\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_3\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"340.66902\" y=\"315.996395\" transform=\"rotate(-0 340.66902 315.996395)\">1/2</text> </g> </g> <g id=\"xtick_4\"> <g id=\"line2d_7\"> <path d=\"M 473.656305 301.398739 L 473.656305 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_8\"> <g> <use xlink:href=\"#mda624babe4\" x=\"473.656305\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_4\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"473.656305\" y=\"315.996395\" transform=\"rotate(-0 473.656305 315.996395)\">3/4</text> </g> </g> <g id=\"xtick_5\"> <g id=\"line2d_9\"> <path d=\"M 606.643589 301.398739 L 606.643589 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_10\"> <g> <use xlink:href=\"#mda624babe4\" x=\"606.643589\" y=\"301.398739\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_5\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"606.643589\" y=\"315.996395\" transform=\"rotate(-0 606.643589 315.996395)\">1 → 0</text> </g> </g> <g id=\"text_6\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"356.627494\" y=\"329.997176\" transform=\"rotate(-0 356.627494 329.997176)\">Reported phase fraction φ ∈ [0, 1)</text> </g> </g> <g id=\"matplotlib.axis_2\"> <g id=\"ytick_1\"> <g id=\"line2d_11\"> <path d=\"M 64.055469 29.638887 L 649.19952 29.638887 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_12\"> <defs> <path id=\"medb564f5fd\" d=\"M 0 0 L -3.5 0 \" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </defs> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"29.638887\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_7\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"33.437715\" transform=\"rotate(-0 57.055469 33.437715)\">+π/t</text> </g> </g> <g id=\"ytick_2\"> <g id=\"line2d_13\"> <path d=\"M 64.055469 91.969128 L 649.19952 91.969128 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_14\"> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"91.969128\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_8\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"95.767956\" transform=\"rotate(-0 57.055469 95.767956)\">+π/(2t)</text> </g> </g> <g id=\"ytick_3\"> <g id=\"line2d_15\"> <path d=\"M 64.055469 154.299369 L 649.19952 154.299369 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_16\"> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"154.299369\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_9\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"158.098197\" transform=\"rotate(-0 57.055469 158.098197)\">0</text> </g> </g> <g id=\"ytick_4\"> <g id=\"line2d_17\"> <path d=\"M 64.055469 216.629611 L 649.19952 216.629611 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_18\"> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"216.629611\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_10\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"220.428439\" transform=\"rotate(-0 57.055469 220.428439)\">−π/(2t)</text> </g> </g> <g id=\"ytick_5\"> <g id=\"line2d_19\"> <path d=\"M 64.055469 278.959852 L 649.19952 278.959852 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: var(--diagram-grid); stroke-width: 0.8; stroke-linecap: square\"/> </g> <g id=\"line2d_20\"> <g> <use xlink:href=\"#medb564f5fd\" x=\"64.055469\" y=\"278.959852\" style=\"stroke: var(--diagram-foreground); stroke-width: 0.8\"/> </g> </g> <g id=\"text_11\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end\" x=\"57.055469\" y=\"282.75868\" transform=\"rotate(-0 57.055469 282.75868)\">−π/t</text> </g> </g> <g id=\"text_12\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle\" x=\"14.798438\" y=\"154.299369\" transform=\"rotate(-90 14.798438 154.299369)\">Signed reconstructed energy</text> </g> </g> <g id=\"line2d_21\"> <path d=\"M 74.694452 154.299369 L 340.66902 278.959852 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: #00796b; stroke-width: 3; stroke-linecap: square\"/> </g> <g id=\"line2d_22\"> <path d=\"M 340.66902 29.638887 L 606.643589 154.299369 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: #7b1fa2; stroke-width: 3; stroke-linecap: square\"/> </g> <g id=\"line2d_23\"> <path d=\"M 340.66902 301.398739 L 340.66902 7.2 \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #78909c; stroke-width: 1.5\"/> </g> <g id=\"patch_3\"> <path d=\"M 64.055469 301.398739 L 64.055469 7.2 \" style=\"fill: none; stroke: var(--diagram-foreground); stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square\"/> </g> <g id=\"patch_4\"> <path d=\"M 64.055469 301.398739 L 649.19952 301.398739 \" style=\"fill: none; stroke: var(--diagram-foreground); stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square\"/> </g> <g id=\"PathCollection_1\"> <defs> <path id=\"m92b30d0e14\" d=\"M 0 4.609772 C 1.222526 4.609772 2.395145 4.124058 3.259601 3.259601 C 4.124058 2.395145 4.609772 1.222526 4.609772 0 C 4.609772 -1.222526 4.124058 -2.395145 3.259601 -3.259601 C 2.395145 -4.124058 1.222526 -4.609772 0 -4.609772 C -1.222526 -4.609772 -2.395145 -4.124058 -3.259601 -3.259601 C -4.124058 -2.395145 -4.609772 -1.222526 -4.609772 0 C -4.609772 1.222526 -4.124058 2.395145 -3.259601 3.259601 C -2.395145 4.124058 -1.222526 4.609772 0 4.609772 z \" style=\"stroke: #00796b\"/> </defs> <g clip-path=\"url(#pc895b022ad)\"> <use xlink:href=\"#m92b30d0e14\" x=\"340.66902\" y=\"278.959852\" style=\"fill: #00796b; stroke: #00796b\"/> </g> </g> <g id=\"PathCollection_2\"> <path d=\"M 340.66902 34.248659 C 341.891546 34.248659 343.064165 33.762944 343.928621 32.898488 C 344.793078 32.034032 345.278792 30.861413 345.278792 29.638887 C 345.278792 28.416361 344.793078 27.243742 343.928621 26.379286 C 343.064165 25.514829 341.891546 25.029115 340.66902 25.029115 C 339.446494 25.029115 338.273875 25.514829 337.409419 26.379286 C 336.544963 27.243742 336.059248 28.416361 336.059248 29.638887 C 336.059248 30.861413 336.544963 32.034032 337.409419 32.898488 C 338.273875 33.762944 339.446494 34.248659 340.66902 34.248659 L 340.66902 34.248659 z \" clip-path=\"url(#pc895b022ad)\" style=\"fill: none; stroke: #7b1fa2; stroke-width: 2.5\"/> </g> <g id=\"text_13\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #00796b\" x=\"325.66902\" y=\"296.959852\" transform=\"rotate(-0 325.66902 296.959852)\">included boundary</text> </g> <g id=\"text_14\"> <text style=\"font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #7b1fa2\" x=\"354.66902\" y=\"17.638887\" transform=\"rotate(-0 354.66902 17.638887)\">excluded boundary</text> </g> <g id=\"patch_5\"> <path d=\"M 630.5813 265.311469 Q 630.5813 154.301072 630.5813 43.290675 \" style=\"fill: none; stroke: #c62828; stroke-width: 1.5; stroke-linecap: round\"/> <path d=\"M 632.5813 261.311469 L 630.5813 265.311469 L 628.5813 261.311469 \" style=\"fill: none; stroke: #c62828; stroke-width: 1.5; stroke-linecap: round\"/> <path d=\"M 628.5813 47.290675 L 630.5813 43.290675 L 632.5813 47.290675 \" style=\"fill: none; stroke: #c62828; stroke-width: 1.5; stroke-linecap: round\"/> </g> </g> </g> <defs> <clipPath id=\"pc895b022ad\"> <rect x=\"64.055469\" y=\"7.2\" width=\"585.144051\" height=\"294.198739\"/> </clipPath> </defs> </svg>\n",
+    "\n",
+    "*QDK/Chemistry converts the wrapped phase fraction to one signed energy branch. The neutral dashed guide marks the shared phase $\\varphi=1/2$; the red bracket spans the $2\\pi/t$ energy difference between its included and excluded boundary representations. Energies separated by that amount alias to the same reported phase.*\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "With $m$ measured phase bits, the representable fractions are multiples of $2^{-m}$, so adjacent energy-grid points are separated by\n",
+    "\n",
+    "$$\n",
+    "\\Delta E_{\\mathrm{grid}}=\\frac{2\\pi}{t2^m}.\n",
+    "$$\n",
+    "\n",
+    "With $m$ measured phase bits, the largest controlled power is $U^{2^{m-1}}$.\n",
+    "Increasing $m$ from six to ten therefore raises the largest power from $U^{32}$ to $U^{512}$, increasing the size and runtime cost of the largest iteration circuit by a factor of sixteen for this repeated-power strategy.\n",
+    "This tutorial uses six bits to keep the simulation tractable; that choice does not by itself provide $\\mathrm{m}E_{\\mathrm{h}}$ resolution.\n",
+    "\n",
+    "The evolution time is computed from quantities already produced by the classically tractable example chosen for this tutorial.\n",
+    "If we write the mapped Hamiltonian as $\\hat H_{\\mathrm{qubit}}=\\sum_\\ell h_\\ell P_\\ell$ and define\n",
+    "\n",
+    "$$\n",
+    "\\lambda=\\sum_\\ell\\lvert h_\\ell\\rvert.\n",
+    "$$\n",
+    "\n",
+    "The QDK/Chemistry application programming interface (API) exposes this coefficient 1-norm as `qubit_hamiltonian.schatten_norm`; the tutorial script uses it to choose the evolution time and reports it in the pre-simulation settings.\n",
+    "For this Hamiltonian, the reported value is $\\lambda=19.610172748837\\ E_{\\mathrm{h}}$.\n",
+    "Because $\\lambda$ bounds the magnitudes of the Hamiltonian eigenvalues, the initial choice\n",
+    "\n",
+    "$$\n",
+    "t_{\\mathrm{bound}}=\\frac{\\pi}{\\lambda}\n",
+    "=0.160202191680\\ E_{\\mathrm{h}}^{-1}\n",
+    "$$\n",
+    "\n",
+    "keeps the spectrum within the signed, unaliased phase interval.\n",
+    "The script reports this value as the `Initial unaliased time bound` in its pre-simulation settings.\n",
+    "Using the active-space reference from the chapter *Mapping the problem to qubits*, $E_{\\mathrm{ref}}=-9.653276065987\\ E_{\\mathrm{h}}$, this initial time gives the implementation phase fraction\n",
+    "\n",
+    "$$\n",
+    "\\varphi_{\\mathrm{bound}}\n",
+    "=\\left(\\frac{-t_{\\mathrm{bound}}E_{\\mathrm{ref}}}{2\\pi}\\right)\\bmod 1\n",
+    "\\approx0.246129297014.\n",
+    "$$\n",
+    "\n",
+    "The script reports this value as the `Reference phase at initial time bound`.\n",
+    "The nearest six-bit fraction is $16/64=0.25$, represented by `010000`.\n",
+    "Its signed angle is $2\\pi(16/64)=+\\pi/2$.\n",
+    "Finally, we can choose the evolution time so that this grid point reconstructs an energy $\\delta=0.001\\ E_{\\mathrm{h}}$ above the known reference:\n",
+    "\n",
+    "$$\n",
+    "t\n",
+    "=\\frac{-\\pi/2}{E_{\\mathrm{ref}}+\\delta}\n",
+    "=0.162738437655\\ E_{\\mathrm{h}}^{-1}.\n",
+    "$$\n",
+    "\n",
+    "The script reports this adjusted value as the `Selected evolution time`.\n",
+    "Using this time, the reference phase fraction is approximately $0.250025901$, only about $2.59\\times10^{-5}$ above the selected grid point.\n",
+    "The grid point therefore reconstructs an active energy exactly $1\\ \\mathrm{m}E_{\\mathrm{h}}$ above the classical reference to the displayed precision.\n",
+    "\n",
+    "The table below compares the selected point with its neighboring six-bit grid energies and the known reference.\n",
+    "The rows are ordered by energy rather than by grid index, so the more negative $k=17$ energy appears before $k=16$.\n",
+    "The reference row has no grid index or bitstring because the reference does not lie exactly on the six-bit grid.\n",
+    "\n",
+    "<div style=\"display:flex;flex-direction:column;align-items:center;\">\n",
+    "\n",
+    "| Grid point | Bitstring | Active energy ($E_{\\mathrm{h}}$) |\n",
+    "|---|---|---|\n",
+    "| $k=17$ | `010001` | $-10.255543320111$ |\n",
+    "| Known reference (not a grid point) | Not applicable | $-9.653276065987$ |\n",
+    "| $k=16$ (selected) | `010000` | $-9.652276065987$ |\n",
+    "| $k=15$ | `001111` | $-9.049008811863$ |\n",
+    "\n",
+    "*Six-bit active-energy grid near the reference. Here $k$ is the integer grid index, so $\\varphi_k=k/2^6=k/64$; its six-bit binary representation is the measured bitstring.*\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "The neighboring grid energies differ by approximately $0.6033\\ E_{\\mathrm{h}}$.\n",
+    "By contrast, selected grid point $k=16$ is only $0.001\\ E_{\\mathrm{h}}$ above the known reference.\n",
+    "This small offset is possible because the evolution time was tuned using that reference; it is not the general resolution of the six-bit grid.\n",
+    "\n",
+    "**Please note**: this use of the already known classical energy is circular.\n",
+    "It is useful for this tutorial, but it is not a generally available strategy when the target energy is unknown.\n",
+    "For the chosen $t$, adjacent energies represented by the six-bit phase grid differ by approximately $0.6033\\ E_{\\mathrm{h}}$, not $0.001\\ E_{\\mathrm{h}}$.\n",
+    "The smaller value, $0.001\\ E_{\\mathrm{h}}$ or $1\\ \\mathrm{m}E_{\\mathrm{h}}$, is the accuracy target adopted for this tutorial.\n",
+    "The question below asks why one grid point can nevertheless reconstruct this particular reference energy within that target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-8002aa5f3b38",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Why does six-bit phase estimation meet a 1 mEh target here, even though adjacent grid points are much farther apart than that?",
+       "options": [
+        {
+         "id": "shots-interpolate",
+         "text": "Averaging over the 20 shots interpolates between neighbouring grid points.",
+         "correct": false,
+         "explanation": "Shots make the selected grid point more reliable. They never produce an energy that lies between two grid points."
+        },
+        {
+         "id": "trotter-cancels",
+         "text": "Trotter approximation error happens to cancel the grid spacing error.",
+         "correct": false,
+         "explanation": "Trotter error is a separate contribution and is not controlled here, so it cannot be relied on to offset discretization."
+        },
+        {
+         "id": "six-bits-enough",
+         "text": "Six phase bits are enough to resolve any energy to 1 mEh.",
+         "correct": false,
+         "explanation": "They are not. At this evolution time the grid spacing is far coarser than 1 mEh; the agreement comes from where the target sits."
+        },
+        {
+         "id": "tuned",
+         "text": "The evolution time was tuned using the classically known reference energy, so the target lands almost exactly on one six-bit grid point.",
+         "correct": true,
+         "explanation": "The alignment is deliberate. Six bits do not give mEh resolution for an arbitrary energy at this evolution time."
+        }
+       ],
+       "cellId": "iqpe-grid-target"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Why does six-bit phase estimation meet a 1 mEh target here, even though adjacent grid points are much farther apart than that?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Averaging over the 20 shots interpolates between neighbouring grid points.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Trotter approximation error happens to cancel the grid spacing error.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Six phase bits are enough to resolve any energy to 1 mEh.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The evolution time was tuned using the classically known reference energy, so the target lands almost exactly on one six-bit grid point.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Why does six-bit phase estimation meet a 1 mEh target here, even though adjacent grid points are much farther apart than that?\n  ( ) Averaging over the 20 shots interpolates between neighbouring grid points.\n  ( ) Trotter approximation error happens to cancel the grid spacing error.\n  ( ) Six phase bits are enough to resolve any energy to 1 mEh.\n  ( ) The evolution time was tuned using the classically known reference energy, so the target lands almost exactly on one six-bit grid point."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-grid-target\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -90,7 +283,114 @@
      "section:one-phase-bit-at-a-time"
     ]
    },
-   "source": "## One phase bit at a time\n\nStandard phase estimation uses several readout ancillas and an inverse quantum Fourier transform to obtain a complete phase in one coherent circuit.\nThe QDK/Chemistry iterative implementation (IQPE) instead reuses a single readout ancilla across a sequence of independently executed circuits.\nThis reduces each circuit's logical-qubit requirement, both on quantum hardware and in this tutorial's classical simulator, at the cost of repeated state preparation and circuit execution.\nThis qubit-resource tradeoff is why the tutorial uses IQPE.\n\nFor iterations over $k=0,1,\\ldots,m-1$, the circuit builder uses the controlled power\n\n$$\nU^{2^{m-k-1}}.\n$$\n\nWith $m=6$, the six iteration circuits therefore apply powers $32,16,8,4,2,1$.\nQDK/Chemistry reverses the measurements from execution order when it constructs the conventional most-significant-bit-first result.\nFor an input eigenstate, the first H gate prepares the readout ancilla in $(\\vert0\\rangle+\\vert1\\rangle)/\\sqrt{2}$.\nThe feedback rotation applies a corrective phase determined by earlier iterations.\nThe controlled power then produces *phase kickback*: the $\\vert1\\rangle$ branch acquires the eigenphase of $U^{2^{m-k-1}}$, while the $\\vert0\\rangle$ branch does not.\nTogether, the feedback and kickback phases cancel the contribution already determined by earlier iterations.\nAfter the second H gate, the remaining relative phase changes the probabilities of measuring zero or one, revealing the next phase bit.\n\nIf iteration $k$ selects bit $b_k$, QDK/Chemistry updates its accumulated feedback angle according to\n\n$$\n\\Phi_{k+1}=\\frac{\\Phi_k}{2}+\\frac{\\pi b_k}{2},\n\\qquad \\Phi_0=0.\n$$\n\nAfter the last iteration, the reported phase fraction is $\\Phi_m/\\pi$.\nThe following figure summarizes one iteration, from fresh register preparation through repeated shots, majority voting, and the feedback update for the next phase bit.\n\n<div style=\"text-align:center;\">\n\n<svg width=\"587pt\" height=\"891pt\" viewBox=\"0.00 0.00 587.00 891.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" class=\"qdk-chemistry-iqpe-iteration\" role=\"img\" data-asset=\"tutorial_qpe_iqpe_iteration.svg\" aria-label=\"Flow through one IQPE iteration. In parallel, freshly prepare the molecular trial state on the compute register and a Hadamard superposition on a new readout ancilla. Rotate the ancilla using feedback from earlier measured bits, then use it to control this iteration&#x27;s time-evolution power on the compute register. Apply a final Hadamard gate and measure the ancilla for one shot. Repeat with fresh registers for an odd number of shots; their majority selects phase bit b sub k. Use that bit to update the classical feedback angle and continue to iteration k plus 1.\" style=\"max-width:100%;height:auto\"><style>.qdk-chemistry-iqpe-iteration { --qdk-fg: var(--vscode-editor-foreground, var(--jp-content-font-color1, currentColor)); } .qdk-chemistry-iqpe-iteration path[fill=\"#ffffff\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#ffffff\"] { fill: transparent; } .qdk-chemistry-iqpe-iteration path[fill=\"lightgrey\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"lightgrey\"] { fill: none; } .qdk-chemistry-iqpe-iteration path[fill=\"#e8eaf6\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#e8eaf6\"] { fill: color-mix(in srgb, #3949ab 16%, transparent); } .qdk-chemistry-iqpe-iteration path[fill=\"#e0f2f1\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#e0f2f1\"] { fill: color-mix(in srgb, #00796b 16%, transparent); } .qdk-chemistry-iqpe-iteration path[fill=\"#e3f2fd\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#e3f2fd\"] { fill: color-mix(in srgb, #1976d2 16%, transparent); } .qdk-chemistry-iqpe-iteration path[fill=\"#f3e5f5\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#f3e5f5\"] { fill: color-mix(in srgb, #7b1fa2 16%, transparent); } .qdk-chemistry-iqpe-iteration text[fill=\"#004d40\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#004d40\"] { stroke: color-mix(in srgb, #004d40 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#00796b\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#00796b\"] { stroke: color-mix(in srgb, #00796b 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#0d47a1\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#0d47a1\"] { stroke: color-mix(in srgb, #0d47a1 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#1976d2\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#1976d2\"] { stroke: color-mix(in srgb, #1976d2 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#26a69a\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#26a69a\"] { stroke: color-mix(in srgb, #26a69a 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#283593\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#283593\"] { stroke: color-mix(in srgb, #283593 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#3949ab\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#3949ab\"] { stroke: color-mix(in srgb, #3949ab 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#42a5f5\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#42a5f5\"] { stroke: color-mix(in srgb, #42a5f5 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#4a148c\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#4a148c\"] { stroke: color-mix(in srgb, #4a148c 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#5c6bc0\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#5c6bc0\"] { stroke: color-mix(in srgb, #5c6bc0 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#7b1fa2\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#7b1fa2\"] { stroke: color-mix(in srgb, #7b1fa2 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#ab47bc\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#ab47bc\"] { stroke: color-mix(in srgb, #ab47bc 65%, var(--qdk-fg)); }</style> <g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(14.4 876.6)\"> <title>TutorialQpeIqpeIteration</title> <!-- Compute --> <g id=\"node1\" class=\"node\"> <title>Compute</title> <path fill=\"#e0f2f1\" stroke=\"#00796b\" stroke-width=\"2.5\" d=\"M247.2,-862.2C247.2,-862.2 12,-862.2 12,-862.2 6,-862.2 0,-856.2 0,-850.2 0,-850.2 0,-805.8 0,-805.8 0,-799.8 6,-793.8 12,-793.8 12,-793.8 247.2,-793.8 247.2,-793.8 253.2,-793.8 259.2,-799.8 259.2,-805.8 259.2,-805.8 259.2,-850.2 259.2,-850.2 259.2,-856.2 253.2,-862.2 247.2,-862.2\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"54.22\" y=\"-835.2\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#004d40\">Fresh compute register</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"54.97\" y=\"-810.05\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#004d40\">Prepare the trial state |Ψ<tspan baseline-shift=\"sub\" font-size=\"8.25\">trial</tspan>⟩</text> </g> <!-- Evolution --> <g id=\"node4\" class=\"node\"> <title>Evolution</title> <path fill=\"#e0f2f1\" stroke=\"#00796b\" stroke-width=\"2.5\" d=\"M424.6,-635.4C424.6,-635.4 88.6,-635.4 88.6,-635.4 82.6,-635.4 76.6,-629.4 76.6,-623.4 76.6,-623.4 76.6,-579 76.6,-579 76.6,-573 82.6,-567 88.6,-567 88.6,-567 424.6,-567 424.6,-567 430.6,-567 436.6,-573 436.6,-579 436.6,-579 436.6,-623.4 436.6,-623.4 436.6,-629.4 430.6,-635.4 424.6,-635.4\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"155.35\" y=\"-608.4\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#004d40\">Apply controlled time evolution</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"124.23\" y=\"-583.25\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#004d40\">Ancilla controls U^(2^(m−k−1)) on the compute register</text> </g> <!-- Compute&#45;&gt;Evolution --> <g id=\"edge2\" class=\"edge\"> <title>Compute&#45;&gt;Evolution</title> <path fill=\"none\" stroke=\"#00796b\" stroke-width=\"2.5\" d=\"M155,-792.56C155,-792.56 155,-649.17 155,-649.17\"/> <polygon fill=\"#00796b\" stroke=\"#00796b\" stroke-width=\"2.5\" points=\"158.15,-649.17 155,-640.17 151.85,-649.17 158.15,-649.17\"/> </g> <!-- Ancilla --> <g id=\"node2\" class=\"node\"> <title>Ancilla</title> <path fill=\"#e8eaf6\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M546.2,-862.2C546.2,-862.2 311,-862.2 311,-862.2 305,-862.2 299,-856.2 299,-850.2 299,-850.2 299,-805.8 299,-805.8 299,-799.8 305,-793.8 311,-793.8 311,-793.8 546.2,-793.8 546.2,-793.8 552.2,-793.8 558.2,-799.8 558.2,-805.8 558.2,-805.8 558.2,-850.2 558.2,-850.2 558.2,-856.2 552.2,-862.2 546.2,-862.2\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"343.85\" y=\"-835.2\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#283593\">Fresh readout ancilla |0⟩</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"378.35\" y=\"-810.05\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#283593\">Apply the first H gate</text> </g> <!-- Feedback --> <g id=\"node3\" class=\"node\"> <title>Feedback</title> <path fill=\"#e8eaf6\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M523.8,-748.8C523.8,-748.8 245.4,-748.8 245.4,-748.8 239.4,-748.8 233.4,-742.8 233.4,-736.8 233.4,-736.8 233.4,-692.4 233.4,-692.4 233.4,-686.4 239.4,-680.4 245.4,-680.4 245.4,-680.4 523.8,-680.4 523.8,-680.4 529.8,-680.4 535.8,-686.4 535.8,-692.4 535.8,-692.4 535.8,-736.8 535.8,-736.8 535.8,-742.8 529.8,-748.8 523.8,-748.8\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"313.35\" y=\"-721.8\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#283593\">Apply phase feedback</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"287.85\" y=\"-696.65\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#283593\">Use angle Φ<tspan baseline-shift=\"sub\" font-size=\"8.25\">k</tspan> from earlier measured bits</text> </g> <!-- Ancilla&#45;&gt;Feedback --> <g id=\"edge1\" class=\"edge\"> <title>Ancilla&#45;&gt;Feedback</title> <path fill=\"none\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M417.4,-792.74C417.4,-792.74 417.4,-762.62 417.4,-762.62\"/> <polygon fill=\"#5c6bc0\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" points=\"420.55,-762.62 417.4,-753.62 414.25,-762.62 420.55,-762.62\"/> </g> <!-- Feedback&#45;&gt;Evolution --> <g id=\"edge3\" class=\"edge\"> <title>Feedback&#45;&gt;Evolution</title> <path fill=\"none\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M335,-679.34C335,-679.34 335,-649.22 335,-649.22\"/> <polygon fill=\"#5c6bc0\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" points=\"338.15,-649.22 335,-640.22 331.85,-649.22 338.15,-649.22\"/> </g> <!-- Measure --> <g id=\"node5\" class=\"node\"> <title>Measure</title> <path fill=\"#e8eaf6\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M395.8,-522C395.8,-522 117.4,-522 117.4,-522 111.4,-522 105.4,-516 105.4,-510 105.4,-510 105.4,-465.6 105.4,-465.6 105.4,-459.6 111.4,-453.6 117.4,-453.6 117.4,-453.6 395.8,-453.6 395.8,-453.6 401.8,-453.6 407.8,-459.6 407.8,-465.6 407.8,-465.6 407.8,-510 407.8,-510 407.8,-516 401.8,-522 395.8,-522\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"152.35\" y=\"-495\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#283593\">Apply H and measure the ancilla</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"201.1\" y=\"-469.85\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#283593\">One shot returns 0 or 1</text> </g> <!-- Evolution&#45;&gt;Measure --> <g id=\"edge4\" class=\"edge\"> <title>Evolution&#45;&gt;Measure</title> <path fill=\"none\" stroke=\"#00796b\" stroke-width=\"2.5\" d=\"M256.6,-565.94C256.6,-565.94 256.6,-535.82 256.6,-535.82\"/> <polygon fill=\"#00796b\" stroke=\"#00796b\" stroke-width=\"2.5\" points=\"259.75,-535.82 256.6,-526.82 253.45,-535.82 259.75,-535.82\"/> </g> <!-- Shots --> <g id=\"node6\" class=\"node\"> <title>Shots</title> <path fill=\"#ffffff\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M417.4,-408.6C417.4,-408.6 95.8,-408.6 95.8,-408.6 89.8,-408.6 83.8,-402.6 83.8,-396.6 83.8,-396.6 83.8,-352.2 83.8,-352.2 83.8,-346.2 89.8,-340.2 95.8,-340.2 95.8,-340.2 417.4,-340.2 417.4,-340.2 423.4,-340.2 429.4,-346.2 429.4,-352.2 429.4,-352.2 429.4,-396.6 429.4,-396.6 429.4,-402.6 423.4,-408.6 417.4,-408.6\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"133.23\" y=\"-381.6\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#3949ab\">Repeat with freshly prepared registers</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"138.85\" y=\"-356.45\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#3949ab\">Collect an odd number of outcomes for iteration k</text> </g> <!-- Measure&#45;&gt;Shots --> <g id=\"edge5\" class=\"edge\"> <title>Measure&#45;&gt;Shots</title> <path fill=\"none\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M256.6,-452.54C256.6,-452.54 256.6,-422.42 256.6,-422.42\"/> <polygon fill=\"#5c6bc0\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" points=\"259.75,-422.42 256.6,-413.42 253.45,-422.42 259.75,-422.42\"/> </g> <!-- Majority --> <g id=\"node7\" class=\"node\"> <title>Majority</title> <path fill=\"#f3e5f5\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M395.8,-295.2C395.8,-295.2 117.4,-295.2 117.4,-295.2 111.4,-295.2 105.4,-289.2 105.4,-283.2 105.4,-283.2 105.4,-238.8 105.4,-238.8 105.4,-232.8 111.4,-226.8 117.4,-226.8 117.4,-226.8 395.8,-226.8 395.8,-226.8 401.8,-226.8 407.8,-232.8 407.8,-238.8 407.8,-238.8 407.8,-283.2 407.8,-283.2 407.8,-289.2 401.8,-295.2 395.8,-295.2\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"170.35\" y=\"-268.2\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#4a148c\">Majority vote selects bit b<tspan baseline-shift=\"sub\" font-size=\"10.50\">k</tspan></text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"182.35\" y=\"-243.05\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#4a148c\">Classical result for this iteration</text> </g> <!-- Shots&#45;&gt;Majority --> <g id=\"edge6\" class=\"edge\"> <title>Shots&#45;&gt;Majority</title> <path fill=\"none\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M256.6,-339.14C256.6,-339.14 256.6,-309.02 256.6,-309.02\"/> <polygon fill=\"#7b1fa2\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" points=\"259.75,-309.02 256.6,-300.02 253.45,-309.02 259.75,-309.02\"/> </g> <!-- Update --> <g id=\"node8\" class=\"node\"> <title>Update</title> <path fill=\"#f3e5f5\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M403,-181.8C403,-181.8 110.2,-181.8 110.2,-181.8 104.2,-181.8 98.2,-175.8 98.2,-169.8 98.2,-169.8 98.2,-125.4 98.2,-125.4 98.2,-119.4 104.2,-113.4 110.2,-113.4 110.2,-113.4 403,-113.4 403,-113.4 409,-113.4 415,-119.4 415,-125.4 415,-125.4 415,-169.8 415,-169.8 415,-175.8 409,-181.8 403,-181.8\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"141.1\" y=\"-154.8\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#4a148c\">Update the classical feedback angle</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"198.48\" y=\"-129.65\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#4a148c\">Use b<tspan baseline-shift=\"sub\" font-size=\"8.25\">k</tspan> to compute Φ<tspan baseline-shift=\"sub\" font-size=\"8.25\">k+1</tspan></text> </g> <!-- Majority&#45;&gt;Update --> <g id=\"edge7\" class=\"edge\"> <title>Majority&#45;&gt;Update</title> <path fill=\"none\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M256.6,-225.74C256.6,-225.74 256.6,-195.62 256.6,-195.62\"/> <polygon fill=\"#7b1fa2\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" points=\"259.75,-195.62 256.6,-186.62 253.45,-195.62 259.75,-195.62\"/> </g> <!-- Next --> <g id=\"node9\" class=\"node\"> <title>Next</title> <path fill=\"#ffffff\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M403,-68.4C403,-68.4 110.2,-68.4 110.2,-68.4 104.2,-68.4 98.2,-62.4 98.2,-56.4 98.2,-56.4 98.2,-12 98.2,-12 98.2,-6 104.2,0 110.2,0 110.2,0 403,0 403,0 409,0 415,-6 415,-12 415,-12 415,-56.4 415,-56.4 415,-62.4 409,-68.4 403,-68.4\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"173.35\" y=\"-41.4\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#4a148c\">Continue to iteration k + 1</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"155.35\" y=\"-16.25\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#4a148c\">Build the next controlled power and repeat</text> </g> <!-- Update&#45;&gt;Next --> <g id=\"edge8\" class=\"edge\"> <title>Update&#45;&gt;Next</title> <path fill=\"none\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M256.6,-112.34C256.6,-112.34 256.6,-82.22 256.6,-82.22\"/> <polygon fill=\"#7b1fa2\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" points=\"259.75,-82.22 256.6,-73.22 253.45,-82.22 259.75,-82.22\"/> </g> </g> </svg>\n\n*One IQPE iteration estimates phase bit $b_k$. Every shot freshly prepares the trial state and readout ancilla; the majority outcome updates $\\Phi_{k+1}=\\Phi_k/2+\\pi b_k/2$ for the next controlled power.*\n\n</div>\n\nAfter all iterations, the feedback accumulator determines the final phase fraction.\n\nEach iteration circuit contains twelve compute qubits and one readout ancilla, for thirteen logical qubits in the simulated circuit.\nThe readout ancilla does not represent an additional molecular spin orbital.\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;Why is trial-state preparation included in every IQPE iteration circuit?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nEach phase bit is measured by executing a separate circuit, and every shot begins with newly allocated qubits in the all-zero state.\nThe state-preparation logical circuit must therefore reload the trial state before each controlled evolution.\n\n</div>\n\n</details></div>\n\nThe script configures the native iterative circuit builder and first-order Trotter unitary through nested `AlgorithmRef` objects:"
+   "source": [
+    "## One phase bit at a time\n",
+    "\n",
+    "Standard phase estimation uses several readout ancillas and an inverse quantum Fourier transform to obtain a complete phase in one coherent circuit.\n",
+    "The QDK/Chemistry iterative implementation (IQPE) instead reuses a single readout ancilla across a sequence of independently executed circuits.\n",
+    "This reduces each circuit's logical-qubit requirement, both on quantum hardware and in this tutorial's classical simulator, at the cost of repeated state preparation and circuit execution.\n",
+    "This qubit-resource tradeoff is why the tutorial uses IQPE.\n",
+    "\n",
+    "For iterations over $k=0,1,\\ldots,m-1$, the circuit builder uses the controlled power\n",
+    "\n",
+    "$$\n",
+    "U^{2^{m-k-1}}.\n",
+    "$$\n",
+    "\n",
+    "With $m=6$, the six iteration circuits therefore apply powers $32,16,8,4,2,1$.\n",
+    "QDK/Chemistry reverses the measurements from execution order when it constructs the conventional most-significant-bit-first result.\n",
+    "For an input eigenstate, the first H gate prepares the readout ancilla in $(\\vert0\\rangle+\\vert1\\rangle)/\\sqrt{2}$.\n",
+    "The feedback rotation applies a corrective phase determined by earlier iterations.\n",
+    "The controlled power then produces *phase kickback*: the $\\vert1\\rangle$ branch acquires the eigenphase of $U^{2^{m-k-1}}$, while the $\\vert0\\rangle$ branch does not.\n",
+    "Together, the feedback and kickback phases cancel the contribution already determined by earlier iterations.\n",
+    "After the second H gate, the remaining relative phase changes the probabilities of measuring zero or one, revealing the next phase bit.\n",
+    "\n",
+    "If iteration $k$ selects bit $b_k$, QDK/Chemistry updates its accumulated feedback angle according to\n",
+    "\n",
+    "$$\n",
+    "\\Phi_{k+1}=\\frac{\\Phi_k}{2}+\\frac{\\pi b_k}{2},\n",
+    "\\qquad \\Phi_0=0.\n",
+    "$$\n",
+    "\n",
+    "After the last iteration, the reported phase fraction is $\\Phi_m/\\pi$.\n",
+    "The following figure summarizes one iteration, from fresh register preparation through repeated shots, majority voting, and the feedback update for the next phase bit.\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "\n",
+    "<svg width=\"587pt\" height=\"891pt\" viewBox=\"0.00 0.00 587.00 891.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" class=\"qdk-chemistry-iqpe-iteration\" role=\"img\" data-asset=\"tutorial_qpe_iqpe_iteration.svg\" aria-label=\"Flow through one IQPE iteration. In parallel, freshly prepare the molecular trial state on the compute register and a Hadamard superposition on a new readout ancilla. Rotate the ancilla using feedback from earlier measured bits, then use it to control this iteration&#x27;s time-evolution power on the compute register. Apply a final Hadamard gate and measure the ancilla for one shot. Repeat with fresh registers for an odd number of shots; their majority selects phase bit b sub k. Use that bit to update the classical feedback angle and continue to iteration k plus 1.\" style=\"max-width:100%;height:auto\"><style>.qdk-chemistry-iqpe-iteration { --qdk-fg: var(--vscode-editor-foreground, var(--jp-content-font-color1, currentColor)); } .qdk-chemistry-iqpe-iteration path[fill=\"#ffffff\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#ffffff\"] { fill: transparent; } .qdk-chemistry-iqpe-iteration path[fill=\"lightgrey\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"lightgrey\"] { fill: none; } .qdk-chemistry-iqpe-iteration path[fill=\"#e8eaf6\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#e8eaf6\"] { fill: color-mix(in srgb, #3949ab 16%, transparent); } .qdk-chemistry-iqpe-iteration path[fill=\"#e0f2f1\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#e0f2f1\"] { fill: color-mix(in srgb, #00796b 16%, transparent); } .qdk-chemistry-iqpe-iteration path[fill=\"#e3f2fd\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#e3f2fd\"] { fill: color-mix(in srgb, #1976d2 16%, transparent); } .qdk-chemistry-iqpe-iteration path[fill=\"#f3e5f5\"], .qdk-chemistry-iqpe-iteration polygon[fill=\"#f3e5f5\"] { fill: color-mix(in srgb, #7b1fa2 16%, transparent); } .qdk-chemistry-iqpe-iteration text[fill=\"#004d40\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#004d40\"] { stroke: color-mix(in srgb, #004d40 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#00796b\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#00796b\"] { stroke: color-mix(in srgb, #00796b 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#0d47a1\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#0d47a1\"] { stroke: color-mix(in srgb, #0d47a1 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#1976d2\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#1976d2\"] { stroke: color-mix(in srgb, #1976d2 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#26a69a\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#26a69a\"] { stroke: color-mix(in srgb, #26a69a 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#283593\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#283593\"] { stroke: color-mix(in srgb, #283593 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#3949ab\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#3949ab\"] { stroke: color-mix(in srgb, #3949ab 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#42a5f5\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#42a5f5\"] { stroke: color-mix(in srgb, #42a5f5 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#4a148c\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#4a148c\"] { stroke: color-mix(in srgb, #4a148c 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#5c6bc0\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#5c6bc0\"] { stroke: color-mix(in srgb, #5c6bc0 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#7b1fa2\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#7b1fa2\"] { stroke: color-mix(in srgb, #7b1fa2 65%, var(--qdk-fg)); } .qdk-chemistry-iqpe-iteration text[fill=\"#ab47bc\"] { fill: var(--qdk-fg); } .qdk-chemistry-iqpe-iteration [stroke=\"#ab47bc\"] { stroke: color-mix(in srgb, #ab47bc 65%, var(--qdk-fg)); }</style> <g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(14.4 876.6)\"> <title>TutorialQpeIqpeIteration</title> <!-- Compute --> <g id=\"node1\" class=\"node\"> <title>Compute</title> <path fill=\"#e0f2f1\" stroke=\"#00796b\" stroke-width=\"2.5\" d=\"M247.2,-862.2C247.2,-862.2 12,-862.2 12,-862.2 6,-862.2 0,-856.2 0,-850.2 0,-850.2 0,-805.8 0,-805.8 0,-799.8 6,-793.8 12,-793.8 12,-793.8 247.2,-793.8 247.2,-793.8 253.2,-793.8 259.2,-799.8 259.2,-805.8 259.2,-805.8 259.2,-850.2 259.2,-850.2 259.2,-856.2 253.2,-862.2 247.2,-862.2\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"54.22\" y=\"-835.2\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#004d40\">Fresh compute register</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"54.97\" y=\"-810.05\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#004d40\">Prepare the trial state |Ψ<tspan baseline-shift=\"sub\" font-size=\"8.25\">trial</tspan>⟩</text> </g> <!-- Evolution --> <g id=\"node4\" class=\"node\"> <title>Evolution</title> <path fill=\"#e0f2f1\" stroke=\"#00796b\" stroke-width=\"2.5\" d=\"M424.6,-635.4C424.6,-635.4 88.6,-635.4 88.6,-635.4 82.6,-635.4 76.6,-629.4 76.6,-623.4 76.6,-623.4 76.6,-579 76.6,-579 76.6,-573 82.6,-567 88.6,-567 88.6,-567 424.6,-567 424.6,-567 430.6,-567 436.6,-573 436.6,-579 436.6,-579 436.6,-623.4 436.6,-623.4 436.6,-629.4 430.6,-635.4 424.6,-635.4\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"155.35\" y=\"-608.4\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#004d40\">Apply controlled time evolution</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"124.23\" y=\"-583.25\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#004d40\">Ancilla controls U^(2^(m−k−1)) on the compute register</text> </g> <!-- Compute&#45;&gt;Evolution --> <g id=\"edge2\" class=\"edge\"> <title>Compute&#45;&gt;Evolution</title> <path fill=\"none\" stroke=\"#00796b\" stroke-width=\"2.5\" d=\"M155,-792.56C155,-792.56 155,-649.17 155,-649.17\"/> <polygon fill=\"#00796b\" stroke=\"#00796b\" stroke-width=\"2.5\" points=\"158.15,-649.17 155,-640.17 151.85,-649.17 158.15,-649.17\"/> </g> <!-- Ancilla --> <g id=\"node2\" class=\"node\"> <title>Ancilla</title> <path fill=\"#e8eaf6\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M546.2,-862.2C546.2,-862.2 311,-862.2 311,-862.2 305,-862.2 299,-856.2 299,-850.2 299,-850.2 299,-805.8 299,-805.8 299,-799.8 305,-793.8 311,-793.8 311,-793.8 546.2,-793.8 546.2,-793.8 552.2,-793.8 558.2,-799.8 558.2,-805.8 558.2,-805.8 558.2,-850.2 558.2,-850.2 558.2,-856.2 552.2,-862.2 546.2,-862.2\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"343.85\" y=\"-835.2\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#283593\">Fresh readout ancilla |0⟩</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"378.35\" y=\"-810.05\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#283593\">Apply the first H gate</text> </g> <!-- Feedback --> <g id=\"node3\" class=\"node\"> <title>Feedback</title> <path fill=\"#e8eaf6\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M523.8,-748.8C523.8,-748.8 245.4,-748.8 245.4,-748.8 239.4,-748.8 233.4,-742.8 233.4,-736.8 233.4,-736.8 233.4,-692.4 233.4,-692.4 233.4,-686.4 239.4,-680.4 245.4,-680.4 245.4,-680.4 523.8,-680.4 523.8,-680.4 529.8,-680.4 535.8,-686.4 535.8,-692.4 535.8,-692.4 535.8,-736.8 535.8,-736.8 535.8,-742.8 529.8,-748.8 523.8,-748.8\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"313.35\" y=\"-721.8\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#283593\">Apply phase feedback</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"287.85\" y=\"-696.65\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#283593\">Use angle Φ<tspan baseline-shift=\"sub\" font-size=\"8.25\">k</tspan> from earlier measured bits</text> </g> <!-- Ancilla&#45;&gt;Feedback --> <g id=\"edge1\" class=\"edge\"> <title>Ancilla&#45;&gt;Feedback</title> <path fill=\"none\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M417.4,-792.74C417.4,-792.74 417.4,-762.62 417.4,-762.62\"/> <polygon fill=\"#5c6bc0\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" points=\"420.55,-762.62 417.4,-753.62 414.25,-762.62 420.55,-762.62\"/> </g> <!-- Feedback&#45;&gt;Evolution --> <g id=\"edge3\" class=\"edge\"> <title>Feedback&#45;&gt;Evolution</title> <path fill=\"none\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M335,-679.34C335,-679.34 335,-649.22 335,-649.22\"/> <polygon fill=\"#5c6bc0\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" points=\"338.15,-649.22 335,-640.22 331.85,-649.22 338.15,-649.22\"/> </g> <!-- Measure --> <g id=\"node5\" class=\"node\"> <title>Measure</title> <path fill=\"#e8eaf6\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M395.8,-522C395.8,-522 117.4,-522 117.4,-522 111.4,-522 105.4,-516 105.4,-510 105.4,-510 105.4,-465.6 105.4,-465.6 105.4,-459.6 111.4,-453.6 117.4,-453.6 117.4,-453.6 395.8,-453.6 395.8,-453.6 401.8,-453.6 407.8,-459.6 407.8,-465.6 407.8,-465.6 407.8,-510 407.8,-510 407.8,-516 401.8,-522 395.8,-522\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"152.35\" y=\"-495\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#283593\">Apply H and measure the ancilla</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"201.1\" y=\"-469.85\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#283593\">One shot returns 0 or 1</text> </g> <!-- Evolution&#45;&gt;Measure --> <g id=\"edge4\" class=\"edge\"> <title>Evolution&#45;&gt;Measure</title> <path fill=\"none\" stroke=\"#00796b\" stroke-width=\"2.5\" d=\"M256.6,-565.94C256.6,-565.94 256.6,-535.82 256.6,-535.82\"/> <polygon fill=\"#00796b\" stroke=\"#00796b\" stroke-width=\"2.5\" points=\"259.75,-535.82 256.6,-526.82 253.45,-535.82 259.75,-535.82\"/> </g> <!-- Shots --> <g id=\"node6\" class=\"node\"> <title>Shots</title> <path fill=\"#ffffff\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M417.4,-408.6C417.4,-408.6 95.8,-408.6 95.8,-408.6 89.8,-408.6 83.8,-402.6 83.8,-396.6 83.8,-396.6 83.8,-352.2 83.8,-352.2 83.8,-346.2 89.8,-340.2 95.8,-340.2 95.8,-340.2 417.4,-340.2 417.4,-340.2 423.4,-340.2 429.4,-346.2 429.4,-352.2 429.4,-352.2 429.4,-396.6 429.4,-396.6 429.4,-402.6 423.4,-408.6 417.4,-408.6\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"133.23\" y=\"-381.6\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#3949ab\">Repeat with freshly prepared registers</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"138.85\" y=\"-356.45\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#3949ab\">Collect an odd number of outcomes for iteration k</text> </g> <!-- Measure&#45;&gt;Shots --> <g id=\"edge5\" class=\"edge\"> <title>Measure&#45;&gt;Shots</title> <path fill=\"none\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" d=\"M256.6,-452.54C256.6,-452.54 256.6,-422.42 256.6,-422.42\"/> <polygon fill=\"#5c6bc0\" stroke=\"#5c6bc0\" stroke-width=\"2.5\" points=\"259.75,-422.42 256.6,-413.42 253.45,-422.42 259.75,-422.42\"/> </g> <!-- Majority --> <g id=\"node7\" class=\"node\"> <title>Majority</title> <path fill=\"#f3e5f5\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M395.8,-295.2C395.8,-295.2 117.4,-295.2 117.4,-295.2 111.4,-295.2 105.4,-289.2 105.4,-283.2 105.4,-283.2 105.4,-238.8 105.4,-238.8 105.4,-232.8 111.4,-226.8 117.4,-226.8 117.4,-226.8 395.8,-226.8 395.8,-226.8 401.8,-226.8 407.8,-232.8 407.8,-238.8 407.8,-238.8 407.8,-283.2 407.8,-283.2 407.8,-289.2 401.8,-295.2 395.8,-295.2\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"170.35\" y=\"-268.2\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#4a148c\">Majority vote selects bit b<tspan baseline-shift=\"sub\" font-size=\"10.50\">k</tspan></text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"182.35\" y=\"-243.05\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#4a148c\">Classical result for this iteration</text> </g> <!-- Shots&#45;&gt;Majority --> <g id=\"edge6\" class=\"edge\"> <title>Shots&#45;&gt;Majority</title> <path fill=\"none\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M256.6,-339.14C256.6,-339.14 256.6,-309.02 256.6,-309.02\"/> <polygon fill=\"#7b1fa2\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" points=\"259.75,-309.02 256.6,-300.02 253.45,-309.02 259.75,-309.02\"/> </g> <!-- Update --> <g id=\"node8\" class=\"node\"> <title>Update</title> <path fill=\"#f3e5f5\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M403,-181.8C403,-181.8 110.2,-181.8 110.2,-181.8 104.2,-181.8 98.2,-175.8 98.2,-169.8 98.2,-169.8 98.2,-125.4 98.2,-125.4 98.2,-119.4 104.2,-113.4 110.2,-113.4 110.2,-113.4 403,-113.4 403,-113.4 409,-113.4 415,-119.4 415,-125.4 415,-125.4 415,-169.8 415,-169.8 415,-175.8 409,-181.8 403,-181.8\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"141.1\" y=\"-154.8\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#4a148c\">Update the classical feedback angle</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"198.48\" y=\"-129.65\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#4a148c\">Use b<tspan baseline-shift=\"sub\" font-size=\"8.25\">k</tspan> to compute Φ<tspan baseline-shift=\"sub\" font-size=\"8.25\">k+1</tspan></text> </g> <!-- Majority&#45;&gt;Update --> <g id=\"edge7\" class=\"edge\"> <title>Majority&#45;&gt;Update</title> <path fill=\"none\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M256.6,-225.74C256.6,-225.74 256.6,-195.62 256.6,-195.62\"/> <polygon fill=\"#7b1fa2\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" points=\"259.75,-195.62 256.6,-186.62 253.45,-195.62 259.75,-195.62\"/> </g> <!-- Next --> <g id=\"node9\" class=\"node\"> <title>Next</title> <path fill=\"#ffffff\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M403,-68.4C403,-68.4 110.2,-68.4 110.2,-68.4 104.2,-68.4 98.2,-62.4 98.2,-56.4 98.2,-56.4 98.2,-12 98.2,-12 98.2,-6 104.2,0 110.2,0 110.2,0 403,0 403,0 409,0 415,-6 415,-12 415,-12 415,-56.4 415,-56.4 415,-62.4 409,-68.4 403,-68.4\"/> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"173.35\" y=\"-41.4\" font-family=\"Arial\" font-weight=\"bold\" font-size=\"14.00\" fill=\"#4a148c\">Continue to iteration k + 1</text> <text xml:space=\"preserve\" text-anchor=\"start\" x=\"155.35\" y=\"-16.25\" font-family=\"Arial\" font-size=\"11.00\" fill=\"#4a148c\">Build the next controlled power and repeat</text> </g> <!-- Update&#45;&gt;Next --> <g id=\"edge8\" class=\"edge\"> <title>Update&#45;&gt;Next</title> <path fill=\"none\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" d=\"M256.6,-112.34C256.6,-112.34 256.6,-82.22 256.6,-82.22\"/> <polygon fill=\"#7b1fa2\" stroke=\"#7b1fa2\" stroke-width=\"2.5\" points=\"259.75,-82.22 256.6,-73.22 253.45,-82.22 259.75,-82.22\"/> </g> </g> </svg>\n",
+    "\n",
+    "*One IQPE iteration estimates phase bit $b_k$. Every shot freshly prepares the trial state and readout ancilla; the majority outcome updates $\\Phi_{k+1}=\\Phi_k/2+\\pi b_k/2$ for the next controlled power.*\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "After all iterations, the feedback accumulator determines the final phase fraction.\n",
+    "\n",
+    "Each iteration circuit contains twelve compute qubits and one readout ancilla, for thirteen logical qubits in the simulated circuit.\n",
+    "The readout ancilla does not represent an additional molecular spin orbital."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-cba0532542e1",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Why is trial-state preparation included in every IQPE iteration circuit?",
+       "options": [
+        {
+         "id": "feedback-destroys",
+         "text": "The classical feedback rotation destroys the trial state each iteration.",
+         "correct": false,
+         "explanation": "The feedback rotation acts on the readout ancilla, not on the compute register holding the molecular state."
+        },
+        {
+         "id": "average-trotter",
+         "text": "Repeating it suppresses Trotter error by averaging over preparations.",
+         "correct": false,
+         "explanation": "State preparation is not the source of Trotter error, and repeating it does not reduce the error in the evolution unitary."
+        },
+        {
+         "id": "fresh-qubits",
+         "text": "Each phase bit is measured by a separate circuit, and every shot begins with newly allocated qubits in the all-zero state.",
+         "correct": true,
+         "explanation": "So the state-preparation logical circuit has to reload the trial state before each controlled evolution."
+        },
+        {
+         "id": "measurement-collapse",
+         "text": "Measuring the readout ancilla collapses the compute register, so the trial state has to be rebuilt.",
+         "correct": false,
+         "explanation": "Only the ancilla is measured. The register is gone anyway, but because each iteration is its own circuit starting from all zeros."
+        }
+       ],
+       "cellId": "iqpe-state-prep"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Why is trial-state preparation included in every IQPE iteration circuit?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The classical feedback rotation destroys the trial state each iteration.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Repeating it suppresses Trotter error by averaging over preparations.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Each phase bit is measured by a separate circuit, and every shot begins with newly allocated qubits in the all-zero state.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Measuring the readout ancilla collapses the compute register, so the trial state has to be rebuilt.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Why is trial-state preparation included in every IQPE iteration circuit?\n  ( ) The classical feedback rotation destroys the trial state each iteration.\n  ( ) Repeating it suppresses Trotter error by averaging over preparations.\n  ( ) Each phase bit is measured by a separate circuit, and every shot begins with newly allocated qubits in the all-zero state.\n  ( ) Measuring the readout ancilla collapses the compute register, so the trial state has to be rebuilt."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-state-prep\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c-e73a24c9ecf0",
+   "metadata": {},
+   "source": [
+    "The script configures the native iterative circuit builder and first-order Trotter unitary through nested `AlgorithmRef` objects:"
+   ]
   },
   {
    "cell_type": "code",
@@ -108,7 +408,97 @@
      "section:numerical-controls"
     ]
    },
-   "source": "## Numerical controls\n\nFive controls determine the approximation and sampling behavior of this workflow:\n\n- ***Evolution time***<br>\n  The value $t$ sets the signed energy interval and spacing of the phase grid, as described above.\n  Here it is tuned with the known classical reference to produce a $1\\ \\mathrm{m}E_{\\mathrm{h}}$ grid error.\n- **[Hamiltonian simulation ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/hamiltonian_unitary_builder.html)**<br>\n  The qubit Hamiltonian is a sum of Pauli terms that generally do not commute.\n  A first-order [Trotter product formula ↗](https://en.wikipedia.org/wiki/Lie_product_formula) approximates evolution under that sum by applying the exponential of each Pauli term in sequence.\n  For $\\hat H=\\sum_\\ell h_\\ell P_\\ell$, using $r$ Trotter divisions gives\n\n$$\ne^{-i\\hat Ht}\n\\approx\n\\left[\\prod_\\ell e^{-ih_\\ell P_\\ell t/r}\\right]^r.\n$$\n\n  One division ($r=1$) is used for each base evolution in this tutorial.\n  Increasing $r$ shortens each simulated time step and generally reduces product-formula error, but repeats the Pauli-term sequence more times and increases circuit cost.\n  The repeated-power strategy implemented by QDK/Chemistry constructs each controlled power $U^{2^{m-k-1}}$ by repeating that same approximate base unitary, preserving one consistent approximation across the IQPE iterations.\n- ***Phase bits***<br>\n  Six bits produce six iteration circuits and $2^6=64$ representable phase fractions.\n  Increasing this count refines the grid but causes the largest controlled power, circuit size, and simulator runtime to grow exponentially for the repeated-power strategy.\n- ***Shots per bit***<br>\n  Each iteration circuit is executed three times.\n  The odd shot count prevents a tied bit vote, but finite sampling can still select the less probable bit.\n- ***Complete runs***<br>\n  The full six-bit procedure is repeated twenty times with simulator seeds 42 through 61.\n  Each complete run returns one reconstructed bitstring and energy, and the final estimate uses the most frequent complete bitstring.\n\nThe default workflow therefore executes $6\\times3\\times20=360$ iteration-circuit shots.\nPhase-grid error, Trotter error, and sampling variation have different causes and should not be combined with basis-set or active-space model error.\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;Which control changes energy-grid spacing without changing the molecular Hamiltonian?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nThe number of phase bits changes how finely the phase interval is discretized.\nThe evolution time also rescales the grid in energy units, but it simultaneously changes the unaliased energy interval and the simulated evolution.\n\n</div>\n\n</details></div>"
+   "source": [
+    "## Numerical controls\n",
+    "\n",
+    "Five controls determine the approximation and sampling behavior of this workflow:\n",
+    "\n",
+    "- ***Evolution time***<br>\n",
+    "  The value $t$ sets the signed energy interval and spacing of the phase grid, as described above.\n",
+    "  Here it is tuned with the known classical reference to produce a $1\\ \\mathrm{m}E_{\\mathrm{h}}$ grid error.\n",
+    "- **[Hamiltonian simulation ↗](https://microsoft.github.io/qdk-chemistry/user/comprehensive/algorithms/hamiltonian_unitary_builder.html)**<br>\n",
+    "  The qubit Hamiltonian is a sum of Pauli terms that generally do not commute.\n",
+    "  A first-order [Trotter product formula ↗](https://en.wikipedia.org/wiki/Lie_product_formula) approximates evolution under that sum by applying the exponential of each Pauli term in sequence.\n",
+    "  For $\\hat H=\\sum_\\ell h_\\ell P_\\ell$, using $r$ Trotter divisions gives\n",
+    "\n",
+    "$$\n",
+    "e^{-i\\hat Ht}\n",
+    "\\approx\n",
+    "\\left[\\prod_\\ell e^{-ih_\\ell P_\\ell t/r}\\right]^r.\n",
+    "$$\n",
+    "\n",
+    "  One division ($r=1$) is used for each base evolution in this tutorial.\n",
+    "  Increasing $r$ shortens each simulated time step and generally reduces product-formula error, but repeats the Pauli-term sequence more times and increases circuit cost.\n",
+    "  The repeated-power strategy implemented by QDK/Chemistry constructs each controlled power $U^{2^{m-k-1}}$ by repeating that same approximate base unitary, preserving one consistent approximation across the IQPE iterations.\n",
+    "- ***Phase bits***<br>\n",
+    "  Six bits produce six iteration circuits and $2^6=64$ representable phase fractions.\n",
+    "  Increasing this count refines the grid but causes the largest controlled power, circuit size, and simulator runtime to grow exponentially for the repeated-power strategy.\n",
+    "- ***Shots per bit***<br>\n",
+    "  Each iteration circuit is executed three times.\n",
+    "  The odd shot count prevents a tied bit vote, but finite sampling can still select the less probable bit.\n",
+    "- ***Complete runs***<br>\n",
+    "  The full six-bit procedure is repeated twenty times with simulator seeds 42 through 61.\n",
+    "  Each complete run returns one reconstructed bitstring and energy, and the final estimate uses the most frequent complete bitstring.\n",
+    "\n",
+    "The default workflow therefore executes $6\\times3\\times20=360$ iteration-circuit shots.\n",
+    "Phase-grid error, Trotter error, and sampling variation have different causes and should not be combined with basis-set or active-space model error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-a57dfcb82b09",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Which controls change the spacing of the energy grid?",
+       "options": [
+        {
+         "id": "evolution-time",
+         "text": "The evolution time.",
+         "correct": true,
+         "explanation": "It rescales the grid in energy units — but unlike the bit count it also changes the unaliased interval and the simulated evolution, so it is the blunter of the two controls."
+        },
+        {
+         "id": "active-space",
+         "text": "The size of the active space.",
+         "correct": false,
+         "explanation": "That changes the Hamiltonian being measured, not how finely the phase is resolved."
+        },
+        {
+         "id": "phase-bits",
+         "text": "The number of phase bits.",
+         "correct": true,
+         "explanation": "It sets how finely the phase interval is discretized, and changes nothing else."
+        },
+        {
+         "id": "shots",
+         "text": "The number of shots per bit.",
+         "correct": false,
+         "explanation": "More shots make each bit majority more stable. Grid spacing is untouched."
+        }
+       ],
+       "multiSelect": true,
+       "cellId": "iqpe-grid-control"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Which controls change the spacing of the energy grid?</p><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:0 0 8px'>Select all that apply.</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> The evolution time.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> The size of the active space.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> The number of phase bits.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> The number of shots per bit.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Which controls change the spacing of the energy grid?\n  (select all that apply)\n  [ ] The evolution time.\n  [ ] The size of the active space.\n  [ ] The number of phase bits.\n  [ ] The number of shots per bit."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-grid-control\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -118,7 +508,126 @@
      "section:iqpe-circuit-visualization"
     ]
    },
-   "source": "## IQPE circuit visualization\n\nThe cells below build the six iteration circuits and render the shortest one. No quantum simulation runs here.\n\n<div style=\"text-align:center;\">\n\n<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"664\" height=\"864\" viewBox=\"0 0 664 864\" class=\"qdk-chemistry-power-one-circuit\" role=\"img\" data-asset=\"tutorial_qpe_power_one_circuit_overview.svg\" aria-label=\"Overview of the power-one IQPE circuit on thirteen wires. The top wire is the readout ancilla and receives an H gate, an Rz feedback rotation labeled zero, the controlled Pauli-evolution block, a final H gate, and measurement and reset. The remaining twelve wires form the compute register. State-preparation blocks act on the compute wires that require preparation operations, the controlled Pauli-evolution block spans the ancilla and compute register, and reset operations return the compute wires to zero after evolution.\" style=\"max-width:100%;height:auto\"> <style> .qdk-chemistry-power-one-circuit { --qdk-host-foreground: var(--vscode-editor-foreground, var(--jp-widgets-color, currentColor)); --circuit-fg: var(--qdk-host-foreground); --circuit-bg: var(--vscode-editor-background, var(--jp-layout-color0, Canvas)); --unitary-fill: var(--vscode-editor-background, var(--jp-layout-color0, Canvas)); --unitary-text: var(--qdk-host-foreground); --measure-fill: #0067b8; --measure-text: #ffffff; --ket-fill: #0067b8; --ket-text: #ffffff; } .qdk-chemistry-power-one-circuit line, .qdk-chemistry-power-one-circuit circle, .qdk-chemistry-power-one-circuit rect { stroke: var(--circuit-fg); stroke-width: 1; } .qdk-chemistry-power-one-circuit text { fill: var(--circuit-fg); dominant-baseline: middle; text-anchor: middle; font-family: \"Segoe UI\", Arial, sans-serif; } .qdk-chemistry-power-one-circuit .qs-mathtext { font-family: \"Cambria Math\", \"STIX Two Math\", serif; font-style: italic; } .qdk-chemistry-power-one-circuit .gate .qs-group-label { fill: var(--circuit-fg); text-anchor: start; } .qdk-chemistry-power-one-circuit .gate-unitary { fill: var(--unitary-fill); } .qdk-chemistry-power-one-circuit .gate text { fill: var(--unitary-text); } .qdk-chemistry-power-one-circuit .control-line, .qdk-chemistry-power-one-circuit .control-dot { fill: var(--circuit-fg); } .qdk-chemistry-power-one-circuit .oplus > line, .qdk-chemistry-power-one-circuit .oplus > circle { fill: var(--circuit-bg); stroke: var(--circuit-fg); stroke-width: 2; } .qdk-chemistry-power-one-circuit .gate-measure { fill: var(--measure-fill); } .qdk-chemistry-power-one-circuit .qs-line-measure, .qdk-chemistry-power-one-circuit .arc-measure { stroke: var(--measure-text); fill: none; } .qdk-chemistry-power-one-circuit .gate-ket { fill: var(--ket-fill); } .qdk-chemistry-power-one-circuit text.ket-text { fill: var(--ket-text); stroke: none; } .qdk-chemistry-power-one-circuit .register-classical { stroke-width: 0.5; } .qdk-chemistry-power-one-circuit .gate-collapse, .qdk-chemistry-power-one-circuit .gate-expand, .qdk-chemistry-power-one-circuit .dropzone-layer { display: none; } .qdk-chemistry-power-one-circuit .gate-unitary:not([stroke-dasharray]) { fill: var(--unitary-fill); fill-opacity: 1; } .qdk-chemistry-power-one-circuit .gate-unitary[stroke-dasharray] { fill: none; fill-opacity: 0; }</style> <g class=\"qubit-input-states\"><text font-size=\"16\" x=\"20\" y=\"118\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"0\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">0</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"222\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"1\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">1</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"274\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"2\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">2</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"326\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"3\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">3</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"378\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"4\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">4</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"430\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"5\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">5</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"482\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"6\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">6</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"534\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"7\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">7</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"586\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"8\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">8</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"638\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"9\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">9</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"690\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"10\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">10</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"742\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"11\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">11</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"794\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"12\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">12</tspan>⟩</text></g><g class=\"wires\"><line x1=\"40\" x2=\"664\" y1=\"118\" y2=\"118\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"222\" y2=\"222\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"274\" y2=\"274\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"326\" y2=\"326\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"378\" y2=\"378\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"430\" y2=\"430\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"482\" y2=\"482\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"534\" y2=\"534\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"586\" y2=\"586\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"638\" y2=\"638\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"690\" y2=\"690\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"742\" y2=\"742\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"794\" y2=\"794\" class=\"qubit-wire\"></line><g><line x1=\"555\" x2=\"555\" y1=\"118\" y2=\"169\" class=\"register-classical\"></line><line x1=\"553\" x2=\"553\" y1=\"118\" y2=\"171\" class=\"register-classical\"></line><line x1=\"555\" x2=\"664\" y1=\"169\" y2=\"169\" class=\"register-classical\"></line><line x1=\"553\" x2=\"664\" y1=\"171\" y2=\"171\" class=\"register-classical\"></line></g></g><g><g class=\"gate\" data-location=\"0,0\" data-expanded=\"true\"><rect class=\"gate-unitary\" x=\"80\" y=\"46\" width=\"566\" height=\"788\" fill-opacity=\"0\" stroke-dasharray=\"8, 8\"></rect><g><g class=\"gate\" data-location=\"0,0-0,0\" data-expanded=\"true\"><rect class=\"gate-unitary\" x=\"90\" y=\"72\" width=\"546\" height=\"752\" fill-opacity=\"0\" stroke-dasharray=\"8, 8\"></rect><g><g class=\"gate\" data-location=\"0,0-0,0-0,0\"><g><line x1=\"165.5\" x2=\"165.5\" y1=\"222\" y2=\"742\" stroke-dasharray=\"8, 8\"></line><g><rect class=\"gate-unitary\" x=\"100\" y=\"202\" width=\"131\" height=\"248\" data-wire-ys=\"[222,274,326,378,430]\" data-width=\"131\"></rect><text font-size=\"14\" x=\"165.5\" y=\"326\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">StatePreparation</tspan></text></g><g><rect class=\"gate-unitary\" x=\"100\" y=\"514\" width=\"131\" height=\"248\" data-wire-ys=\"[534,586,638,690,742]\" data-width=\"131\"></rect><text font-size=\"14\" x=\"165.5\" y=\"638\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">StatePreparation</tspan></text></g></g><g class=\"gate-control gate-expand\"><circle cx=\"102\" cy=\"204\" r=\"10\"></circle><path d=\"M102,197 v14 M95,204 h14\"></path></g></g><g class=\"gate\" data-location=\"0,0-0,0-0,1\"><g><g><rect class=\"gate-unitary\" x=\"145.5\" y=\"98\" width=\"40\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"165.5\" y=\"118\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">H</tspan></text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-1,0\"><g><g><rect class=\"gate-unitary\" x=\"243\" y=\"98\" width=\"56\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"56\"></rect><text font-size=\"14\" x=\"271\" y=\"111\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">Rz</tspan></text><text font-size=\"12\" x=\"271\" y=\"126\" class=\"arg-button\">0.0000</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-2,0\"><g><g><rect class=\"gate-unitary\" x=\"311\" y=\"98\" width=\"159\" height=\"716\" data-wire-ys=\"[118,222,274,326,378,430,482,534,586,638,690,742,794]\" data-width=\"159\"></rect><text font-size=\"14\" x=\"390.5\" y=\"456\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">RepControlledPauliExp</tspan></text></g></g><g class=\"gate-control gate-expand\"><circle cx=\"313\" cy=\"100\" r=\"10\"></circle><path d=\"M313,93 v14 M306,100 h14\"></path></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,0\"><g><g><rect class=\"gate-unitary\" x=\"482\" y=\"98\" width=\"40\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"118\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">H</tspan></text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,1\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"202\" width=\"40\" height=\"40\" data-wire-ys=\"[222]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"222\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,2\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"254\" width=\"40\" height=\"40\" data-wire-ys=\"[274]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"274\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,3\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"306\" width=\"40\" height=\"40\" data-wire-ys=\"[326]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"326\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,4\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"358\" width=\"40\" height=\"40\" data-wire-ys=\"[378]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"378\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,5\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"410\" width=\"40\" height=\"40\" data-wire-ys=\"[430]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"430\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,6\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"462\" width=\"40\" height=\"40\" data-wire-ys=\"[482]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"482\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,7\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"514\" width=\"40\" height=\"40\" data-wire-ys=\"[534]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"534\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,8\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"566\" width=\"40\" height=\"40\" data-wire-ys=\"[586]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"586\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,9\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"618\" width=\"40\" height=\"40\" data-wire-ys=\"[638]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"638\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,10\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"670\" width=\"40\" height=\"40\" data-wire-ys=\"[690]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"690\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,11\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"722\" width=\"40\" height=\"40\" data-wire-ys=\"[742]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"742\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,12\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"774\" width=\"40\" height=\"40\" data-wire-ys=\"[794]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"794\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-4,0\"><g><rect class=\"gate-measure\" x=\"534\" y=\"98\" width=\"40\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"40\"></rect><path class=\"arc-measure\" d=\"M 569 120 A 15 12 0 0 0 539 120\" style=\"pointer-events: none;\"></path><line x1=\"554\" x2=\"566\" y1=\"126\" y2=\"106\" class=\"qs-line-measure\" style=\"pointer-events: none;\"></line></g></g><g class=\"gate\" data-location=\"0,0-0,0-5,0\"><g><g><rect class=\"gate-ket\" x=\"586\" y=\"98\" width=\"40\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"606\" y=\"118\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g></g><text font-size=\"14\" x=\"100\" y=\"87\" class=\"qs-maintext qs-group-label\"><tspan class=\"qs-mathtext\">RunIQPE</tspan></text><g class=\"gate-control gate-collapse\"><circle cx=\"92\" cy=\"74\" r=\"10\"></circle><path d=\"M85,74 h14\"></path></g></g></g><text font-size=\"14\" x=\"90\" y=\"61\" class=\"qs-maintext qs-group-label\"><tspan class=\"qs-mathtext\">MakeIQPECircuit</tspan></text><g class=\"gate-control gate-collapse\"><circle cx=\"82\" cy=\"48\" r=\"10\"></circle><path d=\"M75,48 h14\"></path></g></g></g> </svg>\n\n*Overview of the rendered power-one iteration circuit. Dashed outlines mark the nested `MakeIQPECircuit` and `RunIQPE` Q# operations; the solid boxes show their principal composite operations.*\n\n</div>\n\nThe top wire, $\\lvert\\psi_0\\rangle$, is readout ancilla q0.\nIts first H gate creates a superposition, and the `Rz(0.0000)` block applies the phase-feedback rotation.\nThis static preview constructs all six circuits with the builder's initial feedback angle of zero, so the displayed rotation is zero.\nDuring an actual IQPE run, each iteration circuit is rebuilt using the accumulated feedback from earlier measured bits; the power-one iteration can therefore have a nonzero feedback rotation.\n\nThe lower wires, $\\lvert\\psi_1\\rangle$ through $\\lvert\\psi_{12}\\rangle$, are compute-register qubits q1–q12.\nThe `StatePreparation` blocks load the four-determinant trial state on the subsets of compute wires that require preparation operations; blank wires remain part of the compute register.\nThe `RepControlledPauliExp` block is the power-one controlled first-order Trotter evolution.\nThe ancilla controls this block, and the resulting phase kickback places the Hamiltonian eigenphase on the ancilla's relative phase.\nThe final H gate converts that relative phase into measurement probabilities, the measurement produces one shot outcome, and the blue reset operations return the allocated qubits to $\\lvert0\\rangle$.\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;How can you identify the readout ancilla in the rendered circuit?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nThe q0 wire receives the H gates and feedback rotation, controls the Hamiltonian evolution, and is measured to obtain the phase bit.\nThe other twelve wires hold the prepared molecular state and form the compute register.\n\n</div>\n\n</details></div>\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;Why do all six iteration circuits have the same width but different lengths?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nEvery iteration uses the same twelve-qubit compute register and one readout ancilla, so each circuit has thirteen logical qubits.\nDifferent controlled powers repeat the approximate time-evolution unitary different numbers of times, changing the logical gate count rather than the register size.\n\n</div>\n\n</details></div>"
+   "source": [
+    "## IQPE circuit visualization\n",
+    "\n",
+    "The cells below build the six iteration circuits and render the shortest one. No quantum simulation runs here.\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "\n",
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"664\" height=\"864\" viewBox=\"0 0 664 864\" class=\"qdk-chemistry-power-one-circuit\" role=\"img\" data-asset=\"tutorial_qpe_power_one_circuit_overview.svg\" aria-label=\"Overview of the power-one IQPE circuit on thirteen wires. The top wire is the readout ancilla and receives an H gate, an Rz feedback rotation labeled zero, the controlled Pauli-evolution block, a final H gate, and measurement and reset. The remaining twelve wires form the compute register. State-preparation blocks act on the compute wires that require preparation operations, the controlled Pauli-evolution block spans the ancilla and compute register, and reset operations return the compute wires to zero after evolution.\" style=\"max-width:100%;height:auto\"> <style> .qdk-chemistry-power-one-circuit { --qdk-host-foreground: var(--vscode-editor-foreground, var(--jp-widgets-color, currentColor)); --circuit-fg: var(--qdk-host-foreground); --circuit-bg: var(--vscode-editor-background, var(--jp-layout-color0, Canvas)); --unitary-fill: var(--vscode-editor-background, var(--jp-layout-color0, Canvas)); --unitary-text: var(--qdk-host-foreground); --measure-fill: #0067b8; --measure-text: #ffffff; --ket-fill: #0067b8; --ket-text: #ffffff; } .qdk-chemistry-power-one-circuit line, .qdk-chemistry-power-one-circuit circle, .qdk-chemistry-power-one-circuit rect { stroke: var(--circuit-fg); stroke-width: 1; } .qdk-chemistry-power-one-circuit text { fill: var(--circuit-fg); dominant-baseline: middle; text-anchor: middle; font-family: \"Segoe UI\", Arial, sans-serif; } .qdk-chemistry-power-one-circuit .qs-mathtext { font-family: \"Cambria Math\", \"STIX Two Math\", serif; font-style: italic; } .qdk-chemistry-power-one-circuit .gate .qs-group-label { fill: var(--circuit-fg); text-anchor: start; } .qdk-chemistry-power-one-circuit .gate-unitary { fill: var(--unitary-fill); } .qdk-chemistry-power-one-circuit .gate text { fill: var(--unitary-text); } .qdk-chemistry-power-one-circuit .control-line, .qdk-chemistry-power-one-circuit .control-dot { fill: var(--circuit-fg); } .qdk-chemistry-power-one-circuit .oplus > line, .qdk-chemistry-power-one-circuit .oplus > circle { fill: var(--circuit-bg); stroke: var(--circuit-fg); stroke-width: 2; } .qdk-chemistry-power-one-circuit .gate-measure { fill: var(--measure-fill); } .qdk-chemistry-power-one-circuit .qs-line-measure, .qdk-chemistry-power-one-circuit .arc-measure { stroke: var(--measure-text); fill: none; } .qdk-chemistry-power-one-circuit .gate-ket { fill: var(--ket-fill); } .qdk-chemistry-power-one-circuit text.ket-text { fill: var(--ket-text); stroke: none; } .qdk-chemistry-power-one-circuit .register-classical { stroke-width: 0.5; } .qdk-chemistry-power-one-circuit .gate-collapse, .qdk-chemistry-power-one-circuit .gate-expand, .qdk-chemistry-power-one-circuit .dropzone-layer { display: none; } .qdk-chemistry-power-one-circuit .gate-unitary:not([stroke-dasharray]) { fill: var(--unitary-fill); fill-opacity: 1; } .qdk-chemistry-power-one-circuit .gate-unitary[stroke-dasharray] { fill: none; fill-opacity: 0; }</style> <g class=\"qubit-input-states\"><text font-size=\"16\" x=\"20\" y=\"118\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"0\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">0</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"222\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"1\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">1</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"274\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"2\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">2</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"326\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"3\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">3</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"378\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"4\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">4</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"430\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"5\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">5</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"482\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"6\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">6</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"534\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"7\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">7</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"586\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"8\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">8</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"638\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"9\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">9</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"690\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"10\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">10</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"742\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"11\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">11</tspan>⟩</text><text font-size=\"16\" x=\"20\" y=\"794\" text-anchor=\"start\" dominant-baseline=\"middle\" data-wire=\"12\" class=\"qs-maintext qs-qubit-label\">|<tspan class=\"qs-mathtext\">ψ</tspan><tspan baseline-shift=\"sub\" font-size=\"65%\">12</tspan>⟩</text></g><g class=\"wires\"><line x1=\"40\" x2=\"664\" y1=\"118\" y2=\"118\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"222\" y2=\"222\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"274\" y2=\"274\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"326\" y2=\"326\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"378\" y2=\"378\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"430\" y2=\"430\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"482\" y2=\"482\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"534\" y2=\"534\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"586\" y2=\"586\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"638\" y2=\"638\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"690\" y2=\"690\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"742\" y2=\"742\" class=\"qubit-wire\"></line><line x1=\"40\" x2=\"664\" y1=\"794\" y2=\"794\" class=\"qubit-wire\"></line><g><line x1=\"555\" x2=\"555\" y1=\"118\" y2=\"169\" class=\"register-classical\"></line><line x1=\"553\" x2=\"553\" y1=\"118\" y2=\"171\" class=\"register-classical\"></line><line x1=\"555\" x2=\"664\" y1=\"169\" y2=\"169\" class=\"register-classical\"></line><line x1=\"553\" x2=\"664\" y1=\"171\" y2=\"171\" class=\"register-classical\"></line></g></g><g><g class=\"gate\" data-location=\"0,0\" data-expanded=\"true\"><rect class=\"gate-unitary\" x=\"80\" y=\"46\" width=\"566\" height=\"788\" fill-opacity=\"0\" stroke-dasharray=\"8, 8\"></rect><g><g class=\"gate\" data-location=\"0,0-0,0\" data-expanded=\"true\"><rect class=\"gate-unitary\" x=\"90\" y=\"72\" width=\"546\" height=\"752\" fill-opacity=\"0\" stroke-dasharray=\"8, 8\"></rect><g><g class=\"gate\" data-location=\"0,0-0,0-0,0\"><g><line x1=\"165.5\" x2=\"165.5\" y1=\"222\" y2=\"742\" stroke-dasharray=\"8, 8\"></line><g><rect class=\"gate-unitary\" x=\"100\" y=\"202\" width=\"131\" height=\"248\" data-wire-ys=\"[222,274,326,378,430]\" data-width=\"131\"></rect><text font-size=\"14\" x=\"165.5\" y=\"326\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">StatePreparation</tspan></text></g><g><rect class=\"gate-unitary\" x=\"100\" y=\"514\" width=\"131\" height=\"248\" data-wire-ys=\"[534,586,638,690,742]\" data-width=\"131\"></rect><text font-size=\"14\" x=\"165.5\" y=\"638\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">StatePreparation</tspan></text></g></g><g class=\"gate-control gate-expand\"><circle cx=\"102\" cy=\"204\" r=\"10\"></circle><path d=\"M102,197 v14 M95,204 h14\"></path></g></g><g class=\"gate\" data-location=\"0,0-0,0-0,1\"><g><g><rect class=\"gate-unitary\" x=\"145.5\" y=\"98\" width=\"40\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"165.5\" y=\"118\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">H</tspan></text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-1,0\"><g><g><rect class=\"gate-unitary\" x=\"243\" y=\"98\" width=\"56\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"56\"></rect><text font-size=\"14\" x=\"271\" y=\"111\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">Rz</tspan></text><text font-size=\"12\" x=\"271\" y=\"126\" class=\"arg-button\">0.0000</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-2,0\"><g><g><rect class=\"gate-unitary\" x=\"311\" y=\"98\" width=\"159\" height=\"716\" data-wire-ys=\"[118,222,274,326,378,430,482,534,586,638,690,742,794]\" data-width=\"159\"></rect><text font-size=\"14\" x=\"390.5\" y=\"456\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">RepControlledPauliExp</tspan></text></g></g><g class=\"gate-control gate-expand\"><circle cx=\"313\" cy=\"100\" r=\"10\"></circle><path d=\"M313,93 v14 M306,100 h14\"></path></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,0\"><g><g><rect class=\"gate-unitary\" x=\"482\" y=\"98\" width=\"40\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"118\" class=\"qs-maintext\"><tspan class=\"qs-mathtext\">H</tspan></text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,1\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"202\" width=\"40\" height=\"40\" data-wire-ys=\"[222]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"222\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,2\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"254\" width=\"40\" height=\"40\" data-wire-ys=\"[274]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"274\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,3\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"306\" width=\"40\" height=\"40\" data-wire-ys=\"[326]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"326\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,4\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"358\" width=\"40\" height=\"40\" data-wire-ys=\"[378]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"378\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,5\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"410\" width=\"40\" height=\"40\" data-wire-ys=\"[430]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"430\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,6\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"462\" width=\"40\" height=\"40\" data-wire-ys=\"[482]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"482\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,7\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"514\" width=\"40\" height=\"40\" data-wire-ys=\"[534]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"534\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,8\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"566\" width=\"40\" height=\"40\" data-wire-ys=\"[586]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"586\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,9\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"618\" width=\"40\" height=\"40\" data-wire-ys=\"[638]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"638\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,10\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"670\" width=\"40\" height=\"40\" data-wire-ys=\"[690]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"690\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,11\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"722\" width=\"40\" height=\"40\" data-wire-ys=\"[742]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"742\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-3,12\"><g><g><rect class=\"gate-ket\" x=\"482\" y=\"774\" width=\"40\" height=\"40\" data-wire-ys=\"[794]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"502\" y=\"794\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g><g class=\"gate\" data-location=\"0,0-0,0-4,0\"><g><rect class=\"gate-measure\" x=\"534\" y=\"98\" width=\"40\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"40\"></rect><path class=\"arc-measure\" d=\"M 569 120 A 15 12 0 0 0 539 120\" style=\"pointer-events: none;\"></path><line x1=\"554\" x2=\"566\" y1=\"126\" y2=\"106\" class=\"qs-line-measure\" style=\"pointer-events: none;\"></line></g></g><g class=\"gate\" data-location=\"0,0-0,0-5,0\"><g><g><rect class=\"gate-ket\" x=\"586\" y=\"98\" width=\"40\" height=\"40\" data-wire-ys=\"[118]\" data-width=\"40\"></rect><text font-size=\"14\" x=\"606\" y=\"118\" class=\"qs-maintext ket-text\">|0⟩</text></g></g></g></g><text font-size=\"14\" x=\"100\" y=\"87\" class=\"qs-maintext qs-group-label\"><tspan class=\"qs-mathtext\">RunIQPE</tspan></text><g class=\"gate-control gate-collapse\"><circle cx=\"92\" cy=\"74\" r=\"10\"></circle><path d=\"M85,74 h14\"></path></g></g></g><text font-size=\"14\" x=\"90\" y=\"61\" class=\"qs-maintext qs-group-label\"><tspan class=\"qs-mathtext\">MakeIQPECircuit</tspan></text><g class=\"gate-control gate-collapse\"><circle cx=\"82\" cy=\"48\" r=\"10\"></circle><path d=\"M75,48 h14\"></path></g></g></g> </svg>\n",
+    "\n",
+    "*Overview of the rendered power-one iteration circuit. Dashed outlines mark the nested `MakeIQPECircuit` and `RunIQPE` Q# operations; the solid boxes show their principal composite operations.*\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "The top wire, $\\lvert\\psi_0\\rangle$, is readout ancilla q0.\n",
+    "Its first H gate creates a superposition, and the `Rz(0.0000)` block applies the phase-feedback rotation.\n",
+    "This static preview constructs all six circuits with the builder's initial feedback angle of zero, so the displayed rotation is zero.\n",
+    "During an actual IQPE run, each iteration circuit is rebuilt using the accumulated feedback from earlier measured bits; the power-one iteration can therefore have a nonzero feedback rotation.\n",
+    "\n",
+    "The lower wires, $\\lvert\\psi_1\\rangle$ through $\\lvert\\psi_{12}\\rangle$, are compute-register qubits q1–q12.\n",
+    "The `StatePreparation` blocks load the four-determinant trial state on the subsets of compute wires that require preparation operations; blank wires remain part of the compute register.\n",
+    "The `RepControlledPauliExp` block is the power-one controlled first-order Trotter evolution.\n",
+    "The ancilla controls this block, and the resulting phase kickback places the Hamiltonian eigenphase on the ancilla's relative phase.\n",
+    "The final H gate converts that relative phase into measurement probabilities, the measurement produces one shot outcome, and the blue reset operations return the allocated qubits to $\\lvert0\\rangle$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-f098b11065e1",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Which of these are true of the readout ancilla in the rendered circuit?",
+       "options": [
+        {
+         "id": "controls",
+         "text": "It controls the Hamiltonian evolution.",
+         "correct": true,
+         "explanation": "The controlled-unitary hangs off this wire, which is how the phase is kicked back onto it."
+        },
+        {
+         "id": "measured",
+         "text": "It is measured to obtain the phase bit.",
+         "correct": true,
+         "explanation": "One measurement per iteration, and that bit feeds the next one."
+        },
+        {
+         "id": "h-gates",
+         "text": "It receives the H gates and the feedback rotation.",
+         "correct": true,
+         "explanation": "That pair is what puts it in superposition and applies the phase learned from earlier iterations."
+        },
+        {
+         "id": "molecular-state",
+         "text": "It holds the prepared molecular state.",
+         "correct": false,
+         "explanation": "The other twelve wires do that — they are the compute register. The ancilla is algorithm workspace."
+        }
+       ],
+       "multiSelect": true,
+       "cellId": "iqpe-readout-ancilla"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Which of these are true of the readout ancilla in the rendered circuit?</p><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:0 0 8px'>Select all that apply.</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> It controls the Hamiltonian evolution.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> It is measured to obtain the phase bit.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> It receives the H gates and the feedback rotation.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> It holds the prepared molecular state.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Which of these are true of the readout ancilla in the rendered circuit?\n  (select all that apply)\n  [ ] It controls the Hamiltonian evolution.\n  [ ] It is measured to obtain the phase bit.\n  [ ] It receives the H gates and the feedback rotation.\n  [ ] It holds the prepared molecular state."
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Why do all six iteration circuits have the same width but different lengths?",
+       "options": [
+        {
+         "id": "growing-space",
+         "text": "The Trotter step count grows with the active-space size across iterations.",
+         "correct": false,
+         "explanation": "The active space is fixed for the whole run. What varies between iterations is the controlled power."
+        },
+        {
+         "id": "feedback-ancilla",
+         "text": "Each iteration adds another ancilla to carry the feedback.",
+         "correct": false,
+         "explanation": "The feedback is classical. It changes a rotation angle, not the number of qubits."
+        },
+        {
+         "id": "power-varies",
+         "text": "Every iteration uses the same twelve-qubit compute register and one readout ancilla, while different controlled powers repeat the evolution unitary different numbers of times.",
+         "correct": true,
+         "explanation": "Width is register size, thirteen logical qubits every time. Length is logical gate count, which the controlled power sets."
+        },
+        {
+         "id": "more-qubits",
+         "text": "Later iterations act on more qubits, because they resolve more significant bits.",
+         "correct": false,
+         "explanation": "The register is fixed at thirteen qubits. Resolving a different bit changes the controlled power, not the width."
+        }
+       ],
+       "cellId": "iqpe-circuit-shape"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Why do all six iteration circuits have the same width but different lengths?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The Trotter step count grows with the active-space size across iterations.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Each iteration adds another ancilla to carry the feedback.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Every iteration uses the same twelve-qubit compute register and one readout ancilla, while different controlled powers repeat the evolution unitary different numbers of times.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Later iterations act on more qubits, because they resolve more significant bits.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Why do all six iteration circuits have the same width but different lengths?\n  ( ) The Trotter step count grows with the active-space size across iterations.\n  ( ) Each iteration adds another ancilla to carry the feedback.\n  ( ) Every iteration uses the same twelve-qubit compute register and one readout ancilla, while different controlled powers repeat the evolution unitary different numbers of times.\n  ( ) Later iterations act on more qubits, because they resolve more significant bits."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-readout-ancilla\", \"iqpe-circuit-shape\")\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -232,7 +741,64 @@
    "cell_type": "markdown",
    "id": "c-57097058fd45",
    "metadata": {},
-   "source": "Each iteration contributes one measured phase bit to the complete IQPE result.\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;How does IQPE use the result from each iteration to construct the final bitstring and phase fraction?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nThe majority measurement for one iteration selects a phase bit, which updates the classical phase feedback used by the next iteration.\nAfter all six iterations, the feedback calculation combines the measured bits into one phase fraction.\nThe script writes that fraction as a conventional six-bit string, with the most significant bit first.\n\n</div>\n\n</details></div>"
+   "source": [
+    "Each iteration contributes one measured phase bit to the complete IQPE result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-1ea05946cab6",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "How does IQPE turn the result of each iteration into the final bitstring and phase fraction?",
+       "options": [
+        {
+         "id": "feedback-chain",
+         "text": "The majority measurement for each iteration selects a phase bit, which updates the classical phase feedback used by the next iteration; after six iterations the feedback calculation combines the bits into one fraction.",
+         "correct": true,
+         "explanation": "The script writes that fraction as a conventional six-bit string, with the most significant bit first."
+        },
+        {
+         "id": "average-estimates",
+         "text": "The phase fraction is the average of the six per-iteration phase estimates.",
+         "correct": false,
+         "explanation": "Each iteration yields a single bit, not a phase estimate. Averaging them would throw away each bit's place value."
+        },
+        {
+         "id": "independent-bits",
+         "text": "The bits are independent, so they can be measured in any order and concatenated.",
+         "correct": false,
+         "explanation": "They are not independent. Each measured bit updates the phase feedback for the next iteration, so the order is fixed."
+        },
+        {
+         "id": "one-circuit",
+         "text": "All six bits are measured together in a single circuit and read off at the end.",
+         "correct": false,
+         "explanation": "That is textbook QPE. The iterative variant deliberately measures one bit per circuit, which is what keeps the register small."
+        }
+       ],
+       "cellId": "iqpe-bit-feedback"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>How does IQPE turn the result of each iteration into the final bitstring and phase fraction?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The majority measurement for each iteration selects a phase bit, which updates the classical phase feedback used by the next iteration; after six iterations the feedback calculation combines the bits into one fraction.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The phase fraction is the average of the six per-iteration phase estimates.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The bits are independent, so they can be measured in any order and concatenated.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> All six bits are measured together in a single circuit and read off at the end.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: How does IQPE turn the result of each iteration into the final bitstring and phase fraction?\n  ( ) The majority measurement for each iteration selects a phase bit, which updates the classical phase feedback used by the next iteration; after six iterations the feedback calculation combines the bits into one fraction.\n  ( ) The phase fraction is the average of the six per-iteration phase estimates.\n  ( ) The bits are independent, so they can be measured in any order and concatenated.\n  ( ) All six bits are measured together in a single circuit and read off at the end."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-bit-feedback\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -242,7 +808,71 @@
      "section:repeated-complete-runs"
     ]
    },
-   "source": "## Repeated complete runs\n\nOne complete run can differ from another because every phase bit is selected from a finite number of simulator shots and the trial state contains several Hamiltonian eigenstates.\nThe workflow therefore repeats the complete six-bit procedure with twenty deterministic simulator seeds.\n\nThe final aggregation rule selects the most frequent complete bitstring, or *mode*.\nThis differs from the majority vote used inside one complete run: a per-bit majority chooses one bit from three shots, whereas the complete-run mode chooses one reconstructed bitstring from twenty runs.\nIf several bitstrings tie for the highest count, the script reports that no unique mode exists instead of silently choosing one.\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;Why should the final aggregation use complete bitstrings rather than vote on each bit across complete runs?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nEach complete bitstring represents one phase-grid point and its corresponding energy.\nVoting independently on bits could assemble a bitstring that was never produced by any complete run and would discard the observed joint distribution.\n\n</div>\n\n</details></div>"
+   "source": [
+    "## Repeated complete runs\n",
+    "\n",
+    "One complete run can differ from another because every phase bit is selected from a finite number of simulator shots and the trial state contains several Hamiltonian eigenstates.\n",
+    "The workflow therefore repeats the complete six-bit procedure with twenty deterministic simulator seeds.\n",
+    "\n",
+    "The final aggregation rule selects the most frequent complete bitstring, or *mode*.\n",
+    "This differs from the majority vote used inside one complete run: a per-bit majority chooses one bit from three shots, whereas the complete-run mode chooses one reconstructed bitstring from twenty runs.\n",
+    "If several bitstrings tie for the highest count, the script reports that no unique mode exists instead of silently choosing one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-dd3abe6d02e9",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Why should the final aggregation use complete bitstrings rather than vote on each bit across complete runs?",
+       "options": [
+        {
+         "id": "msb-bias",
+         "text": "Per-bit voting would bias the result toward the most significant bit.",
+         "correct": false,
+         "explanation": "The problem is not bias toward one bit. It is that the assembled string may correspond to no observed run at all."
+        },
+        {
+         "id": "joint",
+         "text": "Each complete bitstring is one phase-grid point with a corresponding energy, and voting per bit could assemble a bitstring that no run ever produced.",
+         "correct": true,
+         "explanation": "Voting bit by bit also discards the joint distribution that was actually observed."
+        },
+        {
+         "id": "simultaneous",
+         "text": "Complete bitstrings are required because the bits are measured simultaneously.",
+         "correct": false,
+         "explanation": "They are measured one per iteration. The reason is that a bitstring is only meaningful as a whole grid point."
+        },
+        {
+         "id": "slower",
+         "text": "Per-bit voting gives the same answer but takes longer to compute.",
+         "correct": false,
+         "explanation": "It does not give the same answer: it can synthesize a result that never occurred in any run."
+        }
+       ],
+       "cellId": "iqpe-aggregation"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Why should the final aggregation use complete bitstrings rather than vote on each bit across complete runs?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Per-bit voting would bias the result toward the most significant bit.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Each complete bitstring is one phase-grid point with a corresponding energy, and voting per bit could assemble a bitstring that no run ever produced.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Complete bitstrings are required because the bits are measured simultaneously.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Per-bit voting gives the same answer but takes longer to compute.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Why should the final aggregation use complete bitstrings rather than vote on each bit across complete runs?\n  ( ) Per-bit voting would bias the result toward the most significant bit.\n  ( ) Each complete bitstring is one phase-grid point with a corresponding energy, and voting per bit could assemble a bitstring that no run ever produced.\n  ( ) Complete bitstrings are required because the bits are measured simultaneously.\n  ( ) Per-bit voting gives the same answer but takes longer to compute."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-aggregation\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -252,7 +882,100 @@
      "section:molecular-energy-reconstruction"
     ]
    },
-   "source": "## Molecular energy reconstruction\n\nAfter the repeated complete runs, the script selects the bitstring observed most often.\nInterpret this bitstring as a binary integer $b$.\nIf the calculation measures $m$ phase bits, convert $b$ to the phase fraction\n\n$$\n\\varphi=\\frac{b}{2^m}.\n$$\n\nQDK/Chemistry converts $2\\pi\\varphi$ to its equivalent signed angle $\\alpha$ between $-\\pi$ and $\\pi$.\nNegating that angle and dividing by the evolution time maps the measured phase to the active-space energy:\n\n$$\nE_{\\mathrm{active}}^{\\mathrm{IQPE}}=\\frac{-\\alpha}{t}.\n$$\n\nThis estimates an eigenvalue of the qubit Hamiltonian, not yet the selected-space molecular total.\nFinite phase resolution, sampling, and product-formula time evolution all contribute error.\nAs the chapter *Mapping the problem to qubits* explains, the mapper does not include the core energy in the qubit Hamiltonian.\nThe core energy contains the nuclear repulsion and the constant contribution from frozen inactive orbitals.\nBecause these contributions are not measured by phase estimation, the script adds them classically:\n\n$$\nE_{\\mathrm{total}}^{\\mathrm{IQPE}}\n=E_{\\mathrm{active}}^{\\mathrm{IQPE}}+E_{\\mathrm{core}}.\n$$\n\nFinally, compare this reconstructed total with the CASCI energy of the same selected-space Hamiltonian:\n\n$$\n\\Delta E_{\\mathrm{algorithm}}\n=E_{\\mathrm{total}}^{\\mathrm{IQPE}}-E_{\\mathrm{CASCI}}.\n$$\n\nThe workflow meets the teaching target when $\\lvert\\Delta E_{\\mathrm{algorithm}}\\rvert\\leq1\\ \\mathrm{m}E_{\\mathrm{h}}$.\nThis comparison evaluates the configured quantum algorithm against its classical reference; it does not measure basis-set or active-space model error.\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;Which energy comparison determines whether the IQPE workflow meets the teaching target?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nCompare the reconstructed IQPE total energy with the CASCI energy of the same selected active-space Hamiltonian.\nComparing with experiment or a larger orbital space would mix algorithmic error with model error.\n\n</div>\n\n</details></div>"
+   "source": [
+    "## Molecular energy reconstruction\n",
+    "\n",
+    "After the repeated complete runs, the script selects the bitstring observed most often.\n",
+    "Interpret this bitstring as a binary integer $b$.\n",
+    "If the calculation measures $m$ phase bits, convert $b$ to the phase fraction\n",
+    "\n",
+    "$$\n",
+    "\\varphi=\\frac{b}{2^m}.\n",
+    "$$\n",
+    "\n",
+    "QDK/Chemistry converts $2\\pi\\varphi$ to its equivalent signed angle $\\alpha$ between $-\\pi$ and $\\pi$.\n",
+    "Negating that angle and dividing by the evolution time maps the measured phase to the active-space energy:\n",
+    "\n",
+    "$$\n",
+    "E_{\\mathrm{active}}^{\\mathrm{IQPE}}=\\frac{-\\alpha}{t}.\n",
+    "$$\n",
+    "\n",
+    "This estimates an eigenvalue of the qubit Hamiltonian, not yet the selected-space molecular total.\n",
+    "Finite phase resolution, sampling, and product-formula time evolution all contribute error.\n",
+    "As the chapter *Mapping the problem to qubits* explains, the mapper does not include the core energy in the qubit Hamiltonian.\n",
+    "The core energy contains the nuclear repulsion and the constant contribution from frozen inactive orbitals.\n",
+    "Because these contributions are not measured by phase estimation, the script adds them classically:\n",
+    "\n",
+    "$$\n",
+    "E_{\\mathrm{total}}^{\\mathrm{IQPE}}\n",
+    "=E_{\\mathrm{active}}^{\\mathrm{IQPE}}+E_{\\mathrm{core}}.\n",
+    "$$\n",
+    "\n",
+    "Finally, compare this reconstructed total with the CASCI energy of the same selected-space Hamiltonian:\n",
+    "\n",
+    "$$\n",
+    "\\Delta E_{\\mathrm{algorithm}}\n",
+    "=E_{\\mathrm{total}}^{\\mathrm{IQPE}}-E_{\\mathrm{CASCI}}.\n",
+    "$$\n",
+    "\n",
+    "The workflow meets the teaching target when $\\lvert\\Delta E_{\\mathrm{algorithm}}\\rvert\\leq1\\ \\mathrm{m}E_{\\mathrm{h}}$.\n",
+    "This comparison evaluates the configured quantum algorithm against its classical reference; it does not measure basis-set or active-space model error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-13926c85dc5b",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Which energy comparison determines whether the IQPE workflow meets the teaching target?",
+       "options": [
+        {
+         "id": "hartree-fock",
+         "text": "The active-space energy against the Hartree-Fock energy.",
+         "correct": false,
+         "explanation": "That measures how much correlation energy was recovered, not whether phase estimation reached its target."
+        },
+        {
+         "id": "larger-space",
+         "text": "The reconstructed IQPE total energy against a CASCI energy computed in a larger active space.",
+         "correct": false,
+         "explanation": "Changing the space changes the Hamiltonian, so the comparison would no longer isolate the algorithm."
+        },
+        {
+         "id": "casci-same-space",
+         "text": "The reconstructed IQPE total energy against the CASCI energy of the same selected active-space Hamiltonian.",
+         "correct": true,
+         "explanation": "The same Hamiltonian sits on both sides, so the difference isolates algorithmic error."
+        },
+        {
+         "id": "experiment",
+         "text": "The reconstructed IQPE total energy against an experimental measurement for the molecule.",
+         "correct": false,
+         "explanation": "That would mix algorithmic error with molecular-model error and could not tell you which one you were looking at."
+        }
+       ],
+       "cellId": "iqpe-energy-comparison"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Which energy comparison determines whether the IQPE workflow meets the teaching target?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The active-space energy against the Hartree-Fock energy.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The reconstructed IQPE total energy against a CASCI energy computed in a larger active space.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The reconstructed IQPE total energy against the CASCI energy of the same selected active-space Hamiltonian.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The reconstructed IQPE total energy against an experimental measurement for the molecule.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Which energy comparison determines whether the IQPE workflow meets the teaching target?\n  ( ) The active-space energy against the Hartree-Fock energy.\n  ( ) The reconstructed IQPE total energy against a CASCI energy computed in a larger active space.\n  ( ) The reconstructed IQPE total energy against the CASCI energy of the same selected active-space Hamiltonian.\n  ( ) The reconstructed IQPE total energy against an experimental measurement for the molecule."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-energy-comparison\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -316,7 +1039,109 @@
      "section:the-complete-workflow"
     ]
    },
-   "source": "## The complete workflow\n\nThe cell below runs the complete workflow. It is the long step in this chapter and reports progress after each complete run.\n\nThe script prints its settings before simulation and reports progress for every complete run, including the seed, bitstring, total energy, error, and elapsed time.\nA successful run completes all twenty runs and prints the complete-run bitstring counts, most frequent bitstring, component energies, reconstructed total, reference energy, and signed error.\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;What bitstring distribution and energy estimate did the script produce?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nThe bitstring `010000` appeared 19 times and `001111` appeared once, so `010000` was the most frequent result.\nIt produced an active-space energy of $-9.652276065987\\ E_{\\mathrm{h}}$ and a reconstructed total of $-108.770051792909\\ E_{\\mathrm{h}}$ after adding the core energy.\n\n</div>\n\n</details></div>\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;Does the result meet the teaching target, and what does that establish?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nThe reconstructed total is $+1\\ \\mathrm{m}E_{\\mathrm{h}}$ above the selected-space CASCI reference, meeting the teaching target at its boundary.\nThat offset was deliberately set by the reference-guided phase-grid alignment, while Trotter approximation and finite sampling can still affect which bitstring is selected.\nThis classical simulation of the quantum calculation therefore validates this configured teaching workflow; it does not remove molecular-model error or establish agreement with experiment.\n\n</div>\n\n</details></div>"
+   "source": [
+    "## The complete workflow\n",
+    "\n",
+    "The cell below runs the complete workflow. It is the long step in this chapter and reports progress after each complete run.\n",
+    "\n",
+    "The script prints its settings before simulation and reports progress for every complete run, including the seed, bitstring, total energy, error, and elapsed time.\n",
+    "A successful run completes all twenty runs and prints the complete-run bitstring counts, most frequent bitstring, component energies, reconstructed total, reference energy, and signed error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-eca0c3efb565",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "What bitstring distribution did the script produce?",
+       "options": [
+        {
+         "id": "unanimous",
+         "text": "All 20 runs produced `010000`.",
+         "correct": false,
+         "explanation": "Close, but one run landed on the adjacent grid point `001111`. Finite sampling and Trotter error still move the outcome sometimes."
+        },
+        {
+         "id": "spread",
+         "text": "The 20 runs were spread across six different bitstrings, one per phase bit.",
+         "correct": false,
+         "explanation": "The distribution is far tighter: two grid points in total, one of them nineteen times."
+        },
+        {
+         "id": "reversed",
+         "text": "`001111` appeared 19 times and `010000` once.",
+         "correct": false,
+         "explanation": "Reversed. `010000` is the majority result; `001111` is the neighbouring grid point that turned up once."
+        },
+        {
+         "id": "19-1",
+         "text": "`010000` appeared 19 times and `001111` once, so `010000` is the most frequent result.",
+         "correct": true,
+         "explanation": "It gives an active-space energy of -9.652276065987 Eh and a reconstructed total of -108.770051792909 Eh once the core energy is added back."
+        }
+       ],
+       "cellId": "iqpe-observed-result"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>What bitstring distribution did the script produce?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> All 20 runs produced `010000`.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> The 20 runs were spread across six different bitstrings, one per phase bit.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> `001111` appeared 19 times and `010000` once.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> `010000` appeared 19 times and `001111` once, so `010000` is the most frequent result.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: What bitstring distribution did the script produce?\n  ( ) All 20 runs produced `010000`.\n  ( ) The 20 runs were spread across six different bitstrings, one per phase bit.\n  ( ) `001111` appeared 19 times and `010000` once.\n  ( ) `010000` appeared 19 times and `001111` once, so `010000` is the most frequent result."
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Does the result meet the teaching target, and what does that establish?",
+       "options": [
+        {
+         "id": "boundary",
+         "text": "Yes, at the boundary: the reconstructed total is 1 mEh above the selected-space CASCI reference, which validates this configured teaching workflow.",
+         "correct": true,
+         "explanation": "It does not remove molecular-model error or establish agreement with experiment. The offset itself was set by the reference-guided phase-grid alignment."
+        },
+        {
+         "id": "matches-experiment",
+         "text": "Yes, and it establishes that the workflow reproduces the experimental energy of the molecule to 1 mEh.",
+         "correct": false,
+         "explanation": "Nothing here is compared against experiment. The reference is a CASCI energy in the same active space."
+        },
+        {
+         "id": "errors-negligible",
+         "text": "Yes, and it shows that Trotter and sampling error are negligible.",
+         "correct": false,
+         "explanation": "Both can still affect which bitstring is selected. The agreement comes from the deliberate grid alignment, not from those errors vanishing."
+        },
+        {
+         "id": "misses",
+         "text": "No, a 1 mEh offset is outside the teaching target.",
+         "correct": false,
+         "explanation": "The target is 1 mEh, so this meets it, though only exactly at the boundary."
+        }
+       ],
+       "cellId": "iqpe-target-met"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Does the result meet the teaching target, and what does that establish?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Yes, at the boundary: the reconstructed total is 1 mEh above the selected-space CASCI reference, which validates this configured teaching workflow.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Yes, and it establishes that the workflow reproduces the experimental energy of the molecule to 1 mEh.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Yes, and it shows that Trotter and sampling error are negligible.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> No, a 1 mEh offset is outside the teaching target.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Does the result meet the teaching target, and what does that establish?\n  ( ) Yes, at the boundary: the reconstructed total is 1 mEh above the selected-space CASCI reference, which validates this configured teaching workflow.\n  ( ) Yes, and it establishes that the workflow reproduces the experimental energy of the molecule to 1 mEh.\n  ( ) Yes, and it shows that Trotter and sampling error are negligible.\n  ( ) No, a 1 mEh offset is outside the teaching target."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-observed-result\", \"iqpe-target-met\")\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -334,7 +1159,105 @@
      "section:knowledge-check"
     ]
    },
-   "source": "## Knowledge check\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;What changes if the number of phase bits increases while the repeated-power strategy remains fixed?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nThe phase grid becomes finer, but an additional iteration circuit is required and the largest controlled-unitary power doubles.\nFor repeated-power Trotter evolution, that larger power increases circuit size and simulator runtime substantially.\n\n</div>\n\n</details></div>\n\n<div style=\"border-left:4px solid #8c4a00;background:#8c4a001a;border-radius:4px;margin:1em 0;\"><details><summary style=\"background:#8c4a00;color:#ffffff;padding:0.35em 0.8em;cursor:pointer;font-weight:600;\">&#10067;&nbsp;Would increasing shots per bit make the phase grid finer?</summary>\n\n<div style=\"padding:0.1em 1em;\">\n\nNo.\nMore shots can make each bit majority more stable, but grid spacing is controlled by the evolution time and number of phase bits.\n\n</div>\n\n</details></div>"
+   "source": [
+    "## Knowledge check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c-c7f8bfdb8bcc",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quiz"
+    ]
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "What happens if the number of phase bits increases while the repeated-power strategy stays fixed?",
+       "options": [
+        {
+         "id": "extra-circuit",
+         "text": "One more iteration circuit is needed.",
+         "correct": true,
+         "explanation": "One circuit per bit, so an extra bit is an extra circuit to run."
+        },
+        {
+         "id": "shorter",
+         "text": "The circuits get shorter, because each bit carries less information.",
+         "correct": false,
+         "explanation": "The opposite — the longest circuit grows, because the largest controlled power doubles."
+        },
+        {
+         "id": "power-doubles",
+         "text": "The largest controlled-unitary power doubles.",
+         "correct": true,
+         "explanation": "For repeated-power Trotter evolution that is the expensive part: it increases circuit size and simulator runtime substantially."
+        },
+        {
+         "id": "finer-grid",
+         "text": "The phase grid becomes finer.",
+         "correct": true,
+         "explanation": "That is the point of adding a bit — the interval is divided more finely."
+        }
+       ],
+       "multiSelect": true,
+       "cellId": "iqpe-more-bits"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>What happens if the number of phase bits increases while the repeated-power strategy stays fixed?</p><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:0 0 8px'>Select all that apply.</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> One more iteration circuit is needed.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> The circuits get shorter, because each bit carries less information.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> The largest controlled-unitary power doubles.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9744;</span> The phase grid becomes finer.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: What happens if the number of phase bits increases while the repeated-power strategy stays fixed?\n  (select all that apply)\n  [ ] One more iteration circuit is needed.\n  [ ] The circuits get shorter, because each bit carries less information.\n  [ ] The largest controlled-unitary power doubles.\n  [ ] The phase grid becomes finer."
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.qdk.learning+json": {
+       "schemaVersion": 1,
+       "kind": "multiple-choice",
+       "prompt": "Would increasing the number of shots per bit make the phase grid finer?",
+       "options": [
+        {
+         "id": "no-spacing-fixed",
+         "text": "No. More shots can make each bit majority more stable, but grid spacing is set by the evolution time and the number of phase bits.",
+         "correct": true,
+         "explanation": "Shots change how confidently one grid point is selected, never the spacing between grid points."
+        },
+        {
+         "id": "yes-interpolate",
+         "text": "Yes, averaging more shots interpolates between grid points.",
+         "correct": false,
+         "explanation": "The majority vote selects one grid point. It never produces a value between two of them."
+        },
+        {
+         "id": "no-active-space",
+         "text": "No, because the grid is fixed by the size of the active space.",
+         "correct": false,
+         "explanation": "The right verdict for the wrong reason. Spacing comes from the evolution time and the number of phase bits."
+        },
+        {
+         "id": "yes-trotter",
+         "text": "Yes, more shots reduce Trotter error, which is what sets the spacing.",
+         "correct": false,
+         "explanation": "Trotter error is not what sets grid spacing, and repeating shots does not reduce it."
+        }
+       ],
+       "cellId": "iqpe-more-shots"
+      },
+      "text/html": "<div style='font-family:var(--qdk-font-family, system-ui, sans-serif);color:var(--qdk-host-foreground, #222);background:var(--qdk-host-background, #fff);border:1px solid var(--qdk-widget-outline, #ccc);border-radius:6px;margin:10px 0;line-height:1.45;overflow:hidden;'><div style='background:var(--qdk-quiz-accent, #8c4a00);color:var(--qdk-quiz-accent-foreground, #ffffff);padding:0.35em 0.8em;font-weight:600;'>&#10067;&nbsp;Check your understanding</div><div style='padding:12px 14px'><p style='margin:0 0 8px'>Would increasing the number of shots per bit make the phase grid finer?</p><ol style='margin:0 0 0 20px;padding:0'><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> No. More shots can make each bit majority more stable, but grid spacing is set by the evolution time and the number of phase bits.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Yes, averaging more shots interpolates between grid points.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> No, because the grid is fixed by the size of the active space.</li><li style='margin:6px 0'><span aria-hidden='true'>&#9711;</span> Yes, more shots reduce Trotter error, which is what sets the spacing.</li></ol><p style='color:var(--qdk-description-foreground, #666);font-size:0.9em;margin:10px 0 0'>Open this lesson in VS Code for interactive checking and explanations.</p></div></div>",
+      "text/plain": "Check your understanding: Would increasing the number of shots per bit make the phase grid finer?\n  ( ) No. More shots can make each bit majority more stable, but grid spacing is set by the evolution time and the number of phase bits.\n  ( ) Yes, averaging more shots interpolates between grid points.\n  ( ) No, because the grid is fixed by the size of the active space.\n  ( ) Yes, more shots reduce Trotter error, which is what sets the spacing."
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "quiz(\"iqpe-more-bits\", \"iqpe-more-shots\")\n"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/_learning_output.py
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/_learning_output.py
@@ -1,0 +1,349 @@
+"""Interactive outputs for QDK learning notebooks.
+
+This module lives at the course root. Per-unit helper files (``_unit.py``)
+import from it and re-export the small authoring surface the notebooks need.
+
+The output model
+----------------
+Each helper returns a lightweight display object carrying three views of the
+same content: a custom QDK MIME payload, a ``text/html`` fallback, and a
+``text/plain`` fallback. IPython writes all three into the ``.ipynb``; VS Code
+picks the custom one and renders it interactively, while other notebook hosts
+fall back to clean, non-interactive HTML or plain text.
+
+The payload shape is mirrored by ``src/notebookRenderer/schema.ts``. The two
+are compared at build time by ``checkRendererContract()`` in ``build.mjs``, so
+renaming a field on one side without the other fails the build rather than
+producing an empty cell in front of a learner.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from html import escape
+from typing import Any, Iterable, Mapping, Sequence
+
+MIME_TYPE = "application/vnd.qdk.learning+json"
+
+_CARD_STYLE = (
+    "font-family:var(--qdk-font-family, system-ui, sans-serif);"
+    "color:var(--qdk-host-foreground, #222);"
+    "background:var(--qdk-host-background, #fff);"
+    "border:1px solid var(--qdk-widget-outline, #ccc);"
+    "border-radius:6px;"
+    "margin:10px 0;"
+    "line-height:1.45;"
+    "overflow:hidden;"
+)
+
+#: The burnt-orange band the chemistry tutorial already uses to mark a
+#: self-check question. The fallback matters: this HTML is what a host without
+#: the QDK renderer shows, and it has no ``--qdk-*`` palette to resolve.
+_QUIZ_HEADER_STYLE = (
+    "background:var(--qdk-quiz-accent, #8c4a00);"
+    "color:var(--qdk-quiz-accent-foreground, #ffffff);"
+    "padding:0.35em 0.8em;"
+    "font-weight:600;"
+)
+_MUTED_STYLE = "color:var(--qdk-description-foreground, #666);font-size:0.9em"
+
+
+@dataclass(frozen=True)
+class LearningOutput:
+    """Display object for one QDK learning output.
+
+    Parameters
+    ----------
+    payload : mapping
+        JSON-serializable payload for ``application/vnd.qdk.learning+json``.
+    html : str
+        Non-interactive, escaped HTML fallback for notebook hosts that do not
+        know about the QDK learning renderer.
+    text : str
+        Plain text fallback for terminals and text-only exports.
+    """
+
+    payload: Mapping[str, Any]
+    html: str
+    text: str
+
+    def _repr_mimebundle_(
+        self,
+        include: Iterable[str] | None = None,
+        exclude: Iterable[str] | None = None,
+    ) -> dict[str, Any]:
+        """Return the custom MIME payload plus HTML and plain text fallbacks."""
+        bundle: dict[str, Any] = {
+            MIME_TYPE: dict(self.payload),
+            "text/html": self.html,
+            "text/plain": self.text,
+        }
+        if include is not None:
+            allowed = set(include)
+            bundle = {key: value for key, value in bundle.items() if key in allowed}
+        if exclude is not None:
+            blocked = set(exclude)
+            bundle = {key: value for key, value in bundle.items() if key not in blocked}
+        return bundle
+
+    def __str__(self) -> str:
+        """Return the plain text fallback."""
+        return self.text
+
+
+def multiple_choice(
+    prompt: str,
+    options: Sequence[Sequence[Any]],
+    *,
+    multi_select: bool = False,
+    cell_id: str | None = None,
+) -> LearningOutput:
+    """Create a multiple-choice learning output.
+
+    ``options`` are ``(id, text, correct, explanation)`` tuples. Option ids must
+    be unique, and a question needs at least two options, so authoring mistakes
+    fail loudly when the notebook cell is run.
+
+    A single-select question needs exactly one correct option. Pass
+    ``multi_select=True`` for a question with several right answers; the learner
+    then has to find all of them, and is told so.
+    """
+    normalized = _normalize_options(options, multi_select=multi_select)
+    payload: dict[str, Any] = {
+        "schemaVersion": 1,
+        "kind": "multiple-choice",
+        "prompt": str(prompt),
+        "options": normalized,
+    }
+    if multi_select:
+        payload["multiSelect"] = True
+    if cell_id is not None:
+        payload["cellId"] = str(cell_id)
+
+    html = _mcq_html(str(prompt), normalized, multi_select=multi_select)
+    text = _mcq_text(str(prompt), normalized, multi_select=multi_select)
+    return LearningOutput(payload, html, text)
+
+
+# ---------------------------------------------------------------------------
+# Registered quizzes
+# ---------------------------------------------------------------------------
+
+# Quiz definitions live here, keyed by id, and units register into it from
+# `_unit.py`. The notebook cell only names the quiz.
+_quizzes: dict[str, LearningOutput] = {}
+
+
+def register_quiz(
+    quiz_id: str,
+    prompt: str,
+    options: Sequence[Sequence[Any]],
+    *,
+    multi_select: bool = False,
+    shuffle: bool = True,
+) -> str:
+    """Register a quiz under ``quiz_id`` so a notebook can show it by name.
+
+    Answers are kept out of the *cell source*. A quiz written inline would put
+    the ``correct`` flags and the per-option explanations right there in the
+    code the learner reads, where reading them is easier than answering. So
+    quizzes are declared in the unit's ``_unit.py`` — the same place exercise
+    checkers already live — and the notebook cell just says ``quiz("...")``.
+
+    The answers do still reach the browser, in the baked cell output, because
+    the renderer grades without a kernel. This raises the effort of cheating; it
+    does not make it impossible, and it is no weaker than the collapsible
+    answers it replaced.
+
+    Pass ``multi_select=True`` for a question with several right answers; the
+    learner gets checkboxes and is told to select all that apply.
+
+    Options are shuffled by default. It is natural to write the correct answer
+    first and the distractors after it, which makes "always pick A" a winning
+    strategy across a unit. The shuffle is seeded from ``quiz_id``, so the
+    order is stable: re-running a notebook, or baking its outputs again, does
+    not reorder the options or produce a spurious diff. Pass ``shuffle=False``
+    for a question whose options have a meaningful order of their own.
+    """
+    if quiz_id in _quizzes:
+        raise ValueError(f"a quiz is already registered as {quiz_id!r}")
+    ordered = _shuffled(quiz_id, options) if shuffle else options
+    _quizzes[quiz_id] = multiple_choice(
+        prompt, ordered, multi_select=multi_select, cell_id=quiz_id
+    )
+    return quiz_id
+
+
+def _shuffled(seed: str, options: Sequence[Sequence[Any]]) -> list[Sequence[Any]]:
+    """Permute options deterministically from a string seed.
+
+    ``random.Random`` derives its state from a hash of the string rather than
+    from ``PYTHONHASHSEED``, so the same id yields the same order on every
+    machine and every run.
+    """
+    shuffled = list(options)
+    random.Random(seed).shuffle(shuffled)
+    return shuffled
+
+
+def quiz(*quiz_ids: str) -> None:
+    """Show the quizzes registered under ``quiz_ids``.
+
+    Accepts more than one id because the progress tree names a code cell after
+    the heading above it, so two adjacent quiz cells in one section would
+    appear twice under the same name. Where the chapter asks two questions
+    back to back, one cell shows both.
+
+    Displays rather than returns, so the call does not have to be the last
+    expression in the cell and one cell can produce several outputs.
+    """
+    if not quiz_ids:
+        raise ValueError('quiz() needs at least one quiz id, e.g. quiz("my-quiz")')
+
+    try:
+        from IPython.display import display
+    except ImportError as exc:  # pragma: no cover - notebooks always have IPython
+        raise RuntimeError(
+            "quiz() displays its output and so needs IPython; "
+            "use multiple_choice() directly outside a notebook."
+        ) from exc
+
+    for quiz_id in quiz_ids:
+        display(_lookup_quiz(quiz_id))
+
+
+def _lookup_quiz(quiz_id: str) -> LearningOutput:
+    try:
+        return _quizzes[quiz_id]
+    except KeyError:
+        known = ", ".join(sorted(_quizzes)) or "none"
+        raise ValueError(
+            f"no quiz is registered as {quiz_id!r}; registered quizzes: {known}. "
+            "Quizzes are registered in the unit's _unit.py."
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _normalize_options(
+    options: Sequence[Sequence[Any]],
+    *,
+    multi_select: bool = False,
+) -> list[dict[str, Any]]:
+    """Validate and normalize the option tuples an author wrote.
+
+    One accepted shape, ``(id, text, correct, explanation)``. Earlier drafts
+    also took dicts and shorter tuples; nothing used them, and each extra shape
+    was another way for two quizzes to end up subtly inconsistent.
+    """
+    if len(options) < 2:
+        raise ValueError("multiple_choice requires at least two options")
+
+    normalized: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    correct_count = 0
+    for option in options:
+        parts = list(option)
+        if len(parts) != 4:
+            raise ValueError(
+                "multiple_choice options must be "
+                "(id, text, correct, explanation) tuples; "
+                f"got {len(parts)} value(s)"
+            )
+        option_id, text, correct, explanation = parts
+        option_id = str(option_id)
+        text = str(text)
+
+        if not isinstance(correct, bool):
+            raise ValueError("multiple_choice option 'correct' values must be bool")
+        if not option_id:
+            raise ValueError("multiple_choice option ids must not be empty")
+        if option_id in seen_ids:
+            raise ValueError(f"duplicate multiple_choice option id: {option_id!r}")
+        seen_ids.add(option_id)
+
+        item: dict[str, Any] = {"id": option_id, "text": text, "correct": correct}
+        if explanation is not None:
+            item["explanation"] = str(explanation)
+        if correct:
+            correct_count += 1
+        normalized.append(item)
+
+    if correct_count == 0:
+        raise ValueError("multiple_choice requires at least one correct option")
+
+    if multi_select:
+        # A "select all that apply" with one answer teaches the learner to
+        # distrust the instruction, and one where everything applies isn't a
+        # question. Both are authoring mistakes, not learner mistakes.
+        if correct_count < 2:
+            raise ValueError(
+                "multi_select questions need at least two correct options; "
+                "drop multi_select=True for a single-answer question"
+            )
+        if correct_count == len(normalized):
+            raise ValueError(
+                "every option is marked correct, so the question cannot be "
+                "answered wrongly"
+            )
+    elif correct_count > 1:
+        # The renderer grades by comparing the selected set with the correct
+        # set, and a radio group holds one selection — so a single-select
+        # question with two correct answers can never be answered right.
+        raise ValueError(
+            f"multiple_choice got {correct_count} correct options; pass "
+            "multi_select=True for a question with several right answers"
+        )
+    return normalized
+
+
+def _mcq_html(
+    prompt: str, options: Sequence[Mapping[str, Any]], *, multi_select: bool
+) -> str:
+    """Render the static fallback.
+
+    Deliberately inert: no answers, no ``correct`` flags, no explanations. This
+    is what a host without the QDK renderer shows, and it is also what lands in
+    an exported HTML page, so anything revealed here is revealed to everyone.
+    """
+    # A box for "pick several", a circle for "pick one" — the same distinction
+    # the interactive version draws with checkboxes and radios.
+    marker = "&#9744;" if multi_select else "&#9711;"
+    hint = (
+        f"<p style='{_MUTED_STYLE};margin:0 0 8px'>Select all that apply.</p>"
+        if multi_select
+        else ""
+    )
+    rows = [
+        "<li style='margin:6px 0'>"
+        f"<span aria-hidden='true'>{marker}</span> {escape(str(option['text']))}"
+        "</li>"
+        for option in options
+    ]
+    return (
+        f"<div style='{_CARD_STYLE}'>"
+        f"<div style='{_QUIZ_HEADER_STYLE}'>&#10067;&nbsp;Check your understanding</div>"
+        "<div style='padding:12px 14px'>"
+        f"<p style='margin:0 0 8px'>{escape(prompt)}</p>"
+        f"{hint}"
+        "<ol style='margin:0 0 0 20px;padding:0'>" + "".join(rows) + "</ol>"
+        f"<p style='{_MUTED_STYLE};margin:10px 0 0'>Open this lesson in VS Code "
+        "for interactive checking and explanations.</p>"
+        "</div>"
+        "</div>"
+    )
+
+
+def _mcq_text(
+    prompt: str, options: Sequence[Mapping[str, Any]], *, multi_select: bool
+) -> str:
+    lines = [f"Check your understanding: {prompt}"]
+    if multi_select:
+        lines.append("  (select all that apply)")
+    marker = "[ ]" if multi_select else "( )"
+    lines.extend(f"  {marker} {option['text']}" for option in options)
+    return "\n".join(lines)

--- a/source/vscode/resources/qdk-learning/courses/chemistry-qpe/_learning_output.py
+++ b/source/vscode/resources/qdk-learning/courses/chemistry-qpe/_learning_output.py
@@ -20,11 +20,19 @@ producing an empty cell in front of a learner.
 from __future__ import annotations
 
 import random
+import re
 from dataclasses import dataclass
 from html import escape
 from typing import Any, Iterable, Mapping, Sequence
 
 MIME_TYPE = "application/vnd.qdk.learning+json"
+
+#: A quiz id has to survive the trip to the extension host, which accepts only
+#: this shape from a notebook — nothing longer, and nothing that could read as
+#: prose. Enforcing it here means an author finds out when they run the cell,
+#: rather than a learner finding the "Why is that wrong?" button quietly doing
+#: less than it should. Keep in step with `QUIZ_ID_PATTERN` in `schema.ts`.
+_QUIZ_ID_RE = re.compile(r"\A[a-z0-9][a-z0-9-]{0,63}\Z")
 
 _CARD_STYLE = (
     "font-family:var(--qdk-font-family, system-ui, sans-serif);"
@@ -168,6 +176,12 @@ def register_quiz(
     """
     if quiz_id in _quizzes:
         raise ValueError(f"a quiz is already registered as {quiz_id!r}")
+    if not _QUIZ_ID_RE.match(quiz_id):
+        raise ValueError(
+            f"quiz id {quiz_id!r} must be lowercase letters, digits and hyphens, "
+            "start with a letter or digit, and be at most 64 characters; the "
+            "renderer's Copilot action drops anything else"
+        )
     ordered = _shuffled(quiz_id, options) if shuffle else options
     _quizzes[quiz_id] = multiple_choice(
         prompt, ordered, multi_select=multi_select, cell_id=quiz_id

--- a/source/vscode/resources/qdk-learning/utils/chemistry-qpe/README.md
+++ b/source/vscode/resources/qdk-learning/utils/chemistry-qpe/README.md
@@ -31,8 +31,43 @@ list the same units; the converter stops if they disagree. The links point at
 the learner's `*.workbook.ipynb` copies, which the extension materializes beside
 the authored notebooks, so they only resolve inside a learner's workspace.
 
-| Script               | What it does                                                                                                                |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `rst_to_notebook.py` | Converts one tutorial chapter to a unit notebook. `RECIPES` holds the per-chapter decisions a human still has to make.      |
-| `bake_outputs.py`    | Runs a notebook so its outputs ship with the course.                                                                        |
-| `verify_course.py`   | Checks every unit loads, validates, and carries what the tree needs. Pass `--allow-outputs` when reviewing baked notebooks. |
+| Script               | What it does                                                                                                                                  |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rst_to_notebook.py` | Converts one tutorial chapter to a unit notebook. `RECIPES` holds the per-chapter decisions a human still has to make.                        |
+| `details_to_quiz.py` | Bakes a chapter's self-check questions into answerable quizzes. The quiz counterpart of `bake_outputs.py`; run it after `rst_to_notebook.py`. |
+| `bake_outputs.py`    | Runs a notebook so its outputs ship with the course.                                                                                          |
+| `verify_course.py`   | Checks every unit loads, validates, and carries what the tree needs. Pass `--allow-outputs` when reviewing baked notebooks.                   |
+
+## Self-check questions
+
+`details_to_quiz.py` bakes a chapter's self-check questions into the notebook,
+so a learner sees them on opening the file and can answer without a kernel. It
+is the quiz counterpart of `bake_outputs.py`, but a quiz is pure data, so it
+calls the emitter directly instead of starting a kernel.
+
+The first run on a chapter also creates the cells to bake. A chapter's
+`quiz-question` admonitions arrive as `<details>` disclosures whose only
+interaction is revealing the answer, and those blocks are replaced with
+`quiz("id")` calls. Afterwards every run is only a rebake.
+
+The choices themselves live in the unit's `_unit.py`, registered by id, so the
+notebook cell a learner reads is just `quiz("id")` rather than the answer key.
+Write them by hand: which wrong answers are worth offering is a judgement about
+what a learner is likely to believe, and the converter never touches `_unit.py`.
+The answers do travel to the browser inside the baked cell output, because the
+renderer grades without a kernel — this raises the effort of looking them up
+rather than making it impossible, and it is no weaker than the collapsible
+answers it replaces.
+
+Regenerating a chapter puts the `<details>` back, so re-run this afterwards.
+Both steps are idempotent and safe to run either way:
+
+    python rst_to_notebook.py 06_iterative_phase_estimation
+    python details_to_quiz.py 06-iterative-phase-estimation --ids <ids in document order>
+    python verify_course.py
+
+After that first conversion the notebook names its own ids, so rebaking edited
+questions, or checking for drift against `_unit.py`, is just:
+
+    python details_to_quiz.py 06-iterative-phase-estimation
+    python details_to_quiz.py 06-iterative-phase-estimation --check

--- a/source/vscode/resources/qdk-learning/utils/chemistry-qpe/details_to_quiz.py
+++ b/source/vscode/resources/qdk-learning/utils/chemistry-qpe/details_to_quiz.py
@@ -1,0 +1,427 @@
+"""Bake a chapter's self-check questions into answerable quizzes.
+
+This is the quiz counterpart of ``bake_outputs.py``: it stores each question's
+rendered output in the notebook so a learner sees it on opening the file, with
+no kernel. Where ``bake_outputs.py`` starts a kernel to run the chemistry, a
+quiz is pure data, so this just calls the emitter and keeps what it returns.
+
+The first run on a chapter also has to create the cells to bake. Chapters
+written by ``rst_to_notebook.py`` render each ``quiz-question`` admonition as a
+``<details>`` disclosure whose only interaction is revealing the answer, so
+those blocks are replaced with ``quiz()`` calls. Afterwards there is nothing
+left to convert and every run is only a rebake.
+
+The choices are written by hand in ``_unit.py``: deciding which wrong answers
+are worth offering is the author's judgement, not something to generate. This
+never writes ``_unit.py``.
+
+Both steps are idempotent. The one-time conversion:
+
+* a markdown cell is split at each quiz block, and the block becomes a code
+  cell between the prose that surrounded it;
+* quiz blocks with no prose between them share one code cell, because the
+  progress tree names a code cell after the heading above it and two cells in
+  one section would appear twice under the same name;
+* the first fragment keeps the original cell's id and tags, so a ``section:``
+  tag is not duplicated onto a fragment that does not start a section.
+
+A first conversion needs the ids to substitute, in document order::
+
+    python details_to_quiz.py 06-iterative-phase-estimation --ids iqpe-grid-target ...
+
+After that the notebook names them, so rebaking after editing ``_unit.py`` is
+just the unit, and ``--check`` reports drift without writing::
+
+    python details_to_quiz.py 06-iterative-phase-estimation --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+COURSE = Path(__file__).resolve().parent.parent.parent / "courses" / "chemistry-qpe"
+
+#: The wrapper the generator emits around every self-check question. Matching
+#: the whole wrapper, not just the ``<details>``, keeps the tinted border from
+#: being left behind as an empty box.
+QUIZ_BLOCK = re.compile(
+    r'<div style="border-left:4px solid #8c4a00;[^"]*">\s*<details>.*?</details>\s*</div>',
+    re.S,
+)
+
+#: How `rst_to_notebook.py` names a generated cell, so converted notebooks and
+#: regenerated ones agree.
+def _cell_id(body: str) -> str:
+    return "c-" + hashlib.sha256(body.encode()).hexdigest()[:12]
+
+
+#: A converted question. One ``quiz()`` call can name several ids.
+#:
+#: `verify_course.py` carries the same pair, deliberately: it is a script that
+#: verifies on import, so importing it here would run the whole course check.
+#: Two one-line regexes are cheaper than that coupling — but if the `quiz()`
+#: call shape changes, both files need it.
+QUIZ_CALL = re.compile(r"^quiz\(([^)]*)\)", re.M)
+QUIZ_ID = re.compile(r'"([^"]+)"')
+
+
+def _load_unit_module(unit_dir: Path) -> tuple[Any, Any]:
+    """Import a unit's ``_unit.py`` so its ``register_quiz`` calls run.
+
+    Returns the unit module and the emitter module it registered into. The
+    emitter is reached through ``sys.modules`` rather than the unit's
+    namespace: importing ``_unit`` puts ``_learning_output`` there, and going
+    to the source avoids depending on which names a unit chose to re-export.
+    """
+    course_root = str(unit_dir.parent)
+    if course_root not in sys.path:
+        sys.path.insert(0, course_root)
+    if str(unit_dir) not in sys.path:
+        sys.path.insert(0, str(unit_dir))
+
+    spec = importlib.util.spec_from_file_location(
+        f"_unit_{unit_dir.name}", unit_dir / "_unit.py"
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {unit_dir / '_unit.py'}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    emitter = sys.modules.get("_learning_output")
+    if emitter is None:
+        raise SystemExit(
+            f"{unit_dir / '_unit.py'} does not import _learning_output, so it "
+            "registers no quizzes."
+        )
+    return module, emitter
+
+
+def _cell_tags(cell: dict[str, Any]) -> list[str]:
+    tags = cell.get("metadata", {}).get("tags", [])
+    return [str(t) for t in tags]
+
+
+def _split_cell(source: str) -> list[tuple[str, str]]:
+    """Split markdown into an alternating run of prose and quiz markers.
+
+    Returns ``("prose", text)`` and ``("quiz", block)`` pairs in document
+    order, with empty prose dropped.
+    """
+    pieces: list[tuple[str, str]] = []
+    cursor = 0
+    for match in QUIZ_BLOCK.finditer(source):
+        prose = source[cursor : match.start()].strip("\n")
+        if prose.strip():
+            pieces.append(("prose", prose))
+        pieces.append(("quiz", match.group(0)))
+        cursor = match.end()
+    tail = source[cursor:].strip("\n")
+    if tail.strip():
+        pieces.append(("prose", tail))
+    return pieces
+
+
+def _group_adjacent_quizzes(
+    pieces: list[tuple[str, str]],
+) -> list[tuple[str, list[str]]]:
+    """Collapse a run of quizzes with no prose between them into one group."""
+    grouped: list[tuple[str, list[str]]] = []
+    for kind, text in pieces:
+        if kind == "quiz" and grouped and grouped[-1][0] == "quiz":
+            grouped[-1][1].append(text)
+            continue
+        grouped.append((kind, [text]))
+    return grouped
+
+
+def _baked_outputs(emitter: Any, ids: list[str]) -> list[dict[str, Any]]:
+    """Render the display bundles the cell would produce when run.
+
+    ``quiz()`` displays rather than returns, so running it yields one
+    ``display_data`` output per question.
+    """
+    outputs = []
+    for quiz_id in ids:
+        bundle = emitter._lookup_quiz(quiz_id)._repr_mimebundle_()
+        outputs.append(
+            {
+                "output_type": "display_data",
+                "data": bundle,
+                "metadata": {},
+            }
+        )
+    return outputs
+
+
+def _ensure_quiz_import(cell: dict[str, Any]) -> bool:
+    """Add ``quiz`` to the unit import in the setup cell.
+
+    Returns whether this cell *is* the setup cell, not whether it changed — so
+    a re-run stops at the same place a first run did.
+
+    The notebook's first code cell already imports from ``_unit``; extending
+    that line keeps the plumbing a learner sees to the one import they were
+    always going to run.
+    """
+    source = "".join(cell["source"])
+    match = re.search(r"^from _unit import (.+)$", source, re.M)
+    if match is None:
+        # Not the setup cell. Distinct from "found it and it already imports
+        # quiz", so the caller can stop scanning once the line is seen and not
+        # go on to rewrite an exercise cell's own `from _unit import`.
+        return False
+
+    names = [name.strip() for name in match.group(1).split(",")]
+    if "quiz" not in names:
+        replacement = f"from _unit import {', '.join(sorted({*names, 'quiz'}))}"
+        updated = source[: match.start()] + replacement + source[match.end() :]
+        cell["source"] = updated.splitlines(keepends=True)
+    return True
+
+
+def _cell_quiz_ids(cell: dict[str, Any]) -> list[str]:
+    """The quiz ids a single cell shows, in order."""
+    source = "".join(cell["source"])
+    return [
+        quiz_id
+        for call in QUIZ_CALL.findall(source)
+        for quiz_id in QUIZ_ID.findall(call)
+    ]
+
+
+def _notebook_quiz_ids(notebook: dict[str, Any]) -> list[str]:
+    """The quiz ids the notebook already shows, in document order."""
+    found: list[str] = []
+    for cell in notebook["cells"]:
+        found.extend(_cell_quiz_ids(cell))
+    return found
+
+
+def _already_converted(notebook: dict[str, Any], quiz_ids: list[str]) -> bool:
+    """True when the notebook already shows exactly these quizzes."""
+    return _notebook_quiz_ids(notebook) == quiz_ids
+
+
+def convert(notebook_path: Path, unit_dir: Path, quiz_ids: list[str]) -> dict[str, Any]:
+    _unit_module, emitter = _load_unit_module(unit_dir)
+    notebook = json.loads(notebook_path.read_text(encoding="utf-8"))
+
+    imported = False
+    remaining = list(quiz_ids)
+    converted: list[dict[str, Any]] = []
+    for cell in notebook["cells"]:
+        source = "".join(cell["source"])
+        if cell["cell_type"] == "code" and not imported:
+            imported = _ensure_quiz_import(cell)
+        if cell["cell_type"] != "markdown" or not QUIZ_BLOCK.search(source):
+            converted.append(cell)
+            continue
+
+        groups = _group_adjacent_quizzes(_split_cell(source))
+        # The original cell's id and tags belong to whichever fragment comes
+        # first, whether that is prose or a question. Tying them to "the first
+        # prose fragment" would drop a section: tag from a cell that opens
+        # with a question.
+        identity_used = False
+        for kind, texts in groups:
+            if kind == "prose":
+                body = texts[0]
+                if identity_used:
+                    # Key order matches the cells `rst_to_notebook.py` emits,
+                    # so a split fragment looks like every other cell.
+                    fragment: dict[str, Any] = {
+                        "cell_type": "markdown",
+                        "id": _cell_id(body),
+                        "metadata": {},
+                        "source": [],
+                    }
+                else:
+                    fragment = dict(cell)
+                    identity_used = True
+                fragment["source"] = body.splitlines(keepends=True)
+                converted.append(fragment)
+            else:
+                ids = [remaining.pop(0) for _ in texts]
+                call = "quiz({})\n".format(", ".join(f'"{i}"' for i in ids))
+                # Tagged so the progress tree looks past this cell for the
+                # section heading: a quiz sits inside a section rather than
+                # starting one.
+                tags = ["quiz"]
+                quiz_cell_id = _cell_id(call)
+                if not identity_used:
+                    tags = sorted({*_cell_tags(cell), "quiz"})
+                    quiz_cell_id = cell["id"]
+                    identity_used = True
+                converted.append(
+                    {
+                        "cell_type": "code",
+                        "id": quiz_cell_id,
+                        "execution_count": None,
+                        "metadata": {"tags": tags},
+                        "outputs": _baked_outputs(emitter, ids),
+                        "source": [call],
+                    }
+                )
+
+    if remaining:
+        raise SystemExit(
+            f"{len(remaining)} unused quiz id(s): {', '.join(remaining)}. "
+            "Ids must be given in document order, one per question."
+        )
+    if not imported and quiz_ids:
+        raise SystemExit(
+            "could not find a 'from _unit import ...' line to add quiz to; "
+            "add the import to the notebook's setup cell by hand."
+        )
+
+    notebook["cells"] = converted
+    return notebook
+
+
+def _rebake(notebook: dict[str, Any], emitter: Any, stale: set[str]) -> None:
+    """Re-render the outputs of the cells holding a stale quiz.
+
+    Rebaking is per cell because a cell can hold several quizzes, so one stale
+    question re-renders its neighbours too. That is why only the cells that
+    need it are touched: it keeps the write to what the report named.
+    """
+    for cell in notebook["cells"]:
+        ids = _cell_quiz_ids(cell)
+        if ids and not stale.isdisjoint(ids):
+            cell["outputs"] = _baked_outputs(emitter, ids)
+
+
+def _normalize_bundle(data: Any) -> Any:
+    """Undo nbformat's line splitting so two bundles can be compared.
+
+    nbformat stores every non-JSON MIME value as a list of lines, and applies
+    that on read *and* on write. So a notebook saved by VS Code, by Jupyter, or
+    by ``bake_outputs.py`` holds lists where this tool wrote strings. Comparing
+    without rejoining would report every quiz as stale forever.
+    """
+    if isinstance(data, list) and all(isinstance(x, str) for x in data):
+        return "".join(data)
+    if isinstance(data, dict):
+        return {key: _normalize_bundle(value) for key, value in data.items()}
+    return data
+
+
+def _stale_baked_outputs(notebook: dict[str, Any], emitter: Any) -> list[str]:
+    """Report quizzes whose baked output no longer matches ``_unit.py``.
+
+    This is the drift that matters once a notebook is converted: the questions
+    a learner sees are the outputs stored in the file, so editing a quiz's
+    wording or its options without re-running this tool would leave the old
+    version on screen.
+    """
+    stale: list[str] = []
+    for cell in notebook["cells"]:
+        source = "".join(cell["source"])
+        outputs = cell.get("outputs", [])
+        position = 0
+        for call in QUIZ_CALL.findall(source):
+            for quiz_id in QUIZ_ID.findall(call):
+                expected = _normalize_bundle(
+                    emitter._lookup_quiz(quiz_id)._repr_mimebundle_()
+                )
+                actual = (
+                    _normalize_bundle(outputs[position].get("data"))
+                    if position < len(outputs)
+                    else None
+                )
+                if actual != expected:
+                    stale.append(quiz_id)
+                position += 1
+    return stale
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("unit", help="unit folder name, e.g. 06-iterative-phase-estimation")
+    parser.add_argument(
+        "--ids",
+        nargs="+",
+        help="quiz ids in document order; only needed for a first conversion, "
+        "since a converted notebook already names them",
+    )
+    parser.add_argument("--course", default=str(COURSE), help="course root")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify without writing; exits non-zero if the notebook is stale",
+    )
+    args = parser.parse_args()
+
+    unit_dir = Path(args.course) / args.unit
+    notebooks = sorted(unit_dir.glob("*.ipynb"))
+    if len(notebooks) != 1:
+        raise SystemExit(f"expected exactly one notebook in {unit_dir}, found {len(notebooks)}")
+    notebook_path = notebooks[0]
+
+    original = notebook_path.read_text(encoding="utf-8")
+
+    # Fall back to the ids the notebook already names, so re-running the
+    # converter or checking for drift does not mean repeating the list every
+    # time. A first conversion has none to read and still has to be told.
+    quiz_ids = list(args.ids) if args.ids else _notebook_quiz_ids(json.loads(original))
+    if not quiz_ids:
+        raise SystemExit(
+            f"{notebook_path.name} has no quiz() calls yet, so --ids is required "
+            "to say which questions to substitute, in document order"
+        )
+
+    # Re-runnable on purpose. The conversion is a step after
+    # `rst_to_notebook.py`, so a pipeline should be able to run it without
+    # first checking whether the notebook was regenerated.
+    if _already_converted(json.loads(original), quiz_ids):
+        _unit_module, emitter = _load_unit_module(unit_dir)
+        stale = _stale_baked_outputs(json.loads(original), emitter)
+        if not stale:
+            print(f"{notebook_path.name}: already converted and up to date")
+            return 0
+
+        listed = ", ".join(sorted(set(stale)))
+        if args.check:
+            print(f"{notebook_path.name}: baked output is stale for {listed}")
+            return 1
+
+        # Rebake in place rather than refusing: the questions live in
+        # _unit.py, and the notebook is only a rendering of them.
+        notebook = json.loads(original)
+        _rebake(notebook, emitter, set(stale))
+        notebook_path.write_text(
+            json.dumps(notebook, indent=1, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        print(f"{notebook_path.name}: rebaked {listed}")
+        return 0
+
+    converted = convert(notebook_path, unit_dir, quiz_ids)
+    # nbformat writes one-space indent and a trailing newline; match it so the
+    # file stays comparable with the ones `rst_to_notebook.py` produces.
+    text = json.dumps(converted, indent=1, ensure_ascii=False) + "\n"
+
+    quiz_cells = sum(
+        1 for c in converted["cells"] if c["cell_type"] == "code" and c["source"][0].startswith("quiz(")
+    )
+    print(f"{notebook_path.name}: {len(quiz_ids)} questions in {quiz_cells} cells")
+
+    if args.check:
+        print("unchanged" if text == original else "would rewrite")
+        return 0 if text == original else 1
+
+    notebook_path.write_text(text, encoding="utf-8", newline="\n")
+    print(f"wrote {notebook_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/source/vscode/resources/qdk-learning/utils/chemistry-qpe/details_to_quiz.py
+++ b/source/vscode/resources/qdk-learning/utils/chemistry-qpe/details_to_quiz.py
@@ -323,22 +323,30 @@ def _stale_baked_outputs(notebook: dict[str, Any], emitter: Any) -> list[str]:
     """
     stale: list[str] = []
     for cell in notebook["cells"]:
-        source = "".join(cell["source"])
+        ids = _cell_quiz_ids(cell)
+        if not ids:
+            continue
+
         outputs = cell.get("outputs", [])
-        position = 0
-        for call in QUIZ_CALL.findall(source):
-            for quiz_id in QUIZ_ID.findall(call):
-                expected = _normalize_bundle(
-                    emitter._lookup_quiz(quiz_id)._repr_mimebundle_()
-                )
-                actual = (
-                    _normalize_bundle(outputs[position].get("data"))
-                    if position < len(outputs)
-                    else None
-                )
-                if actual != expected:
-                    stale.append(quiz_id)
-                position += 1
+        for position, quiz_id in enumerate(ids):
+            expected = _normalize_bundle(
+                emitter._lookup_quiz(quiz_id)._repr_mimebundle_()
+            )
+            actual = (
+                _normalize_bundle(outputs[position].get("data"))
+                if position < len(outputs)
+                else None
+            )
+            if actual != expected:
+                stale.append(quiz_id)
+
+        # An output past the last quiz the cell still calls is left over from a
+        # question that was removed. Nothing above compares it, so without this
+        # the notebook keeps showing a deleted question while --check reports
+        # the file as up to date. Naming the cell's remaining quizzes is what
+        # makes `_rebake` re-render it, which drops the extra output.
+        if len(outputs) > len(ids) and not any(i in stale for i in ids):
+            stale.extend(ids)
     return stale
 
 

--- a/source/vscode/resources/qdk-learning/utils/chemistry-qpe/verify_course.py
+++ b/source/vscode/resources/qdk-learning/utils/chemistry-qpe/verify_course.py
@@ -27,7 +27,7 @@ COURSE = args.course
 EXPECTED_TOTALS = Counter(
     {
         "units": 7,
-        "cells": 181,
+        "cells": 191,
         "exercises": 6,
         "hints": 6,
         "solutions": 6,
@@ -44,6 +44,10 @@ AUTHORING_KINDS = {
     "explanation": "markdown",
 }
 REGISTER_CALLS = {"register_exercise", "register_value_exercise"}
+#: A converted self-check question. One ``quiz()`` call can name several ids,
+#: so the questions are counted from the ids rather than from the calls.
+QUIZ_CALL = re.compile(r"^quiz\(([^)]*)\)", re.M)
+QUIZ_ID = re.compile(r'"([^"]+)"')
 EXPECTED_ATTACHMENT_MIMES = {
     "tutorial_qpe_atomic_basis_functions.png": "image/png",
     "tutorial_qpe_example_molecular_orbitals.png": "image/png",
@@ -169,6 +173,9 @@ for unit in manifest["units"]:
                 current_exercise = None
             counts["sections"] += any(tag.startswith("section:") for tag in tags)
             counts["quizzes"] += source.count("<details>")
+            counts["quizzes"] += sum(
+                len(QUIZ_ID.findall(call)) for call in QUIZ_CALL.findall(source)
+            )
             for name in re.findall(r'<svg[^>]+data-asset="([^"]+)"', source):
                 counts["inline_svgs"] += 1
                 if name not in EXPECTED_INLINE_SVGS:
@@ -250,8 +257,11 @@ for unit in manifest["units"]:
             if cell.cell_type == "code":
                 counts["code_cells"] += 1
                 uses_unit_module |= "_unit" in source
-                allow_cell_output = args.allow_outputs and not (
-                    tags & AUTHORING_KINDS.keys()
+                # A quiz cell's output is the question itself, baked so it is
+                # visible on opening rather than after a run. That is content,
+                # not a leftover from executing the notebook.
+                allow_cell_output = "quiz" in tags or (
+                    args.allow_outputs and not (tags & AUTHORING_KINDS.keys())
                 )
                 if cell.get("outputs") and not allow_cell_output:
                     problems.append(f"{cell.id}: code cell ships output")

--- a/source/vscode/src/learning/index.ts
+++ b/source/vscode/src/learning/index.ts
@@ -9,6 +9,7 @@ import {
 import { registerLearningCommands } from "./commands.js";
 import { LessonPanelManager, registerLessonPanelSerializer } from "./panel.js";
 import { createNotebookCellStatusBarProvider } from "./notebookCellStatusBar.js";
+import { registerNotebookRendererMessaging } from "./notebookRendererMessaging.js";
 import { registerNotebookSync } from "./notebookSync.js";
 import { registerLearningProgressView } from "./progressTreeView.js";
 import { LearningService } from "./service.js";
@@ -91,6 +92,7 @@ export function initLearning(
   registerLearningCommands(context, learningService, panelManager);
   registerLessonPanelSerializer(context, panelManager);
   registerNotebookSync(context, learningService);
+  registerNotebookRendererMessaging(context, learningService);
   return learningService;
 }
 

--- a/source/vscode/src/learning/notebookExercises.ts
+++ b/source/vscode/src/learning/notebookExercises.ts
@@ -39,6 +39,18 @@ import type {
 /** Tag marking the code cell a learner edits. */
 const EXERCISE_TAG = "exercise";
 
+/**
+ * Tag marking a code cell that only shows a registered quiz.
+ *
+ * A quiz cell is learner content, so unlike the authoring tags it stays in the
+ * working copy — but it is not an activity, for the reasons in
+ * `parseNotebookActivities`. It is called out because it sits *inside* a
+ * section's prose: without the tag it would hide the section heading from the
+ * code cell that follows it, which would then fall back to being named after
+ * its cell id.
+ */
+const QUIZ_TAG = "quiz";
+
 /** Tags marking author-only cells, removed from the learner's working copy. */
 const AUTHORING_TAGS = ["hint", "solution", "explanation"] as const;
 
@@ -86,6 +98,16 @@ export function parseNotebookActivities(
   for (let i = 0; i < cells.length; i++) {
     const cell = cells[i];
     const tags = cellTags(cell);
+
+    // A quiz cell stays in the learner's copy but is not an activity. Its
+    // outputs are already in the notebook, running it does not produce a
+    // result the service records, and whether the learner answered correctly
+    // never leaves the renderer — so a progress entry would claim tracking
+    // that does not exist. Skipped before `current` is cleared so a quiz
+    // between an exercise and its hint would not orphan the hint.
+    if (tags.includes(QUIZ_TAG)) {
+      continue;
+    }
 
     const authoringTag = AUTHORING_TAGS.find((t) => tags.includes(t));
 
@@ -310,6 +332,11 @@ function extractTitleFromPrecedingCell(
       AUTHORING_TAGS.some((t) => tags.includes(t))
     ) {
       break;
+    }
+    // A quiz sits within a section rather than starting one, so look straight
+    // past it for the heading instead of stopping at it.
+    if (tags.includes(QUIZ_TAG)) {
+      continue;
     }
     if (cellKind(cell) !== "markdown") {
       break;

--- a/source/vscode/src/learning/notebookRendererMessaging.ts
+++ b/source/vscode/src/learning/notebookRendererMessaging.ts
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { log } from "qsharp-lang";
+import * as vscode from "vscode";
+import { isNotebookCourse } from "./courseLayout.js";
+import type { CopilotActionId } from "../notebookRenderer/schema.js";
+import {
+  isRendererToExtensionMessage,
+  RENDERER_ID,
+} from "../notebookRenderer/schema.js";
+import type { LearningService } from "./service.js";
+
+/**
+ * Bridges the QDK learning notebook renderer to the extension host.
+ *
+ * A renderer webview can't execute VS Code commands, so `createRendererMessaging`
+ * is the channel out. Everything arriving here is authored notebook content and
+ * therefore untrusted: the renderer may only name an action id from a fixed
+ * allowlist, never a prompt or command id, and any free text it contributes is
+ * sanitized into an extension-owned template.
+ */
+export function registerNotebookRendererMessaging(
+  context: vscode.ExtensionContext,
+  service: LearningService,
+): void {
+  const messaging = vscode.notebooks.createRendererMessaging(RENDERER_ID);
+
+  context.subscriptions.push(
+    messaging.onDidReceiveMessage(async (event) => {
+      const message: unknown = event.message;
+      if (!isRendererToExtensionMessage(message)) {
+        log.warn(
+          "Learning: discarding malformed message from the notebook renderer.",
+        );
+        return;
+      }
+
+      try {
+        await handleAction(service, message.actionId, {
+          ...message.context,
+        });
+      } catch (e) {
+        log.error(`Learning: renderer message "${message.type}" failed`, e);
+      }
+    }),
+  );
+}
+
+async function handleAction(
+  service: LearningService,
+  actionId: CopilotActionId,
+  context: Record<string, string>,
+): Promise<void> {
+  // The learner may open a course notebook before anything has started the
+  // learning experience. Initialize first — the same thing the "continue"
+  // command does — so the button never silently does nothing.
+  if (!service.initialized) {
+    await service.tryInitialize({ createIfMissing: true });
+  }
+
+  if (
+    !service.initialized ||
+    !isNotebookCourse(service.getActiveCourseInfo())
+  ) {
+    log.warn(
+      "Learning: ignoring a renderer action outside an active notebook course.",
+    );
+    return;
+  }
+
+  await openChat(buildQuery(actionId, context));
+}
+
+/**
+ * Prompt templates, owned by the extension.
+ *
+ * These stay as short as the queries the cell status bar sends
+ * ("/qdk-learning Give me a hint"). The `qdk-learning-*` language model tools
+ * already report the learner's position, progress and code on every
+ * invocation, so a long prompt would be restating what the agent can look up.
+ * The question and the chosen option are the exception: a quiz is not an
+ * activity, so nothing the tools can read says which of a unit's questions
+ * was answered or what was picked.
+ */
+function buildQuery(
+  actionId: CopilotActionId,
+  context: Record<string, string>,
+): string {
+  const choice = sanitize(context.choice);
+  const question = sanitize(context.question);
+
+  switch (actionId) {
+    case "why-wrong":
+      if (question && choice) {
+        return `/qdk-learning I answered "${choice}" to: ${question} — why is that wrong?`;
+      }
+      return choice
+        ? `/qdk-learning I picked "${choice}" and it was marked wrong. Why?`
+        : `/qdk-learning I got this question wrong. Why?`;
+  }
+}
+
+async function openChat(query: string): Promise<void> {
+  // No position move here. A quiz cell is deliberately not an activity, so
+  // there is nothing for `goToActivityByCellId` to find — the payload's
+  // `cellId` is the quiz's own id, not an ipynb cell id. The question and the
+  // chosen option travel in the query instead.
+
+  await vscode.commands.executeCommand("workbench.action.chat.open", {
+    query,
+    isPartialQuery: false,
+  });
+}
+
+/** Longest run of renderer-supplied text we'll splice into a chat prompt. */
+const MAX_CONTEXT_CHARS = 300;
+
+/**
+ * Flatten renderer-supplied text so it can sit inside a quoted prompt template.
+ *
+ * Control characters, line separators and newlines are folded to spaces so the
+ * text can't break out of its sentence and read as a fresh instruction, double
+ * quotes become single quotes so they can't close the quoted span, and the
+ * result is truncated. This is defence in depth: the values are authored by the
+ * course or chosen by the learner, but they still reach a language model.
+ */
+function sanitize(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  let flattened = "";
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    const isControl =
+      code < 0x20 ||
+      (code >= 0x7f && code <= 0x9f) ||
+      code === 0x2028 ||
+      code === 0x2029;
+
+    if (isControl) {
+      flattened += " ";
+    } else if (char === '"') {
+      flattened += "'";
+    } else {
+      flattened += char;
+    }
+  }
+
+  const collapsed = flattened.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) {
+    return undefined;
+  }
+
+  return collapsed.length > MAX_CONTEXT_CHARS
+    ? `${collapsed.slice(0, MAX_CONTEXT_CHARS - 1)}\u2026`
+    : collapsed;
+}

--- a/source/vscode/src/learning/notebookRendererMessaging.ts
+++ b/source/vscode/src/learning/notebookRendererMessaging.ts
@@ -3,7 +3,6 @@
 
 import { log } from "qsharp-lang";
 import * as vscode from "vscode";
-import { isNotebookCourse } from "./courseLayout.js";
 import type { CopilotActionId } from "../notebookRenderer/schema.js";
 import {
   isRendererToExtensionMessage,
@@ -16,9 +15,10 @@ import type { LearningService } from "./service.js";
  *
  * A renderer webview can't execute VS Code commands, so `createRendererMessaging`
  * is the channel out. Everything arriving here is authored notebook content and
- * therefore untrusted: the renderer may only name an action id from a fixed
- * allowlist, never a prompt or command id, and any free text it contributes is
- * sanitized into an extension-owned template.
+ * therefore untrusted: the renderer may name an action id from a fixed
+ * allowlist and a quiz id of a fixed shape, and nothing else. No prose from a
+ * notebook reaches a prompt, because no amount of escaping stops a sentence
+ * from reading as an instruction.
  */
 export function registerNotebookRendererMessaging(
   context: vscode.ExtensionContext,
@@ -37,39 +37,35 @@ export function registerNotebookRendererMessaging(
       }
 
       try {
-        await handleAction(service, message.actionId, {
-          ...message.context,
-        });
+        // Detect only — never `createIfMissing`. This runs on a message a
+        // notebook asked for, and `notebookSync.ts` already sets the rule: a
+        // notebook-driven event must not materialize a learning workspace
+        // behind the learner's back. Authorizing the sender needs a loaded
+        // course, so an unstarted workspace simply means "not trusted".
+        if (!service.initialized) {
+          await service.tryInitialize();
+        }
+
+        // Any notebook can carry an output of this MIME type, so a message is
+        // only as trustworthy as the file it came from. This is the whole
+        // authorization: a workbook this workspace materialized is a course
+        // file whichever course the learner last navigated to.
+        if (
+          !service.initialized ||
+          !service.isCourseWorkbookUri(event.editor.notebook.uri)
+        ) {
+          log.warn(
+            "Learning: ignoring a renderer message from a notebook this workspace did not create.",
+          );
+          return;
+        }
+
+        await openChat(buildQuery(message.actionId, message.quizId));
       } catch (e) {
         log.error(`Learning: renderer message "${message.type}" failed`, e);
       }
     }),
   );
-}
-
-async function handleAction(
-  service: LearningService,
-  actionId: CopilotActionId,
-  context: Record<string, string>,
-): Promise<void> {
-  // The learner may open a course notebook before anything has started the
-  // learning experience. Initialize first — the same thing the "continue"
-  // command does — so the button never silently does nothing.
-  if (!service.initialized) {
-    await service.tryInitialize({ createIfMissing: true });
-  }
-
-  if (
-    !service.initialized ||
-    !isNotebookCourse(service.getActiveCourseInfo())
-  ) {
-    log.warn(
-      "Learning: ignoring a renderer action outside an active notebook course.",
-    );
-    return;
-  }
-
-  await openChat(buildQuery(actionId, context));
 }
 
 /**
@@ -79,81 +75,29 @@ async function handleAction(
  * ("/qdk-learning Give me a hint"). The `qdk-learning-*` language model tools
  * already report the learner's position, progress and code on every
  * invocation, so a long prompt would be restating what the agent can look up.
- * The question and the chosen option are the exception: a quiz is not an
- * activity, so nothing the tools can read says which of a unit's questions
- * was answered or what was picked.
+ *
+ * Nothing the renderer wrote is quoted here. An earlier version spliced in the
+ * question and the chosen option, which are notebook content and therefore
+ * attacker-supplied prose in a file that only has to sit at a workbook's path.
+ * The quiz id is enough for the agent to find the question in the open
+ * notebook, and its shape leaves no room for an instruction.
  */
-function buildQuery(
-  actionId: CopilotActionId,
-  context: Record<string, string>,
-): string {
-  const choice = sanitize(context.choice);
-  const question = sanitize(context.question);
-
+function buildQuery(actionId: CopilotActionId, quizId?: string): string {
   switch (actionId) {
     case "why-wrong":
-      if (question && choice) {
-        return `/qdk-learning I answered "${choice}" to: ${question} — why is that wrong?`;
-      }
-      return choice
-        ? `/qdk-learning I picked "${choice}" and it was marked wrong. Why?`
+      return quizId
+        ? `/qdk-learning I answered the quiz "${quizId}" in this notebook incorrectly. Why is my answer wrong?`
         : `/qdk-learning I got this question wrong. Why?`;
   }
 }
 
 async function openChat(query: string): Promise<void> {
   // No position move here. A quiz cell is deliberately not an activity, so
-  // there is nothing for `goToActivityByCellId` to find — the payload's
-  // `cellId` is the quiz's own id, not an ipynb cell id. The question and the
-  // chosen option travel in the query instead.
+  // there is nothing for `goToActivityByCellId` to find — the payload's quiz
+  // id is the quiz's own id, not an ipynb cell id.
 
   await vscode.commands.executeCommand("workbench.action.chat.open", {
     query,
     isPartialQuery: false,
   });
-}
-
-/** Longest run of renderer-supplied text we'll splice into a chat prompt. */
-const MAX_CONTEXT_CHARS = 300;
-
-/**
- * Flatten renderer-supplied text so it can sit inside a quoted prompt template.
- *
- * Control characters, line separators and newlines are folded to spaces so the
- * text can't break out of its sentence and read as a fresh instruction, double
- * quotes become single quotes so they can't close the quoted span, and the
- * result is truncated. This is defence in depth: the values are authored by the
- * course or chosen by the learner, but they still reach a language model.
- */
-function sanitize(value: string | undefined): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  let flattened = "";
-  for (const char of value) {
-    const code = char.codePointAt(0) ?? 0;
-    const isControl =
-      code < 0x20 ||
-      (code >= 0x7f && code <= 0x9f) ||
-      code === 0x2028 ||
-      code === 0x2029;
-
-    if (isControl) {
-      flattened += " ";
-    } else if (char === '"') {
-      flattened += "'";
-    } else {
-      flattened += char;
-    }
-  }
-
-  const collapsed = flattened.replace(/\s+/g, " ").trim();
-  if (collapsed.length === 0) {
-    return undefined;
-  }
-
-  return collapsed.length > MAX_CONTEXT_CHARS
-    ? `${collapsed.slice(0, MAX_CONTEXT_CHARS - 1)}\u2026`
-    : collapsed;
 }

--- a/source/vscode/src/learning/service.ts
+++ b/source/vscode/src/learning/service.ts
@@ -655,6 +655,35 @@ export class LearningService {
     return { id: course.id, title: course.title, kind: course.kind };
   }
 
+  /**
+   * True when `uri` is a workbook this workspace materialized for a learner.
+   *
+   * Notebook output runs in a webview, and any notebook can claim a MIME type,
+   * so a message arriving from one is only as trustworthy as the file it came
+   * from. Comparing against each unit's workbook URI rather than matching the
+   * `.workbook.ipynb` suffix means a lookalike opened from elsewhere does not
+   * pass.
+   *
+   * Every known course is searched, not just the active one: which course is
+   * active is a matter of where the learner navigated last, and a workbook
+   * open in front of them is theirs either way. Narrowing to the active course
+   * would drop valid actions whenever the two disagree.
+   */
+  isCourseWorkbookUri(uri: vscode.Uri): boolean {
+    const target = uri.toString();
+    for (const course of this.requireWorkspace().courses.values()) {
+      if (!isNotebookCourse(course)) {
+        continue;
+      }
+      if (
+        course.units.some((unit) => workbookUri(unit).toString() === target)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** True once the user has explicitly picked a course. */
   hasUserSelectedCourse(): boolean {
     const ws = this.workspace;

--- a/source/vscode/src/notebookRenderer/css.d.ts
+++ b/source/vscode/src/notebookRenderer/css.d.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * The renderer build loads `.css` with esbuild's `text` loader (see the
+ * `renderer` target in `build.mjs`), so a CSS import yields the stylesheet
+ * source as a string for us to inject.
+ */
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/source/vscode/src/notebookRenderer/index.ts
+++ b/source/vscode/src/notebookRenderer/index.ts
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+  ActivationFunction,
+  OutputItem,
+  RendererContext,
+} from "vscode-notebook-renderer";
+import { renderMultipleChoice } from "./multipleChoice.js";
+import type { LearningPayload, RendererToExtensionMessage } from "./schema.js";
+import {
+  isRecord,
+  isRendererToExtensionMessage,
+  MIME_TYPE,
+  RENDERER_ID,
+} from "./schema.js";
+// Bundled as text by the renderer build so the styles can be injected here —
+// VS Code loads the renderer as a lone JS module and won't fetch a sibling
+// stylesheet. `qdk-theme.css` supplies the shared `--qdk-*` palette and must
+// come first so our rules can build on it.
+import themeCss from "../../../npm/qsharp/ux/qdk-theme.css";
+import rendererCss from "./styles.css";
+
+const STYLE_ELEMENT_ID = "qdk-learning-renderer-styles";
+
+/** Add the stylesheet to the output webview once per document. */
+function ensureStyles() {
+  if (document.getElementById(STYLE_ELEMENT_ID)) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.id = STYLE_ELEMENT_ID;
+  style.textContent = `${themeCss}\n${rendererCss}`;
+  document.head.appendChild(style);
+}
+
+type Cleanup = () => void;
+
+const cleanupByOutputId = new Map<string, Cleanup>();
+const cleanupByElement = new WeakMap<HTMLElement, Cleanup>();
+
+export const activate: ActivationFunction<void> = (
+  context: RendererContext<void>,
+) => {
+  const postAction = (message: RendererToExtensionMessage) => {
+    if (
+      context.postMessage === undefined ||
+      !isRendererToExtensionMessage(message)
+    ) {
+      return false;
+    }
+
+    void context.postMessage(message);
+    return true;
+  };
+
+  return {
+    renderOutputItem(outputItem: OutputItem, element: HTMLElement) {
+      ensureStyles();
+      cleanupOutput(outputItem.id);
+      cleanupElement(element);
+      element.replaceChildren();
+
+      const disposables: Cleanup[] = [];
+      const cleanup = () => {
+        for (const dispose of disposables.splice(0)) {
+          dispose();
+        }
+        if (cleanupByElement.get(element) === cleanup) {
+          element.replaceChildren();
+          cleanupByElement.delete(element);
+        }
+        cleanupByOutputId.delete(outputItem.id);
+      };
+
+      cleanupByOutputId.set(outputItem.id, cleanup);
+      cleanupByElement.set(element, cleanup);
+
+      try {
+        const payload = readPayload(outputItem);
+        switch (payload.kind) {
+          case "multiple-choice":
+            renderMultipleChoice(payload, element, {
+              postAction,
+              addDisposable: (dispose) => disposables.push(dispose),
+            });
+            break;
+        }
+      } catch (error) {
+        cleanup();
+        renderError(element, error);
+      }
+    },
+    disposeOutputItem(id?: string) {
+      // VS Code calls this with no id for "Clear All Outputs", so treating
+      // the parameter as required would leak every listener in the document.
+      if (id === undefined) {
+        for (const cleanup of [...cleanupByOutputId.values()]) {
+          cleanup();
+        }
+        return;
+      }
+      cleanupOutput(id);
+    },
+  };
+};
+
+function readPayload(outputItem: OutputItem): LearningPayload {
+  if (outputItem.mime !== MIME_TYPE) {
+    throw new Error(`Unsupported MIME type: ${outputItem.mime}`);
+  }
+
+  const value: unknown = outputItem.json();
+  if (!isRecord(value)) {
+    throw new Error("Expected a QDK learning payload object.");
+  }
+
+  const payload = value;
+
+  // Say which side is ahead. A notebook can outlive the extension that wrote
+  // it, and "update the QDK extension" is a far more useful thing to read in a
+  // cell than a generic parse failure.
+  if (payload.schemaVersion !== SUPPORTED_SCHEMA_VERSION) {
+    throw new Error(
+      `This output uses QDK learning payload version ${String(payload.schemaVersion)}, ` +
+        `but this renderer supports version ${SUPPORTED_SCHEMA_VERSION}. ` +
+        "Update the QDK extension to view it.",
+    );
+  }
+
+  if (!isSupportedKind(payload.kind)) {
+    throw new Error(
+      `Unknown QDK learning output kind "${String(payload.kind)}". ` +
+        `This renderer knows: ${SUPPORTED_KINDS.join(", ")}.`,
+    );
+  }
+
+  if (payload.cellId !== undefined && typeof payload.cellId !== "string") {
+    throw new Error("QDK learning payload has a non-string cellId.");
+  }
+
+  return payload as unknown as LearningPayload;
+}
+
+/** The only payload version this renderer understands. */
+const SUPPORTED_SCHEMA_VERSION = 1;
+
+const SUPPORTED_KINDS = ["multiple-choice"] as const;
+
+function isSupportedKind(
+  kind: unknown,
+): kind is (typeof SUPPORTED_KINDS)[number] {
+  return (
+    typeof kind === "string" &&
+    SUPPORTED_KINDS.includes(kind as (typeof SUPPORTED_KINDS)[number])
+  );
+}
+
+function cleanupOutput(id: string) {
+  cleanupByOutputId.get(id)?.();
+}
+
+function cleanupElement(element: HTMLElement) {
+  cleanupByElement.get(element)?.();
+}
+
+function renderError(element: HTMLElement, error: unknown) {
+  const root = document.createElement("section");
+  root.className = "qdk-learning qdk-learning-error";
+  root.dataset.rendererId = RENDERER_ID;
+
+  const title = document.createElement("strong");
+  title.textContent = "Unable to render QDK learning output.";
+  const details = document.createElement("pre");
+  details.textContent = error instanceof Error ? error.message : String(error);
+
+  root.append(title, details);
+  element.replaceChildren(root);
+}

--- a/source/vscode/src/notebookRenderer/index.ts
+++ b/source/vscode/src/notebookRenderer/index.ts
@@ -44,14 +44,22 @@ export const activate: ActivationFunction<void> = (
   context: RendererContext<void>,
 ) => {
   const postAction = (message: RendererToExtensionMessage) => {
-    if (
-      context.postMessage === undefined ||
-      !isRendererToExtensionMessage(message)
-    ) {
+    if (context.postMessage === undefined) {
+      // No extension host — an exported HTML page, say.
       return false;
     }
 
-    void context.postMessage(message);
+    // Built here, but from payload values, so this is where a quiz id that
+    // would not survive the host's check is dropped. Sending the action
+    // without it still opens chat; sending it whole would be ignored.
+    const { actionId } = message;
+    const safe: RendererToExtensionMessage = isRendererToExtensionMessage(
+      message,
+    )
+      ? message
+      : { type: "qdk-learning/action", rendererId: RENDERER_ID, actionId };
+
+    void context.postMessage(safe);
     return true;
   };
 
@@ -140,7 +148,106 @@ function readPayload(outputItem: OutputItem): LearningPayload {
     throw new Error("QDK learning payload has a non-string cellId.");
   }
 
+  // Per-kind checks stay behind the kind test: a second payload kind must not
+  // have to satisfy the multiple-choice shape.
+  switch (payload.kind) {
+    case "multiple-choice":
+      assertMultipleChoice(payload);
+      break;
+  }
+
   return payload as unknown as LearningPayload;
+}
+
+/**
+ * Check the fields the question is actually drawn and graded from.
+ *
+ * Version and kind only describe the envelope. Without this a payload that
+ * survived a hand edit could set `correct: "false"`, which is a non-empty
+ * string and therefore truthy, and a wrong option would be marked right — so
+ * these are checked before anything is rendered rather than trusted.
+ */
+function assertMultipleChoice(payload: Record<string, unknown>): void {
+  if (typeof payload.prompt !== "string" || payload.prompt.length === 0) {
+    throw new Error("QDK learning payload has no question text.");
+  }
+
+  if (
+    payload.multiSelect !== undefined &&
+    typeof payload.multiSelect !== "boolean"
+  ) {
+    throw new Error("QDK learning payload has a non-boolean multiSelect.");
+  }
+
+  if (!Array.isArray(payload.options) || payload.options.length === 0) {
+    throw new Error("QDK learning payload has no options.");
+  }
+
+  const ids = new Set<string>();
+  for (const option of payload.options) {
+    if (!isRecord(option)) {
+      throw new Error("QDK learning payload has a malformed option.");
+    }
+    if (typeof option.id !== "string" || option.id.length === 0) {
+      throw new Error("QDK learning payload has an option with no id.");
+    }
+    if (ids.has(option.id)) {
+      throw new Error(
+        `QDK learning payload reuses the option id "${option.id}".`,
+      );
+    }
+    ids.add(option.id);
+
+    if (typeof option.text !== "string" || option.text.length === 0) {
+      throw new Error(
+        `QDK learning option "${option.id}" has no text to show.`,
+      );
+    }
+    if (typeof option.correct !== "boolean") {
+      throw new Error(
+        `QDK learning option "${option.id}" does not say whether it is correct.`,
+      );
+    }
+    if (
+      option.explanation !== undefined &&
+      typeof option.explanation !== "string"
+    ) {
+      throw new Error(
+        `QDK learning option "${option.id}" has a non-string explanation.`,
+      );
+    }
+  }
+
+  // Cardinality mirrors `_normalize_options` in `_learning_output.py`: the two
+  // sides describe the same payload, and a notebook can outlive — or bypass —
+  // the emitter that wrote it.
+  const correct = payload.options.filter(
+    (option) => (option as { correct: boolean }).correct,
+  ).length;
+
+  if (correct === 0) {
+    throw new Error("QDK learning payload has no correct option.");
+  }
+
+  if (payload.multiSelect === true) {
+    if (correct < 2) {
+      throw new Error(
+        "QDK learning payload says select all that apply but marks one option correct.",
+      );
+    }
+    if (correct === payload.options.length) {
+      throw new Error(
+        "QDK learning payload marks every option correct, so it cannot be answered wrongly.",
+      );
+    }
+  } else if (correct > 1) {
+    // Grading compares the selected set with the correct set, and a radio
+    // group holds one selection, so this question could never be answered
+    // right. Refusing to draw it beats showing an unwinnable one.
+    throw new Error(
+      `QDK learning payload marks ${correct} options correct but is not multi-select.`,
+    );
+  }
 }
 
 /** The only payload version this renderer understands. */
@@ -168,7 +275,6 @@ function cleanupElement(element: HTMLElement) {
 function renderError(element: HTMLElement, error: unknown) {
   const root = document.createElement("section");
   root.className = "qdk-learning qdk-learning-error";
-  root.dataset.rendererId = RENDERER_ID;
 
   const title = document.createElement("strong");
   title.textContent = "Unable to render QDK learning output.";

--- a/source/vscode/src/notebookRenderer/multipleChoice.ts
+++ b/source/vscode/src/notebookRenderer/multipleChoice.ts
@@ -1,0 +1,354 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { MultipleChoicePayload } from "./schema.js";
+import { RENDERER_ID } from "./schema.js";
+import {
+  appendRichTextElement,
+  appendTextElement,
+  createActionButton,
+  setLiveRegion,
+  type RenderContext,
+} from "./rendering.js";
+
+let groupId = 0;
+
+export function renderMultipleChoice(
+  payload: MultipleChoicePayload,
+  element: HTMLElement,
+  context: RenderContext,
+): void {
+  const root = document.createElement("section");
+  root.className = "qdk-learning qdk-learning-card";
+
+  // The band the chemistry course already uses to mark a self-check question,
+  // so an interactive question reads as the same thing the collapsible ones
+  // were. Decorative: the legend below carries the question for a reader.
+  const header = document.createElement("div");
+  header.className = "qdk-learning-quiz-header";
+  const mark = appendTextElement(
+    header,
+    "span",
+    "qdk-learning-quiz-mark",
+    "\u2753",
+  );
+  mark.setAttribute("aria-hidden", "true");
+  appendTextElement(
+    header,
+    "span",
+    "qdk-learning-quiz-label",
+    "Check your understanding",
+  );
+  root.appendChild(header);
+
+  // Fieldset/legend keeps the answer controls grouped for screen readers.
+  const fieldset = document.createElement("fieldset");
+  fieldset.className = "qdk-learning-options";
+  const legend = document.createElement("legend");
+  legend.className = "qdk-learning-prompt";
+  appendRichTextElement(legend, "span", "", payload.prompt);
+
+  // Said out loud, and inside the legend so a screen reader hears it with the
+  // question rather than after it. A learner who assumes one answer would stop
+  // at the first correct option and be marked wrong for a question they
+  // actually understood.
+  if (payload.multiSelect) {
+    appendTextElement(
+      legend,
+      "span",
+      "qdk-learning-prompt-hint",
+      "Select all that apply.",
+    );
+  }
+  fieldset.appendChild(legend);
+
+  const feedback = appendTextElement(root, "p", "qdk-learning-feedback", "");
+  feedback.hidden = true;
+  setLiveRegion(feedback);
+
+  const controls = document.createElement("div");
+  controls.className = "qdk-learning-controls";
+
+  const actionList = document.createElement("div");
+  actionList.className = "qdk-learning-action-list";
+  actionList.hidden = true;
+
+  // Include the cell id when available, plus a counter to avoid cross-output
+  // radio grouping even if a notebook renders duplicate cell ids.
+  const groupName = `qdk-learning-${payload.cellId ?? "output"}-${groupId++}`;
+  const optionViews: OptionView[] = [];
+  for (const [index, option] of payload.options.entries()) {
+    const letter = optionLetter(index);
+    const label = document.createElement("label");
+    label.className = "qdk-learning-option";
+
+    const input = document.createElement("input");
+    input.type = payload.multiSelect ? "checkbox" : "radio";
+    input.name = groupName;
+    input.value = option.id;
+
+    // Selecting never grades. Arrow keys move between radios and fire
+    // `change`, so grading here would submit whichever option a keyboard
+    // user landed on first and disable the rest of the group.
+    const onChange = () => {
+      syncSelectedStates();
+      updateCheckButton();
+    };
+    input.addEventListener("change", onChange);
+    context.addDisposable(() => input.removeEventListener("change", onChange));
+
+    const badge = document.createElement("span");
+    badge.className = "qdk-learning-option-badge";
+    badge.setAttribute("aria-hidden", "true");
+    badge.textContent = letter;
+
+    const verdict = document.createElement("span");
+    verdict.className = "qdk-learning-verdict qdk-learning-sr-only";
+
+    const body = document.createElement("span");
+    body.className = "qdk-learning-option-body";
+
+    appendRichTextElement(
+      body,
+      "span",
+      "qdk-learning-option-text",
+      option.text,
+    );
+
+    label.append(input, badge, body, verdict);
+    fieldset.appendChild(label);
+    optionViews.push({ option, input, label, badge, verdict, body, letter });
+  }
+
+  const checkButton = document.createElement("button");
+  checkButton.type = "button";
+  checkButton.textContent = "Check answer";
+  checkButton.disabled = true;
+  const onCheck = () => evaluateAnswer();
+  checkButton.addEventListener("click", onCheck);
+  context.addDisposable(() =>
+    checkButton.removeEventListener("click", onCheck),
+  );
+
+  const tryAgainButton = document.createElement("button");
+  tryAgainButton.type = "button";
+  tryAgainButton.textContent = "Try again";
+  const onTryAgain = () => resetAnswer();
+  tryAgainButton.addEventListener("click", onTryAgain);
+  context.addDisposable(() =>
+    tryAgainButton.removeEventListener("click", onTryAgain),
+  );
+
+  // Built once, not per grading: a learner can cycle Check/Try again any number
+  // of times, and creating a fresh button each time would retain a detached
+  // node and its listener for the life of the output.
+  let lastSelectedIds = new Set<string>();
+  const whyWrongButton = createActionButton("Why is that wrong?");
+  const onWhyWrong = () => {
+    const posted = context.postAction({
+      type: "qdk-learning/action",
+      rendererId: RENDERER_ID,
+      actionId: "why-wrong",
+      cellId: payload.cellId,
+      context: {
+        question: payload.prompt,
+        choice: optionViews
+          .filter((view) => lastSelectedIds.has(view.option.id))
+          .map((view) => view.option.text)
+          .join("; "),
+      },
+    });
+
+    if (!posted) {
+      // Exported HTML has no extension channel, so replace the inert action.
+      appendActionUnavailableNote(actionList);
+    }
+  };
+  whyWrongButton.addEventListener("click", onWhyWrong);
+  context.addDisposable(() =>
+    whyWrongButton.removeEventListener("click", onWhyWrong),
+  );
+
+  controls.appendChild(checkButton);
+
+  root.append(fieldset, feedback, controls, actionList);
+  element.appendChild(root);
+
+  function evaluateAnswer(): void {
+    const selectedIds = new Set(
+      optionViews
+        .filter((view) => view.input.checked)
+        .map((view) => view.option.id),
+    );
+    const isCorrect = optionViews.every(
+      (view) => selectedIds.has(view.option.id) === view.option.correct,
+    );
+
+    for (const view of optionViews) {
+      const selected = selectedIds.has(view.option.id);
+      view.label.dataset.selected = selected ? "true" : "false";
+      if (selected && view.option.correct) {
+        setOptionState(view, "correct");
+      } else if (selected) {
+        setOptionState(view, "incorrect");
+      } else if (view.option.correct) {
+        setOptionState(view, "missed");
+      }
+
+      if (view.option.explanation !== undefined) {
+        appendRichTextElement(
+          view.body,
+          "span",
+          "qdk-learning-option-why",
+          view.option.explanation,
+        );
+      }
+      view.input.disabled = true;
+    }
+
+    feedback.hidden = false;
+    feedback.dataset.state = isCorrect ? "correct" : "incorrect";
+    feedback.textContent = isCorrect
+      ? "Correct!"
+      : incorrectMessage(selectedIds);
+
+    controls.replaceChildren(tryAgainButton);
+    actionList.replaceChildren();
+    actionList.hidden = true;
+
+    if (!isCorrect) {
+      showWhyWrongAction(selectedIds);
+    }
+
+    // Grading replaced the focused Check button, which would drop focus to the
+    // document. Move it to the control that took its place.
+    tryAgainButton.focus();
+  }
+
+  function resetAnswer(): void {
+    for (const view of optionViews) {
+      view.input.checked = false;
+      view.input.disabled = false;
+      delete view.label.dataset.state;
+      delete view.label.dataset.selected;
+      view.badge.textContent = view.letter;
+      view.verdict.textContent = "";
+      for (const why of Array.from(
+        view.body.querySelectorAll(".qdk-learning-option-why"),
+      )) {
+        why.remove();
+      }
+    }
+    feedback.hidden = true;
+    feedback.textContent = "";
+    delete feedback.dataset.state;
+    actionList.replaceChildren();
+    actionList.hidden = true;
+    checkButton.disabled = true;
+    controls.replaceChildren(checkButton);
+
+    // Retrying detaches the Try again button, which is the element the learner
+    // just activated, so focus would fall to the document. Send it to the first
+    // answer instead: `Check answer` was disabled a line ago and a disabled
+    // control cannot take focus, and the first option is where a retry starts
+    // anyway. `:focus-within` paints the row, so the position stays visible.
+    optionViews[0]?.input.focus();
+  }
+
+  function updateCheckButton(): void {
+    checkButton.disabled = !optionViews.some((view) => view.input.checked);
+  }
+
+  /**
+   * Say *how* the answer was wrong.
+   *
+   * On a multi-select, "having the right idea but missing one" and "picking a
+   * wrong one" are different mistakes and deserve different nudges. On a
+   * single-select there is only ever one way to be wrong, so the generic line
+   * is the honest one.
+   */
+  function incorrectMessage(selectedIds: Set<string>): string {
+    if (!payload.multiSelect) {
+      return "Not quite. Review the marked choices, then try again.";
+    }
+
+    const missed = optionViews.filter(
+      (view) => view.option.correct && !selectedIds.has(view.option.id),
+    ).length;
+    const wrong = optionViews.filter(
+      (view) => !view.option.correct && selectedIds.has(view.option.id),
+    ).length;
+
+    if (missed > 0 && wrong === 0) {
+      return missed === 1
+        ? "Close — everything you picked is right, but one more applies."
+        : `Close — everything you picked is right, but ${missed} more apply.`;
+    }
+    if (wrong > 0 && missed === 0) {
+      return wrong === 1
+        ? "Not quite — you found them all, but one choice doesn't apply."
+        : `Not quite — you found them all, but ${wrong} choices don't apply.`;
+    }
+    return "Not quite. Review the marked choices, then try again.";
+  }
+
+  function syncSelectedStates(): void {
+    for (const view of optionViews) {
+      view.label.dataset.selected = view.input.checked ? "true" : "false";
+    }
+  }
+
+  function showWhyWrongAction(selectedIds: Set<string>): void {
+    lastSelectedIds = selectedIds;
+    actionList.hidden = false;
+    actionList.replaceChildren(whyWrongButton);
+  }
+}
+
+type OptionView = {
+  option: MultipleChoicePayload["options"][number];
+  input: HTMLInputElement;
+  label: HTMLLabelElement;
+  badge: HTMLSpanElement;
+  verdict: HTMLSpanElement;
+  body: HTMLSpanElement;
+  letter: string;
+};
+
+type OptionState = "correct" | "incorrect" | "missed";
+
+function setOptionState(view: OptionView, state: OptionState): void {
+  view.label.dataset.state = state;
+  view.badge.textContent =
+    state === "correct"
+      ? "\u2713"
+      : state === "incorrect"
+        ? "\u2717"
+        : "\u2022";
+  view.verdict.textContent =
+    state === "correct"
+      ? "Correct choice"
+      : state === "incorrect"
+        ? "Incorrect choice"
+        : "Missed correct choice";
+}
+
+/**
+ * A, B, C… for the option badges.
+ *
+ * Wraps back to A past 26 rather than carrying into AA: a question with that
+ * many options is an authoring problem, not a labelling one.
+ */
+function optionLetter(index: number): string {
+  return String.fromCharCode(65 + (index % 26));
+}
+
+function appendActionUnavailableNote(parent: HTMLElement): void {
+  parent.replaceChildren();
+  appendTextElement(
+    parent,
+    "span",
+    "qdk-learning-action-note",
+    "This Copilot action is only available in VS Code.",
+  );
+}

--- a/source/vscode/src/notebookRenderer/multipleChoice.ts
+++ b/source/vscode/src/notebookRenderer/multipleChoice.ts
@@ -142,21 +142,15 @@ export function renderMultipleChoice(
   // Built once, not per grading: a learner can cycle Check/Try again any number
   // of times, and creating a fresh button each time would retain a detached
   // node and its listener for the life of the output.
-  let lastSelectedIds = new Set<string>();
   const whyWrongButton = createActionButton("Why is that wrong?");
   const onWhyWrong = () => {
+    // Only the quiz id crosses. The question and the chosen option are
+    // notebook content, and prose from a notebook must not reach a prompt.
     const posted = context.postAction({
       type: "qdk-learning/action",
       rendererId: RENDERER_ID,
       actionId: "why-wrong",
-      cellId: payload.cellId,
-      context: {
-        question: payload.prompt,
-        choice: optionViews
-          .filter((view) => lastSelectedIds.has(view.option.id))
-          .map((view) => view.option.text)
-          .join("; "),
-      },
+      quizId: payload.cellId,
     });
 
     if (!posted) {
@@ -217,7 +211,7 @@ export function renderMultipleChoice(
     actionList.hidden = true;
 
     if (!isCorrect) {
-      showWhyWrongAction(selectedIds);
+      showWhyWrongAction();
     }
 
     // Grading replaced the focused Check button, which would drop focus to the
@@ -298,8 +292,7 @@ export function renderMultipleChoice(
     }
   }
 
-  function showWhyWrongAction(selectedIds: Set<string>): void {
-    lastSelectedIds = selectedIds;
+  function showWhyWrongAction(): void {
     actionList.hidden = false;
     actionList.replaceChildren(whyWrongButton);
   }

--- a/source/vscode/src/notebookRenderer/rendererApi.d.ts
+++ b/source/vscode/src/notebookRenderer/rendererApi.d.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+declare module "vscode-notebook-renderer" {
+  export interface RendererContext<TState> {
+    readonly workspaceState: TState;
+    postMessage?(message: unknown): void | PromiseLike<boolean>;
+  }
+
+  export interface OutputItem {
+    readonly id: string;
+    readonly mime: string;
+    readonly data: Uint8Array;
+    readonly metadata?: Record<string, unknown>;
+    json(): unknown;
+    text(): string;
+    blob(): Blob;
+  }
+
+  export type ActivationFunction<TState> = (
+    context: RendererContext<TState>,
+  ) => {
+    renderOutputItem(
+      outputItem: OutputItem,
+      element: HTMLElement,
+    ): void | Promise<void>;
+    /** Called with no id when the host clears every output in the document. */
+    disposeOutputItem(id?: string): void;
+  };
+}

--- a/source/vscode/src/notebookRenderer/rendering.ts
+++ b/source/vscode/src/notebookRenderer/rendering.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { RendererToExtensionMessage } from "./schema.js";
+
+export type PostAction = (message: RendererToExtensionMessage) => boolean;
+
+export type RenderContext = {
+  postAction: PostAction;
+  addDisposable(dispose: () => void): void;
+};
+
+export function appendTextElement(
+  parent: HTMLElement,
+  tagName: keyof HTMLElementTagNameMap,
+  className: string,
+  text: string,
+): HTMLElement {
+  const element = document.createElement(tagName);
+  element.className = className;
+  element.textContent = text;
+  parent.appendChild(element);
+  return element;
+}
+
+/**
+ * Like {@link appendTextElement}, but renders `backtick` spans as inline code.
+ *
+ * Course prose is authored in Markdown, so prompts and answer options routinely
+ * name APIs as `circuit(...)`. Rendering those as literal backticks looks like
+ * a bug. This deliberately is NOT a Markdown parser: it only splits on
+ * backticks and builds `<code>` nodes with `textContent`, so author text is
+ * never interpreted as HTML.
+ */
+export function appendRichTextElement(
+  parent: HTMLElement,
+  tagName: keyof HTMLElementTagNameMap,
+  className: string,
+  text: string,
+): HTMLElement {
+  const element = document.createElement(tagName);
+  element.className = className;
+  appendInlineText(element, text);
+  parent.appendChild(element);
+  return element;
+}
+
+function appendInlineText(parent: HTMLElement, text: string): void {
+  const parts = text.split("`");
+
+  // An even number of parts means an unbalanced backtick. Treat the whole
+  // string as plain text rather than guessing where the code span ends.
+  if (parts.length % 2 === 0) {
+    parent.appendChild(document.createTextNode(text));
+    return;
+  }
+
+  parts.forEach((part, index) => {
+    if (part.length === 0) {
+      return;
+    }
+    if (index % 2 === 1) {
+      const code = document.createElement("code");
+      code.textContent = part;
+      parent.appendChild(code);
+    } else {
+      parent.appendChild(document.createTextNode(part));
+    }
+  });
+}
+
+/**
+ * Build a Copilot action button.
+ *
+ * The sparkle mark and the `--vscode-button-*` colors are deliberate: this is
+ * the same affordance as the "Ask for a Hint" item in the cell status bar, so
+ * it should read as the same control even though it lives in cell output.
+ */
+export function createActionButton(label: string): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "qdk-learning-action";
+  button.appendChild(createSparkleIcon());
+  button.appendChild(document.createTextNode(label));
+  return button;
+}
+
+function createSparkleIcon(): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 16 16");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("focusable", "false");
+
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute("d", SPARKLE_PATH);
+  svg.appendChild(path);
+  return svg;
+}
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/** A large four-point star with a smaller companion, matching the codicon. */
+const SPARKLE_PATH =
+  "M9.5 1.5 11 5.2 14.7 6.7 11 8.2 9.5 11.9 8 8.2 4.3 6.7 8 5.2 Z " +
+  "M4 9.6 4.8 11.5 6.7 12.3 4.8 13.1 4 15 3.2 13.1 1.3 12.3 3.2 11.5 Z";
+
+/**
+ * Announce a change to assistive technology.
+ *
+ * Answering a question or switching orbitals updates the view in place, which
+ * a screen reader would otherwise miss.
+ */
+export function setLiveRegion(element: HTMLElement) {
+  element.setAttribute("role", "status");
+  element.setAttribute("aria-live", "polite");
+}

--- a/source/vscode/src/notebookRenderer/rendering.ts
+++ b/source/vscode/src/notebookRenderer/rendering.ts
@@ -3,7 +3,7 @@
 
 import type { RendererToExtensionMessage } from "./schema.js";
 
-export type PostAction = (message: RendererToExtensionMessage) => boolean;
+type PostAction = (message: RendererToExtensionMessage) => boolean;
 
 export type RenderContext = {
   postAction: PostAction;

--- a/source/vscode/src/notebookRenderer/schema.ts
+++ b/source/vscode/src/notebookRenderer/schema.ts
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * The contract between a learning notebook's output and the renderer.
+ *
+ * Written twice — here, and as the dicts `_learning_output.py` builds — so
+ * `checkRendererContract()` in `build.mjs` fails the build when they drift.
+ */
+
+export const MIME_TYPE = "application/vnd.qdk.learning+json" as const;
+export const RENDERER_ID = "qsharp-vscode.qdkLearningRenderer" as const;
+
+type LearningPayloadBase = {
+  schemaVersion: 1;
+  kind: string;
+  /**
+   * Identifies the payload, not the notebook cell holding it: for a quiz this
+   * is its registered id, which keeps radio groups unique. Deliberately not an
+   * ipynb cell id, so don't pass it to anything that resolves activities.
+   */
+  cellId?: string;
+};
+
+export type MultipleChoicePayload = LearningPayloadBase & {
+  kind: "multiple-choice";
+  prompt: string;
+  options: Array<{
+    id: string;
+    text: string;
+    correct: boolean;
+    explanation?: string;
+  }>;
+  /**
+   * More than one option is correct, and the learner must find all of them.
+   *
+   * Drives checkboxes rather than radios, and an explicit instruction — a
+   * learner who assumes one answer would stop at the first correct option and
+   * be marked wrong for a question they understood.
+   */
+  multiSelect?: boolean;
+};
+
+export type LearningPayload = MultipleChoicePayload;
+
+/**
+ * Copilot actions a notebook output is allowed to request.
+ *
+ * Security boundary: output may name an id from this list and attach small
+ * structured string context. It may never send a free-form prompt string or a
+ * command identifier across the renderer bridge — the wording lives in the
+ * extension, so a notebook cannot script the chat panel.
+ */
+export const COPILOT_ACTION_IDS = ["why-wrong"] as const;
+
+export type CopilotActionId = (typeof COPILOT_ACTION_IDS)[number];
+
+type RendererActionMessage = {
+  type: "qdk-learning/action";
+  rendererId: typeof RENDERER_ID;
+  actionId: CopilotActionId;
+  cellId?: string;
+  context?: Record<string, string>;
+};
+
+export type RendererToExtensionMessage = RendererActionMessage;
+
+/**
+ * Bounds on renderer-supplied strings.
+ *
+ * Only the value and cell-id limits can be reached by a payload today — the
+ * key set is built here in the renderer. They are enforced anyway because this
+ * validator runs on the extension host, where the message is untrusted input
+ * rather than something this code produced.
+ */
+const MAX_CONTEXT_ENTRIES = 20;
+const MAX_CONTEXT_KEY_LENGTH = 64;
+const MAX_CONTEXT_VALUE_LENGTH = 4096;
+const MAX_CELL_ID_LENGTH = 256;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+export function isRendererToExtensionMessage(
+  x: unknown,
+): x is RendererToExtensionMessage {
+  if (!isRecord(x) || x.rendererId !== RENDERER_ID) {
+    return false;
+  }
+
+  if (x.type !== "qdk-learning/action" || !isCopilotActionId(x.actionId)) {
+    return false;
+  }
+
+  if (
+    x.cellId !== undefined &&
+    !isNonEmptyShortString(x.cellId, MAX_CELL_ID_LENGTH)
+  ) {
+    return false;
+  }
+
+  return x.context === undefined || isContextRecord(x.context);
+}
+
+function isCopilotActionId(value: unknown): value is CopilotActionId {
+  return (
+    typeof value === "string" &&
+    COPILOT_ACTION_IDS.includes(value as CopilotActionId)
+  );
+}
+
+function isContextRecord(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const entries = Object.entries(value);
+  return (
+    entries.length <= MAX_CONTEXT_ENTRIES &&
+    entries.every(
+      ([key, entryValue]) =>
+        isShortString(key, MAX_CONTEXT_KEY_LENGTH) &&
+        key.length > 0 &&
+        isShortString(entryValue, MAX_CONTEXT_VALUE_LENGTH),
+    )
+  );
+}
+
+function isShortString(value: unknown, maxLength: number): value is string {
+  return typeof value === "string" && value.length <= maxLength;
+}
+
+function isNonEmptyShortString(
+  value: unknown,
+  maxLength: number,
+): value is string {
+  return isShortString(value, maxLength) && value.length > 0;
+}

--- a/source/vscode/src/notebookRenderer/schema.ts
+++ b/source/vscode/src/notebookRenderer/schema.ts
@@ -46,9 +46,9 @@ export type LearningPayload = MultipleChoicePayload;
 /**
  * Copilot actions a notebook output is allowed to request.
  *
- * Security boundary: output may name an id from this list and attach small
- * structured string context. It may never send a free-form prompt string or a
- * command identifier across the renderer bridge — the wording lives in the
+ * Security boundary: output may name an id from this list, and nothing else
+ * except a quiz id of a fixed shape. It may never send free text, a prompt or
+ * a command identifier across the renderer bridge — the wording lives in the
  * extension, so a notebook cannot script the chat panel.
  */
 export const COPILOT_ACTION_IDS = ["why-wrong"] as const;
@@ -59,24 +59,22 @@ type RendererActionMessage = {
   type: "qdk-learning/action";
   rendererId: typeof RENDERER_ID;
   actionId: CopilotActionId;
-  cellId?: string;
-  context?: Record<string, string>;
+  quizId?: string;
 };
 
 export type RendererToExtensionMessage = RendererActionMessage;
 
 /**
- * Bounds on renderer-supplied strings.
+ * A quiz id is the only thing a renderer may contribute to a chat prompt.
  *
- * Only the value and cell-id limits can be reached by a payload today — the
- * key set is built here in the renderer. They are enforced anyway because this
- * validator runs on the extension host, where the message is untrusted input
- * rather than something this code produced.
+ * Everything a notebook carries is untrusted: an output of this MIME type can
+ * be hand-written, and a file at a workbook's path can be shipped by whatever
+ * produced the workspace. Free prose from such a payload reaching a prompt is
+ * an injection, and no amount of quote-stripping changes that, because the
+ * payload is a sentence either way. Constraining the one value that does cross
+ * to this shape leaves no room for an instruction.
  */
-const MAX_CONTEXT_ENTRIES = 20;
-const MAX_CONTEXT_KEY_LENGTH = 64;
-const MAX_CONTEXT_VALUE_LENGTH = 4096;
-const MAX_CELL_ID_LENGTH = 256;
+const QUIZ_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return (
@@ -98,14 +96,10 @@ export function isRendererToExtensionMessage(
     return false;
   }
 
-  if (
-    x.cellId !== undefined &&
-    !isNonEmptyShortString(x.cellId, MAX_CELL_ID_LENGTH)
-  ) {
-    return false;
-  }
-
-  return x.context === undefined || isContextRecord(x.context);
+  return (
+    x.quizId === undefined ||
+    (typeof x.quizId === "string" && QUIZ_ID_PATTERN.test(x.quizId))
+  );
 }
 
 function isCopilotActionId(value: unknown): value is CopilotActionId {
@@ -113,32 +107,4 @@ function isCopilotActionId(value: unknown): value is CopilotActionId {
     typeof value === "string" &&
     COPILOT_ACTION_IDS.includes(value as CopilotActionId)
   );
-}
-
-function isContextRecord(value: unknown): value is Record<string, string> {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const entries = Object.entries(value);
-  return (
-    entries.length <= MAX_CONTEXT_ENTRIES &&
-    entries.every(
-      ([key, entryValue]) =>
-        isShortString(key, MAX_CONTEXT_KEY_LENGTH) &&
-        key.length > 0 &&
-        isShortString(entryValue, MAX_CONTEXT_VALUE_LENGTH),
-    )
-  );
-}
-
-function isShortString(value: unknown, maxLength: number): value is string {
-  return typeof value === "string" && value.length <= maxLength;
-}
-
-function isNonEmptyShortString(
-  value: unknown,
-  maxLength: number,
-): value is string {
-  return isShortString(value, maxLength) && value.length > 0;
 }

--- a/source/vscode/src/notebookRenderer/styles.css
+++ b/source/vscode/src/notebookRenderer/styles.css
@@ -1,0 +1,349 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+/* Colors come from the `--qdk-*` palette in `qdk-theme.css`; don't add
+   literal colors here. Buttons map to `--vscode-button-*` so they match the
+   cell status bar. */
+
+.qdk-learning {
+  /* Local semantic aliases, so the rules below never reach for a raw token. */
+  --qdk-l-fg: var(--qdk-host-foreground);
+  --qdk-l-muted: var(--qdk-description-foreground);
+  --qdk-l-border: var(--qdk-widget-outline);
+  --qdk-l-surface: var(--qdk-background-accent);
+  --qdk-l-accent: var(--qdk-atom-fill);
+  --qdk-l-focus: var(--qdk-focus-border);
+  --qdk-l-correct: var(--qdk-gate-reset);
+  --qdk-l-incorrect: var(--qdk-gate-measure);
+  --qdk-l-quiz: var(--qdk-quiz-accent);
+  --qdk-l-on-quiz: var(--qdk-quiz-accent-foreground);
+  --qdk-l-on-accent: var(
+    --vscode-button-foreground,
+    var(--qdk-host-background)
+  );
+  --qdk-l-radius: 4px;
+
+  box-sizing: border-box;
+  width: 100%;
+  margin: 8px 0;
+  font-family: var(--qdk-font-family);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--qdk-l-fg);
+}
+
+.qdk-learning *,
+.qdk-learning *::before,
+.qdk-learning *::after {
+  box-sizing: border-box;
+}
+
+/* Long chemical formulae, failure messages and option text must wrap rather
+   than push the card wider than its cell. */
+.qdk-learning-prompt,
+.qdk-learning-option-text,
+.qdk-learning-feedback {
+  overflow-wrap: anywhere;
+}
+
+/* Inline code spans produced from Markdown backticks in authored prose. */
+.qdk-learning code {
+  font-family: var(--qdk-font-family-monospace);
+  font-size: 0.92em;
+  padding: 0 3px;
+  border-radius: 3px;
+  background: var(--vscode-textCodeBlock-background, var(--qdk-l-surface));
+  overflow-wrap: anywhere;
+}
+
+/* ── Card ─────────────────────────────────────────────────────────── */
+
+.qdk-learning-card {
+  border: 1px solid var(--qdk-l-border);
+  border-radius: var(--qdk-l-radius);
+  padding: 12px 14px;
+  background: var(--qdk-host-background);
+}
+
+/* ── Quiz header ──────────────────────────────────────────────────── */
+
+/* The chemistry course already marks its self-check questions with a filled
+   band in a burnt-orange accent and a question mark, so an interactive
+   question keeps that identity rather than inventing a second one. The band
+   bleeds to the card edge, which is why the negative margin matches the
+   card's own padding. */
+.qdk-learning-quiz-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: -12px -14px 12px;
+  padding: 7px 14px;
+  border-radius: calc(var(--qdk-l-radius) - 1px) calc(var(--qdk-l-radius) - 1px)
+    0 0;
+  background: var(--qdk-l-quiz);
+  color: var(--qdk-l-on-quiz);
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.qdk-learning-quiz-mark {
+  flex: none;
+  font-size: 1.05em;
+}
+
+/* ── Multiple choice ──────────────────────────────────────────────── */
+
+.qdk-learning-prompt {
+  display: block;
+  width: 100%;
+  margin: 0 0 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--qdk-l-border);
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+/* "Select all that apply" — part of the question, but an instruction rather
+   than the question itself, so it is set apart without being hidden. */
+.qdk-learning-prompt-hint {
+  display: block;
+  margin-top: 6px;
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--qdk-l-muted);
+}
+
+.qdk-learning-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.qdk-learning-option {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--qdk-l-border);
+  border-radius: var(--qdk-l-radius);
+  background: var(--qdk-host-background);
+  cursor: pointer;
+}
+
+.qdk-learning-option:hover,
+.qdk-learning-option[data-selected="true"] {
+  background: var(--qdk-l-surface);
+}
+
+.qdk-learning-option input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.qdk-learning-option-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 1.75em;
+  min-width: 1.75em;
+  height: 1.75em;
+  border: 1px solid var(--qdk-l-border);
+  border-radius: var(--qdk-l-radius);
+  background: var(--qdk-l-surface);
+  color: var(--qdk-l-muted);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* Selection tracks the quiz accent so picking an answer reads as part of the
+   same question, not as a generic form control. */
+.qdk-learning-option[data-selected="true"] {
+  border-color: var(--qdk-l-quiz);
+}
+
+.qdk-learning-option[data-selected="true"] .qdk-learning-option-badge {
+  border-color: var(--qdk-l-quiz);
+  background: var(--qdk-l-quiz);
+  color: var(--qdk-l-on-quiz);
+}
+
+.qdk-learning-option:focus-within {
+  outline: 1px solid var(--qdk-l-focus);
+  outline-offset: 2px;
+}
+
+/* Answered state. The border and badge glyph carry the verdict so meaning is
+   not conveyed by color alone; missed answers stay dashed to distinguish them. */
+.qdk-learning-option[data-state="correct"] {
+  border-color: var(--qdk-l-correct);
+}
+
+.qdk-learning-option[data-state="incorrect"] {
+  border-color: var(--qdk-l-incorrect);
+}
+
+.qdk-learning-option[data-state="missed"] {
+  border-color: var(--qdk-l-correct);
+  border-style: dashed;
+}
+
+.qdk-learning-option[data-state] .qdk-learning-option-badge {
+  color: var(--qdk-host-background);
+}
+
+.qdk-learning-option[data-state="correct"] .qdk-learning-option-badge,
+.qdk-learning-option[data-state="missed"] .qdk-learning-option-badge {
+  border-color: var(--qdk-l-correct);
+  background: var(--qdk-l-correct);
+}
+
+.qdk-learning-option[data-state="incorrect"] .qdk-learning-option-badge {
+  border-color: var(--qdk-l-incorrect);
+  background: var(--qdk-l-incorrect);
+}
+
+.qdk-learning-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.qdk-learning-verdict {
+  flex: none;
+}
+
+.qdk-learning-option-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.qdk-learning-option-why {
+  font-size: 12px;
+  color: var(--qdk-l-muted);
+}
+
+.qdk-learning-feedback {
+  margin-top: 10px;
+  font-weight: 600;
+}
+
+.qdk-learning-feedback[data-state="correct"] {
+  color: var(--qdk-l-correct);
+}
+
+.qdk-learning-feedback[data-state="incorrect"] {
+  color: var(--qdk-l-incorrect);
+}
+
+/* ── Controls and actions ─────────────────────────────────────────── */
+
+.qdk-learning-controls,
+.qdk-learning-action-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.qdk-learning button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font: inherit;
+  font-size: 12px;
+  padding: 3px 9px;
+  border-radius: var(--qdk-l-radius);
+  border: 1px solid var(--qdk-l-border);
+  background: var(--vscode-button-secondaryBackground, var(--qdk-l-surface));
+  color: var(--vscode-button-secondaryForeground, var(--qdk-l-fg));
+  cursor: pointer;
+}
+
+.qdk-learning button:hover:not(:disabled) {
+  background: var(
+    --vscode-button-secondaryHoverBackground,
+    var(--qdk-l-surface)
+  );
+  border-color: var(--qdk-l-accent);
+}
+
+.qdk-learning button:focus-visible {
+  outline: 1px solid var(--qdk-l-focus);
+  outline-offset: 1px;
+}
+
+.qdk-learning button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Copilot actions read as the primary thing to do once an answer is in.
+   Qualified with `button` so it outranks the base `.qdk-learning button` rule,
+   which is otherwise more specific and would keep the secondary colors. */
+.qdk-learning button.qdk-learning-action {
+  background: var(--vscode-button-background, var(--qdk-l-accent));
+  color: var(--qdk-l-on-accent);
+  border-color: var(--vscode-button-background, var(--qdk-l-accent));
+}
+
+.qdk-learning button.qdk-learning-action:hover:not(:disabled) {
+  background: var(--vscode-button-hoverBackground, var(--qdk-l-accent));
+  border-color: var(--vscode-button-hoverBackground, var(--qdk-l-accent));
+}
+
+.qdk-learning-action svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  fill: currentColor;
+}
+
+/* Shown instead of the buttons when the renderer has no channel back to the
+   extension — a trusted-but-messaging-less host, or a plain browser export. */
+.qdk-learning-action-note {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--qdk-l-muted);
+}
+
+/* ── Error state ──────────────────────────────────────────────────── */
+
+.qdk-learning-error {
+  border: 1px solid var(--qdk-l-incorrect);
+  border-radius: var(--qdk-l-radius);
+  padding: 10px 12px;
+}
+
+.qdk-learning-error pre {
+  margin: 6px 0 0;
+  font-family: var(--qdk-font-family-monospace);
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--qdk-l-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .qdk-learning * {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/source/vscode/src/notebookRenderer/styles.css
+++ b/source/vscode/src/notebookRenderer/styles.css
@@ -254,6 +254,14 @@
 
 /* ── Controls and actions ─────────────────────────────────────────── */
 
+/* `display` from a rule below outranks the user-agent rule that `hidden`
+   relies on, so the attribute has to be honoured explicitly. Without this,
+   setting `.hidden = true` on a flex container does nothing and the control
+   stays on screen. */
+.qdk-learning [hidden] {
+  display: none;
+}
+
 .qdk-learning-controls,
 .qdk-learning-action-list {
   display: flex;

--- a/source/vscode/src/notebookRenderer/tsconfig.json
+++ b/source/vscode/src/notebookRenderer/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2022",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "lib": ["DOM", "ES2022"],
+    // No `rootDir`: this project only type-checks (esbuild does the bundling),
+    // and the renderer bundles the shared `qsharp/ux` theme stylesheet rather
+    // than keeping a second copy of the palette.
+    "strict": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/source/vscode/tsconfig.json
+++ b/source/vscode/tsconfig.json
@@ -13,5 +13,10 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "exclude": ["test", "src/webview", "src/learning/webview"]
+  "exclude": [
+    "test",
+    "src/webview",
+    "src/learning/webview",
+    "src/notebookRenderer"
+  ]
 }


### PR DESCRIPTION
Each section of the IQPE chapter ends with a self-check question. Today it's a dropdown you click to reveal the answer. This turns those 12 into multiple choice questions a learner answers, gets marked on, and can retry.

- The repo's first notebook renderer, for `application/vnd.qdk.learning+json`
- Grading happens in the renderer, so questions work without a running kernel
- Choices live in `_unit.py`, so the notebook cell only says `quiz("id")`
- `details_to_quiz.py` bakes a chapter's questions; `--check` reports stale output
- A quiz is stored as JSON in the notebook cell's output. That shape is written by hand in `schema.ts`, `_learning_output.py` and the `package.json` contribution with nothing linking them, so `checkRendererContract()` compares them at build time and fails if the MIME type, the payload fields, the id grammar or the quiz cell tag stop matching

### Not in this PR

- **Quizzes don't show in the progress tree.** Whether a learner answered correctly never leaves the renderer, so a progress entry would claim tracking that doesn't exist. Tracking them is a natural follow-up the renderer-to-extension channel this PR adds is what it would use.
- **"Why is that wrong?" needs the extension.** It's inert in VS Code for Web, where QDK Learning doesn't load. On GitHub and in exported HTML the renderer doesn't run at all, so the static fallback shows instead a question with no buttons, and no answers.
- **The contract check only guards the chemistry emitter.** A second course that copies `_learning_output.py` wouldn't be covered.