### PR TITLE
QIR emission should use attributes to allow read result calls to optimize out

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -5980,12 +5980,13 @@ fn array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed_emits_
 
         declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__int_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="3" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -6058,12 +6059,13 @@ fn array_with_dynamic_contents_passed_as_argument_with_static_index_does_not_emi
 
         declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__int_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="2" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -6210,7 +6212,7 @@ fn nested_array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed
 
         declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__array_record_output(i64, ptr)
 
@@ -6218,6 +6220,7 @@ fn nested_array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="6" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 

--- a/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
@@ -109,6 +109,7 @@ fn nested_for_over_qubit_slice_succeeds() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -231,6 +232,7 @@ fn constant_folding_pattern_succeeds() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -387,6 +389,7 @@ fn three_qubit_repetition_code_pattern_succeeds() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -476,12 +479,13 @@ fn for_over_qubit_slice_inside_dynamic_while_succeeds() {
 
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__tuple_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="1" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -571,12 +575,13 @@ fn result_array_dynamic_index_succeeds() {
 
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__int_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="4" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -686,12 +691,13 @@ fn result_array_while_loop_dynamic_index_succeeds() {
 
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__int_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="4" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -823,6 +829,7 @@ fn for_loop_over_qubits_with_reset_all_succeeds() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="1" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -901,6 +908,7 @@ fn measure_each_z_static_qubits_succeeds() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -979,12 +987,13 @@ fn static_while_inside_emit_while_succeeds() {
 
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__int_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1077,6 +1086,7 @@ fn nested_emit_while_loops_succeeds() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1169,12 +1179,13 @@ fn for_loop_over_qubits_with_dynamic_exit_succeeds() {
 
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__bool_record_output(i1, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="1" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1299,6 +1310,7 @@ fn simple_void_operation_emits_ir_function() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1379,6 +1391,7 @@ fn two_call_sites_share_one_ir_function() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1469,6 +1482,7 @@ fn body_and_adjoint_emit_distinct_ir_functions() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1570,6 +1584,7 @@ fn defunctionalized_monomorphized_helper_emits_ir_function() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1647,6 +1662,7 @@ fn qubit_allocating_callable_emits_ir_function_when_dynamic_alloc_enabled() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1736,6 +1752,7 @@ fn qubit_array_allocating_callable_emits_ir_function_when_dynamic_alloc_enabled(
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1843,6 +1860,7 @@ fn tuple_of_scalars_parameter_flattens_to_ir_function() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -1965,6 +1983,7 @@ fn recursive_operation_emits_to_ir_function() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -2092,12 +2111,13 @@ fn value_returning_ir_function_with_dynamic_store_return_is_defined() {
 
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__int_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -2172,12 +2192,13 @@ fn value_returning_ir_function_reloads_after_same_block_store() {
 
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__int_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -2407,6 +2428,7 @@ fn preparepurestated_cyclic_library_calls_generate_correct_qir() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -2496,6 +2518,7 @@ fn cross_package_library_callable_emits_standalone_define() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 

--- a/source/compiler/qsc_codegen/src/qir/v2.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2.rs
@@ -722,13 +722,19 @@ fn callable_to_qir(callable: &rir::Callable, is_entry: bool, program: &rir::Prog
         let callable_name = llvm_global_name(&callable.name);
         return format!(
             "declare {output_type} {callable_name}({input_type}){}",
-            match callable.call_type {
-                rir::CallableType::Measurement | rir::CallableType::Reset => {
-                    // These callables are a special case that need the irreversible attribute.
-                    " #1"
+            if callable_name == "@__quantum__rt__read_result" {
+                // Read result gets special attributes that mark it as side-effect free to allow
+                // LLVM to optimize it out when the resulting i1 value is unused.
+                " #2"
+            } else {
+                match callable.call_type {
+                    rir::CallableType::Measurement | rir::CallableType::Reset => {
+                        // These callables are a special case that need the irreversible attribute.
+                        " #1"
+                    }
+                    rir::CallableType::NoiseIntrinsic => " #3",
+                    _ => "",
                 }
-                rir::CallableType::NoiseIntrinsic => " #2",
-                _ => "",
             }
         );
     };
@@ -839,7 +845,7 @@ impl ToQir<String> for rir::Program {
 fn get_additional_module_attributes(program: &rir::Program) -> String {
     let mut attrs = String::new();
     if program.attrs.contains(Attributes::QdkNoise) {
-        attrs.push_str("\nattributes #2 = { \"qdk_noise\" }");
+        attrs.push_str("\nattributes #3 = { \"qdk_noise\" }");
     }
 
     attrs

--- a/source/compiler/qsc_codegen/src/qir/v2/template.ll
+++ b/source/compiler/qsc_codegen/src/qir/v2/template.ll
@@ -2,7 +2,8 @@
 {}
 
 attributes #0 = {{ "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" {}"required_num_results"="{}" }}
-attributes #1 = {{ "irreversible" }}{}
+attributes #1 = {{ "irreversible" }}
+attributes #2 = {{ nofree nosync nounwind willreturn memory(argmem: read) }}{}
 
 ; module flags
 

--- a/source/compiler/qsc_codegen/src/qir/v2/tests.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2/tests.rs
@@ -37,7 +37,7 @@ fn measurement_decl_works() {
 #[test]
 fn read_result_decl_works() {
     let decl = builder::read_result_decl();
-    expect!["declare i1 @__quantum__rt__read_result(ptr)"]
+    expect!["declare i1 @__quantum__rt__read_result(ptr) #2"]
         .assert_eq(&decl.to_qir(&rir::Program::default()));
 }
 
@@ -156,6 +156,7 @@ fn bell_program() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -189,7 +190,7 @@ fn teleport_program() {
 
         declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-        declare i1 @__quantum__rt__read_result(ptr)
+        declare i1 @__quantum__rt__read_result(ptr) #2
 
         declare void @__quantum__rt__result_record_output(ptr, ptr)
 
@@ -221,6 +222,7 @@ fn teleport_program() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -314,6 +316,7 @@ fn ir_function_program() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 
@@ -602,6 +605,7 @@ fn scalar_ir_function_program() {
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 

--- a/source/compiler/qsc_openqasm_compiler/src/tests/statement/gate_call.rs
+++ b/source/compiler/qsc_openqasm_compiler/src/tests/statement/gate_call.rs
@@ -682,6 +682,7 @@ fn custom_gate_with_angle_parameter_generates_qir_adaptive() -> miette::Result<(
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
         attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
         ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ArithmeticOps.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ArithmeticOps.ll
@@ -166,7 +166,7 @@ declare void @__quantum__qis__x__body(ptr)
 
 declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @Reset(ptr %var_48) {
 block_18:
@@ -182,6 +182,7 @@ declare void @__quantum__rt__int_record_output(i64, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="5" "required_num_results"="5" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/BernsteinVaziraniNISQ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/BernsteinVaziraniNISQ.ll
@@ -113,6 +113,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="6" "required_num_results"="5" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/CallReturnMath.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/CallReturnMath.ll
@@ -62,12 +62,13 @@ declare void @__quantum__qis__x__body(ptr)
 
 declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 declare void @__quantum__rt__int_record_output(i64, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ConstantFolding.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ConstantFolding.ll
@@ -141,6 +141,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="4" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/CopyAndUpdateExpressions.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/CopyAndUpdateExpressions.ll
@@ -73,6 +73,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="5" "required_num_results"="7" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/DeutschJozsaNISQ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/DeutschJozsaNISQ.ll
@@ -202,6 +202,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="5" "required_num_results"="8" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/Doubles.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/Doubles.ll
@@ -94,7 +94,7 @@ declare void @__quantum__qis__x__body(ptr)
 
 declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @Reset(ptr %var_15) {
 block_9:
@@ -114,6 +114,7 @@ declare void @__quantum__rt__int_record_output(i64, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ExpandedTests.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ExpandedTests.ll
@@ -269,6 +269,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/Functors.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/Functors.ll
@@ -316,6 +316,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="8" "required_num_results"="6" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/HiddenShiftNISQ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/HiddenShiftNISQ.ll
@@ -254,6 +254,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="6" "required_num_results"="6" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntegerComparison.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntegerComparison.ll
@@ -68,7 +68,7 @@ declare void @__quantum__qis__x__body(ptr)
 
 declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @Reset(ptr %var_11) {
 block_9:
@@ -84,6 +84,7 @@ declare void @__quantum__rt__bool_record_output(i1, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicCCNOT.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicCCNOT.ll
@@ -139,6 +139,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="9" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicCNOT.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicCNOT.ll
@@ -100,6 +100,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="4" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicHIXYZ.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicHIXYZ.ll
@@ -79,6 +79,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="6" "required_num_results"="6" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicM.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicM.ll
@@ -42,6 +42,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicMeasureWithBitFlipCode.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicMeasureWithBitFlipCode.ll
@@ -105,6 +105,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="7" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicMeasureWithPhaseFlipCode.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicMeasureWithPhaseFlipCode.ll
@@ -109,6 +109,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="7" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicRotationsWithPeriod.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicRotationsWithPeriod.ll
@@ -185,6 +185,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="6" "required_num_results"="6" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicSTSWAP.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/IntrinsicSTSWAP.ll
@@ -85,6 +85,7 @@ declare void @__quantum__rt__array_record_output(i64, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="4" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/LoopOverArrays.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/LoopOverArrays.ll
@@ -99,6 +99,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/MeasureAndReuse.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/MeasureAndReuse.ll
@@ -66,6 +66,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="5" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/MeasurementComparison.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/MeasurementComparison.ll
@@ -70,7 +70,7 @@ block_6:
 
 declare void @__quantum__qis__reset__body(ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 declare void @__quantum__rt__tuple_record_output(i64, ptr)
 
@@ -78,6 +78,7 @@ declare void @__quantum__rt__bool_record_output(i1, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/NegativeIndexing.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/NegativeIndexing.ll
@@ -53,6 +53,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/NestedBranching.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/NestedBranching.ll
@@ -414,7 +414,7 @@ declare void @__quantum__qis__x__body(ptr)
 
 declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @Reset(ptr %var_41) {
 block_95:
@@ -454,6 +454,7 @@ declare void @__quantum__rt__bool_record_output(i1, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="8" "required_num_results"="8" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/RUS.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/RUS.ll
@@ -84,7 +84,7 @@ declare void @__quantum__qis__ccx__body(ptr, ptr, ptr)
 
 declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @Reset(ptr %var_18) {
 block_13:
@@ -100,6 +100,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/RandomBit.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/RandomBit.ll
@@ -34,6 +34,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/SampleTeleport.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/SampleTeleport.ll
@@ -81,7 +81,7 @@ declare void @__quantum__qis__x__body(ptr)
 
 declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
@@ -111,6 +111,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ShortcuttingMeasurement.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ShortcuttingMeasurement.ll
@@ -58,7 +58,7 @@ declare void @__quantum__qis__cx__body(ptr, ptr)
 
 declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @Reset(ptr %var_10) {
 block_7:
@@ -74,6 +74,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="4" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/Slicing.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/Slicing.ll
@@ -85,6 +85,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="10" "required_num_results"="5" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/SuperdenseCoding.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/SuperdenseCoding.ll
@@ -99,7 +99,7 @@ declare void @__quantum__qis__cx__body(ptr, ptr)
 
 declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @SuperdenseEncode(i1 %var_18, i1 %var_19, ptr %var_20) {
 block_7:
@@ -154,6 +154,7 @@ declare void @__quantum__rt__bool_record_output(i1, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="4" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/SwitchHandling.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/SwitchHandling.ll
@@ -109,7 +109,7 @@ declare void @__quantum__qis__x__body(ptr)
 
 declare void @__quantum__qis__m__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @Reset(ptr %var_22) {
 block_21:
@@ -160,6 +160,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/ThreeQubitRepetitionCode.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/ThreeQubitRepetitionCode.ll
@@ -183,7 +183,7 @@ declare void @__quantum__qis__rx__body(double, ptr)
 
 declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
 
-declare i1 @__quantum__rt__read_result(ptr)
+declare i1 @__quantum__rt__read_result(ptr) #2
 
 define internal void @X(ptr %var_28) {
 block_32:
@@ -215,6 +215,7 @@ declare void @__quantum__rt__int_record_output(i64, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="5" "required_num_results"="3" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/qdk_package/tests-integration/resources/adaptive/output/WithinApply.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/WithinApply.ll
@@ -107,6 +107,7 @@ declare void @__quantum__rt__result_record_output(ptr, ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 
 ; module flags
 

--- a/source/samples_test/src/tests/OpenQASM.rs
+++ b/source/samples_test/src/tests/OpenQASM.rs
@@ -10,29 +10,29 @@ pub const BELLPAIR_EXPECT: Expect = expect!["(One, One)"];
 pub const BELLPAIR_EXPECT_DEBUG: Expect = expect!["(One, One)"];
 pub const BELLPAIR_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 412"];
 pub const BELLPAIR_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 2214"];
-pub const BELLPAIR_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2475"];
+pub const BELLPAIR_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2550"];
 pub const OPENQASMHELLOWORLD_EXPECT: Expect = expect!["Zero"];
 pub const OPENQASMHELLOWORLD_EXPECT_DEBUG: Expect = expect!["Zero"];
 pub const OPENQASMHELLOWORLD_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 164"];
 pub const OPENQASMHELLOWORLD_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 1306"];
-pub const OPENQASMHELLOWORLD_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1375"];
+pub const OPENQASMHELLOWORLD_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1450"];
 pub const BERNSTEINVAZIRANI_EXPECT: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4341"];
 pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 4548"];
-pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5893"];
+pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5968"];
 pub const GROVER_EXPECT: Expect = expect!["[Zero, One, Zero, One, Zero]"];
 pub const GROVER_EXPECT_DEBUG: Expect = expect!["[Zero, One, Zero, One, Zero]"];
 pub const GROVER_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 33215"];
 pub const GROVER_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 20376"];
-pub const GROVER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 21865"];
+pub const GROVER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 21940"];
 pub const RANDOMNUMBER_EXPECT: Expect = expect!["9"];
 pub const RANDOMNUMBER_EXPECT_DEBUG: Expect = expect!["9"];
 pub const RANDOMNUMBER_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 3559"];
 pub const RANDOMNUMBER_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 4064"];
-pub const RANDOMNUMBER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2785"];
+pub const RANDOMNUMBER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2863"];
 pub const SIMPLE1DISINGORDER1_EXPECT: Expect =
     expect!["[Zero, One, One, Zero, Zero, One, One, One, One]"];
 pub const SIMPLE1DISINGORDER1_EXPECT_DEBUG: Expect =
@@ -41,9 +41,9 @@ pub const SIMPLE1DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circui
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18979"];
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 12035"];
+    expect!["generated QIR of length 12110"];
 pub const TELEPORTATION_EXPECT: Expect = expect!["Zero"];
 pub const TELEPORTATION_EXPECT_DEBUG: Expect = expect!["Zero"];
 pub const TELEPORTATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 2086"];
 pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 3062"];
-pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7274"];
+pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7352"];

--- a/source/samples_test/src/tests/algorithms.rs
+++ b/source/samples_test/src/tests/algorithms.rs
@@ -11,7 +11,7 @@ pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[127, 238, 512]"];
 pub const BERNSTEINVAZIRANI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 29822"];
 pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 20277"];
-pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 19343"];
+pub const BERNSTEINVAZIRANI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 19421"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zero, One]"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_CIRCUIT: Expect =
@@ -19,7 +19,7 @@ pub const BERNSTEINVAZIRANINISQ_EXPECT_CIRCUIT: Expect =
 pub const BERNSTEINVAZIRANINISQ_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 4194"];
 pub const BERNSTEINVAZIRANINISQ_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 4762"];
+    expect!["generated QIR of length 4837"];
 pub const BITFLIPCODE_EXPECT: Expect = expect![[r#"
     STATE:
     |010⟩: 0.4472+0.0000𝑖
@@ -38,12 +38,12 @@ pub const BITFLIPCODE_EXPECT_DEBUG: Expect = expect![[r#"
     One"#]];
 pub const BITFLIPCODE_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 6530"];
 pub const BITFLIPCODE_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 3794"];
-pub const BITFLIPCODE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5858"];
+pub const BITFLIPCODE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5936"];
 pub const DEUTSCHJOZSA_EXPECT: Expect = expect!["[true, false, true, false]"];
 pub const DEUTSCHJOZSA_EXPECT_DEBUG: Expect = expect!["[true, false, true, false]"];
 pub const DEUTSCHJOZSA_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 197703"];
 pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 82661"];
-pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 31414"];
+pub const DEUTSCHJOZSA_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 31492"];
 pub const DEUTSCHJOZSANISQ_EXPECT: Expect =
     expect!["([One, Zero, Zero, Zero, Zero], [Zero, Zero, Zero, Zero, Zero])"];
 pub const DEUTSCHJOZSANISQ_EXPECT_DEBUG: Expect =
@@ -51,7 +51,7 @@ pub const DEUTSCHJOZSANISQ_EXPECT_DEBUG: Expect =
 pub const DEUTSCHJOZSANISQ_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 5865"];
 pub const DEUTSCHJOZSANISQ_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 7022"];
-pub const DEUTSCHJOZSANISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7431"];
+pub const DEUTSCHJOZSANISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7506"];
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT: Expect = expect![[r#"
     Computing inner product of vectors (cos(Θ₁/2), sin(Θ₁/2))⋅(cos(Θ₂/2), sin(Θ₂/2)) ≈ -cos(x𝝅/2ⁿ)
     Θ₁=0.4487989505128276, Θ₂=0.6283185307179586.
@@ -69,7 +69,7 @@ pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_CIRCUIT: Expect =
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 139362"];
 pub const DOTPRODUCTVIAPHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 21834"];
+    expect!["generated QIR of length 21912"];
 pub const GROVER_EXPECT: Expect = expect![[r#"
     Number of iterations: 4
     Reflecting about marked state...
@@ -86,7 +86,7 @@ pub const GROVER_EXPECT_DEBUG: Expect = expect![[r#"
     [Zero, One, Zero, One, Zero]"#]];
 pub const GROVER_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 36701"];
 pub const GROVER_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 19889"];
-pub const GROVER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 19685"];
+pub const GROVER_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 19760"];
 pub const HIDDENSHIFT_EXPECT: Expect = expect![[r#"
     Found 170 successfully!
     Found 512 successfully!
@@ -99,18 +99,18 @@ pub const HIDDENSHIFT_EXPECT_DEBUG: Expect = expect![[r#"
     [170, 512, 999]"#]];
 pub const HIDDENSHIFT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 42131"];
 pub const HIDDENSHIFT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 25479"];
-pub const HIDDENSHIFT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 33470"];
+pub const HIDDENSHIFT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 33548"];
 pub const HIDDENSHIFTNISQ_EXPECT: Expect = expect!["[One, Zero, Zero, Zero, Zero, One]"];
 pub const HIDDENSHIFTNISQ_EXPECT_DEBUG: Expect = expect!["[One, Zero, Zero, Zero, Zero, One]"];
 pub const HIDDENSHIFTNISQ_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4379"];
 pub const HIDDENSHIFTNISQ_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 5455"];
-pub const HIDDENSHIFTNISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 9661"];
+pub const HIDDENSHIFTNISQ_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 9736"];
 pub const PHASEESTIMATION_EXPECT: Expect = expect!["1.0799224746714913"];
 pub const PHASEESTIMATION_EXPECT_DEBUG: Expect = expect!["1.0799224746714913"];
 pub const PHASEESTIMATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 249358"];
 pub const PHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 95778"];
-pub const PHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 16253"];
+pub const PHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 16331"];
 pub const PHASEFLIPCODE_EXPECT: Expect = expect![[r#"
     STATE:
     |000⟩: 0.4743+0.0000𝑖
@@ -153,12 +153,12 @@ pub const PHASEFLIPCODE_EXPECT_DEBUG: Expect = expect![[r#"
     One"#]];
 pub const PHASEFLIPCODE_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 8247"];
 pub const PHASEFLIPCODE_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 4734"];
-pub const PHASEFLIPCODE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 8636"];
+pub const PHASEFLIPCODE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 8714"];
 pub const QRNG_EXPECT: Expect = expect!["7568811972615905454"];
 pub const QRNG_EXPECT_DEBUG: Expect = expect!["7568811972615905454"];
 pub const QRNG_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 232827"];
 pub const QRNG_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 36023"];
-pub const QRNG_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 31022"];
+pub const QRNG_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 31100"];
 pub const SHOR_EXPECT: Expect = expect![[r#"
     *** Factorizing 187, attempt 1.
     Estimating period of 182.
@@ -190,7 +190,7 @@ pub const SIMPLEPHASEESTIMATION_EXPECT_CIRCUIT: Expect =
 pub const SIMPLEPHASEESTIMATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 39770"];
 pub const SIMPLEPHASEESTIMATION_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 12492"];
+    expect!["generated QIR of length 12567"];
 pub const SIMPLEVQE_EXPECT: Expect = expect![[r#"
    Beginning descent from value 0.43300000000000005.
    Value improved to 0.35300000000000004.
@@ -219,7 +219,7 @@ pub const SUPERDENSECODING_EXPECT_DEBUG: Expect = expect!["((false, true), (fals
 pub const SUPERDENSECODING_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4291"];
 pub const SUPERDENSECODING_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 4842"];
-pub const SUPERDENSECODING_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 5947"];
+pub const SUPERDENSECODING_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 6025"];
 pub const TELEPORTATION_EXPECT: Expect = expect![[r#"
     Teleporting state |0〉
     STATE:
@@ -282,7 +282,7 @@ pub const TELEPORTATION_EXPECT_DEBUG: Expect = expect![[r#"
     [Zero, One, Zero, One]"#]];
 pub const TELEPORTATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 12039"];
 pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 8555"];
-pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 9625"];
+pub const TELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 9703"];
 pub const THREEQUBITREPETITIONCODE_EXPECT: Expect = expect!["(true, 0)"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_DEBUG: Expect = expect!["(true, 0)"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_CIRCUIT: Expect =
@@ -290,4 +290,4 @@ pub const THREEQUBITREPETITIONCODE_EXPECT_CIRCUIT: Expect =
 pub const THREEQUBITREPETITIONCODE_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18122"];
 pub const THREEQUBITREPETITIONCODE_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 7429"];
+    expect!["generated QIR of length 7507"];

--- a/source/samples_test/src/tests/algorithms_Ising.rs
+++ b/source/samples_test/src/tests/algorithms_Ising.rs
@@ -14,7 +14,7 @@ pub const SIMPLE2DISINGORDER2_EXPECT_CIRCUIT: Expect = expect!["generated circui
 pub const SIMPLE2DISINGORDER2_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 20849"];
 pub const SIMPLE2DISINGORDER2_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 14177"];
+    expect!["generated QIR of length 14252"];
 pub const SIMPLE1DISINGORDER1_EXPECT: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, Zero, Zero, Zero]"];
 pub const SIMPLE1DISINGORDER1_EXPECT_DEBUG: Expect =
@@ -22,7 +22,7 @@ pub const SIMPLE1DISINGORDER1_EXPECT_DEBUG: Expect =
 pub const SIMPLE1DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 12317"];
 pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 18408"];
-pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7228"];
+pub const SIMPLE1DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7303"];
 pub const SIMPLE2DISINGORDER1_EXPECT: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, One, One, Zero]"];
 pub const SIMPLE2DISINGORDER1_EXPECT_DEBUG: Expect =
@@ -31,4 +31,4 @@ pub const SIMPLE2DISINGORDER1_EXPECT_CIRCUIT: Expect = expect!["generated circui
 pub const SIMPLE2DISINGORDER1_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 16214"];
 pub const SIMPLE2DISINGORDER1_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 13543"];
+    expect!["generated QIR of length 13618"];

--- a/source/samples_test/src/tests/getting_started.rs
+++ b/source/samples_test/src/tests/getting_started.rs
@@ -18,7 +18,7 @@ pub const BELLPAIR_EXPECT_DEBUG: Expect = expect![[r#"
     (Zero, Zero)"#]];
 pub const BELLPAIR_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 565"];
 pub const BELLPAIR_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 2021"];
-pub const BELLPAIR_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2153"];
+pub const BELLPAIR_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2228"];
 pub const BELLSTATES_EXPECT: Expect = expect![[r#"
     Bell state |Φ+〉:
     STATE:
@@ -57,7 +57,7 @@ pub const BELLSTATES_EXPECT_DEBUG: Expect = expect![[r#"
     [(Zero, Zero), (One, One), (One, Zero), (One, Zero)]"#]];
 pub const BELLSTATES_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 5533"];
 pub const BELLSTATES_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 5628"];
-pub const BELLSTATES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 4773"];
+pub const BELLSTATES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 4848"];
 pub const CATSTATES_EXPECT: Expect = expect![[r#"
     STATE:
     |00000⟩: 0.7071+0.0000𝑖
@@ -70,12 +70,12 @@ pub const CATSTATES_EXPECT_DEBUG: Expect = expect![[r#"
     [Zero, Zero, Zero, Zero, Zero]"#]];
 pub const CATSTATES_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 1807"];
 pub const CATSTATES_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 3311"];
-pub const CATSTATES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 3405"];
+pub const CATSTATES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 3480"];
 pub const RANDOMBITS_EXPECT: Expect = expect!["[Zero, Zero, One, One, One]"];
 pub const RANDOMBITS_EXPECT_DEBUG: Expect = expect!["[Zero, Zero, One, One, One]"];
 pub const RANDOMBITS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 3486"];
 pub const RANDOMBITS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 3101"];
-pub const RANDOMBITS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2635"];
+pub const RANDOMBITS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2710"];
 pub const SIMPLETELEPORTATION_EXPECT: Expect = expect![[r#"
     STATE:
     |000⟩: 1.0000+0.0000𝑖
@@ -89,7 +89,7 @@ pub const SIMPLETELEPORTATION_EXPECT_DEBUG: Expect = expect![[r#"
 pub const SIMPLETELEPORTATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 1463"];
 pub const SIMPLETELEPORTATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 3118"];
-pub const SIMPLETELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 4165"];
+pub const SIMPLETELEPORTATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 4243"];
 pub const ENTANGLEMENT_EXPECT: Expect = expect![[r#"
     STATE:
     |00⟩: 0.7071+0.0000𝑖
@@ -102,7 +102,7 @@ pub const ENTANGLEMENT_EXPECT_DEBUG: Expect = expect![[r#"
     [Zero, Zero]"#]];
 pub const ENTANGLEMENT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 417"];
 pub const ENTANGLEMENT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 2021"];
-pub const ENTANGLEMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2030"];
+pub const ENTANGLEMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2105"];
 pub const JOINTMEASUREMENT_EXPECT: Expect = expect![[r#"
     STATE:
     |00⟩: 0.7071+0.0000𝑖
@@ -130,12 +130,12 @@ pub const JOINTMEASUREMENT_EXPECT_DEBUG: Expect = expect![[r#"
 pub const JOINTMEASUREMENT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 959"];
 pub const JOINTMEASUREMENT_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 3259"];
-pub const JOINTMEASUREMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 3767"];
+pub const JOINTMEASUREMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 3842"];
 pub const MEASUREMENT_EXPECT: Expect = expect!["(One, [Zero, Zero])"];
 pub const MEASUREMENT_EXPECT_DEBUG: Expect = expect!["(One, [Zero, Zero])"];
 pub const MEASUREMENT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 613"];
 pub const MEASUREMENT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 2399"];
-pub const MEASUREMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2168"];
+pub const MEASUREMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2243"];
 pub const QUANTUMHELLOWORLD_EXPECT: Expect = expect![[r#"
     Hello world!
     Zero"#]];
@@ -145,7 +145,7 @@ pub const QUANTUMHELLOWORLD_EXPECT_DEBUG: Expect = expect![[r#"
 pub const QUANTUMHELLOWORLD_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 165"];
 pub const QUANTUMHELLOWORLD_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 1185"];
-pub const QUANTUMHELLOWORLD_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1170"];
+pub const QUANTUMHELLOWORLD_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1245"];
 pub const SUPERPOSITION_EXPECT: Expect = expect![[r#"
     STATE:
     |0⟩: 0.7071+0.0000𝑖
@@ -158,4 +158,4 @@ pub const SUPERPOSITION_EXPECT_DEBUG: Expect = expect![[r#"
     Zero"#]];
 pub const SUPERPOSITION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 187"];
 pub const SUPERPOSITION_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1307"];
-pub const SUPERPOSITION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1368"];
+pub const SUPERPOSITION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1443"];

--- a/source/samples_test/src/tests/language.rs
+++ b/source/samples_test/src/tests/language.rs
@@ -11,7 +11,7 @@ pub const ARITHMETICOPERATORS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const ARITHMETICOPERATORS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const ARITHMETICOPERATORS_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 960"];
-pub const ARITHMETICOPERATORS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const ARITHMETICOPERATORS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const ARRAY_EXPECT: Expect = expect![[r#"
     Integer Array: [1, 2, 3, 4] of length 4
     String Array: [a, string, array]
@@ -32,7 +32,7 @@ pub const ARRAY_EXPECT_DEBUG: Expect = expect![[r#"
     [1, 2, 3, 4]"#]];
 pub const ARRAY_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const ARRAY_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1674"];
-pub const ARRAY_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1465"];
+pub const ARRAY_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1540"];
 pub const BIGINT_EXPECT: Expect = expect![[r#"
     Hexadecimal BigInt: 66
     Octal BigInt: 34
@@ -92,7 +92,7 @@ pub const BITWISEOPERATORS_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const BITWISEOPERATORS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const BITWISEOPERATORS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const BITWISEOPERATORS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const BITWISEOPERATORS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const BOOL_EXPECT: Expect = expect![[r#"
     AND operation: true
     OR operation: true
@@ -107,18 +107,18 @@ pub const BOOL_EXPECT_DEBUG: Expect = expect![[r#"
     true"#]];
 pub const BOOL_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const BOOL_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 959"];
-pub const BOOL_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 986"];
+pub const BOOL_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1061"];
 pub const BREAKANDCONTINUE_EXPECT: Expect = expect!["(8, 147, 9)"];
 pub const BREAKANDCONTINUE_EXPECT_DEBUG: Expect = expect!["(8, 147, 9)"];
 pub const BREAKANDCONTINUE_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const BREAKANDCONTINUE_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 1512"];
-pub const BREAKANDCONTINUE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1362"];
+pub const BREAKANDCONTINUE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1437"];
 pub const COMMENTS_EXPECT: Expect = expect!["[]"];
 pub const COMMENTS_EXPECT_DEBUG: Expect = expect!["[]"];
 pub const COMMENTS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const COMMENTS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const COMMENTS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const COMMENTS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const COMPARISONOPERATORS_EXPECT: Expect = expect![[r#"
     Equality comparison: true
     Equality comparison: false
@@ -158,7 +158,7 @@ pub const COMPARISONOPERATORS_EXPECT_DEBUG: Expect = expect![[r#"
 pub const COMPARISONOPERATORS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const COMPARISONOPERATORS_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 960"];
-pub const COMPARISONOPERATORS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const COMPARISONOPERATORS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const CONDITIONALBRANCHING_EXPECT: Expect = expect![[r#"
     Buzz
     It is livable
@@ -172,7 +172,8 @@ pub const CONDITIONALBRANCHING_EXPECT_DEBUG: Expect = expect![[r#"
 pub const CONDITIONALBRANCHING_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const CONDITIONALBRANCHING_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 960"];
-pub const CONDITIONALBRANCHING_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const CONDITIONALBRANCHING_EXPECT_QIR_ADAPTIVE: Expect =
+    expect!["generated QIR of length 1062"];
 pub const COPYANDUPDATEOPERATOR_EXPECT: Expect = expect![[r#"
     Updated array: [10, 11, 100, 13]
     Updated array: [10, 100, 12, 200]
@@ -185,14 +186,14 @@ pub const COPYANDUPDATEOPERATOR_EXPECT_CIRCUIT: Expect = expect!["generated circ
 pub const COPYANDUPDATEOPERATOR_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 960"];
 pub const COPYANDUPDATEOPERATOR_EXPECT_QIR_ADAPTIVE: Expect =
-    expect!["generated QIR of length 987"];
+    expect!["generated QIR of length 1062"];
 pub const CUSTOMMEASUREMENTS_EXPECT: Expect = expect!["Zero"];
 pub const CUSTOMMEASUREMENTS_EXPECT_DEBUG: Expect = expect!["Zero"];
 // SimulatableIntrinsic, custom measurements are not expected to work in the circuit generation.
 pub const CUSTOMMEASUREMENTS_EXPECT_CIRCUIT: Expect = expect!["circuit error: circuit error"];
 pub const CUSTOMMEASUREMENTS_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 1297"];
-pub const CUSTOMMEASUREMENTS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1358"];
+pub const CUSTOMMEASUREMENTS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1433"];
 pub const DATATYPES_EXPECT: Expect = expect![[r#"
     Binary BigInt: 42
     Octal BigInt: 42
@@ -209,7 +210,7 @@ pub const DATATYPES_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const DATATYPES_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4"];
 pub const DATATYPES_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const DATATYPES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const DATATYPES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const DIAGNOSTICS_EXPECT: Expect = expect![[r#"
     Program is starting.
     STATE:
@@ -224,17 +225,17 @@ pub const DIAGNOSTICS_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const DIAGNOSTICS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 215"];
 pub const DIAGNOSTICS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1463"];
-pub const DIAGNOSTICS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2290"];
+pub const DIAGNOSTICS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2365"];
 pub const DOUBLE_EXPECT: Expect = expect!["0.1973269804"];
 pub const DOUBLE_EXPECT_DEBUG: Expect = expect!["0.1973269804"];
 pub const DOUBLE_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const DOUBLE_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 979"];
-pub const DOUBLE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1006"];
+pub const DOUBLE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1081"];
 pub const ENTRYPOINT_EXPECT: Expect = expect!["[]"];
 pub const ENTRYPOINT_EXPECT_DEBUG: Expect = expect!["[]"];
 pub const ENTRYPOINT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const ENTRYPOINT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const ENTRYPOINT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const ENTRYPOINT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const FAILSTATEMENT_EXPECT: Expect = expect!["()"];
 pub const FAILSTATEMENT_EXPECT_DEBUG: Expect = expect!["()"];
 // Fail statements are expected to cause a circuit generation error since they cannot be executed.
@@ -247,17 +248,17 @@ pub const FORLOOPS_EXPECT: Expect = expect!["()"];
 pub const FORLOOPS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const FORLOOPS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const FORLOOPS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const FORLOOPS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const FORLOOPS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const FUNCTIONS_EXPECT: Expect = expect!["()"];
 pub const FUNCTIONS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const FUNCTIONS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const FUNCTIONS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const FUNCTIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const FUNCTIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const GETTINGSTARTED_EXPECT: Expect = expect!["()"];
 pub const GETTINGSTARTED_EXPECT_DEBUG: Expect = expect!["()"];
 pub const GETTINGSTARTED_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const GETTINGSTARTED_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const GETTINGSTARTED_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const GETTINGSTARTED_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const INT_EXPECT: Expect = expect![[r#"
     Hexadecimal: 66
     Octal: 34
@@ -278,7 +279,7 @@ pub const INT_EXPECT_DEBUG: Expect = expect![[r#"
     1"#]];
 pub const INT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const INT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 956"];
-pub const INT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 983"];
+pub const INT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1058"];
 pub const LAMBDAEXPRESSION_EXPECT: Expect = expect![[r#"
     Lambda add function result: 5
     Sum of array using Fold: 15
@@ -291,12 +292,12 @@ pub const LAMBDAEXPRESSION_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const LAMBDAEXPRESSION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4"];
 pub const LAMBDAEXPRESSION_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const LAMBDAEXPRESSION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const LAMBDAEXPRESSION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const LOGICALOPERATORS_EXPECT: Expect = expect!["()"];
 pub const LOGICALOPERATORS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const LOGICALOPERATORS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const LOGICALOPERATORS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const LOGICALOPERATORS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const LOGICALOPERATORS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const NAMESPACES_EXPECT: Expect = expect![[r#"
     STATE:
     No qubits allocated
@@ -307,7 +308,7 @@ pub const NAMESPACES_EXPECT_DEBUG: Expect = expect![[r#"
     []"#]];
 pub const NAMESPACES_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const NAMESPACES_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const NAMESPACES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const NAMESPACES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const OPERATIONS_EXPECT: Expect = expect![[r#"
     Measurement result: Zero
     Zero"#]];
@@ -316,12 +317,12 @@ pub const OPERATIONS_EXPECT_DEBUG: Expect = expect![[r#"
     Zero"#]];
 pub const OPERATIONS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 187"];
 pub const OPERATIONS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1428"];
-pub const OPERATIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1573"];
+pub const OPERATIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1648"];
 pub const PARALLEL_EXPECT: Expect = expect!["()"];
 pub const PARALLEL_EXPECT_DEBUG: Expect = expect!["()"];
 pub const PARALLEL_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 22638"];
 pub const PARALLEL_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 7028"];
-pub const PARALLEL_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 6350"];
+pub const PARALLEL_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 6425"];
 pub const PARTIALAPPLICATION_EXPECT: Expect = expect![[r#"
     five = incrementByOne(4) => 5
     Incremented array: [2, 3, 4, 5, 6]
@@ -333,7 +334,7 @@ pub const PARTIALAPPLICATION_EXPECT_DEBUG: Expect = expect![[r#"
 pub const PARTIALAPPLICATION_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const PARTIALAPPLICATION_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["generated QIR of length 960"];
-pub const PARTIALAPPLICATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const PARTIALAPPLICATION_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const PAULI_EXPECT: Expect = expect![[r#"
     Pauli dimension: PauliX
     Measurement result: Zero
@@ -344,12 +345,12 @@ pub const PAULI_EXPECT_DEBUG: Expect = expect![[r#"
     Zero"#]];
 pub const PAULI_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 223"];
 pub const PAULI_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1502"];
-pub const PAULI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1737"];
+pub const PAULI_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1812"];
 pub const QUANTUMMEMORY_EXPECT: Expect = expect!["()"];
 pub const QUANTUMMEMORY_EXPECT_DEBUG: Expect = expect!["()"];
 pub const QUANTUMMEMORY_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 40"];
 pub const QUANTUMMEMORY_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 961"];
-pub const QUANTUMMEMORY_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 988"];
+pub const QUANTUMMEMORY_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1063"];
 pub const QUBIT_EXPECT: Expect = expect![[r#"
     STATE:
     |1000⟩: 0.0000+0.5000𝑖
@@ -366,7 +367,7 @@ pub const QUBIT_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const QUBIT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 449"];
 pub const QUBIT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1819"];
-pub const QUBIT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2615"];
+pub const QUBIT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2690"];
 pub const RANGE_EXPECT: Expect = expect![[r#"
     Range: 1..3
     Range: 2..2..5
@@ -413,7 +414,7 @@ pub const REPEATUNTILLOOPS_EXPECT_CIRCUIT: Expect =
     expect!["compilation error: cannot have a loop with a dynamic condition"];
 pub const REPEATUNTILLOOPS_EXPECT_QIR_ADAPTIVE_RIF: Expect =
     expect!["compilation error: cannot have a loop with a dynamic condition"];
-pub const REPEATUNTILLOOPS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2077"];
+pub const REPEATUNTILLOOPS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 2155"];
 pub const RESULT_EXPECT: Expect = expect![[r#"
     Measurement: Zero
     Zero"#]];
@@ -422,17 +423,17 @@ pub const RESULT_EXPECT_DEBUG: Expect = expect![[r#"
     Zero"#]];
 pub const RESULT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 187"];
 pub const RESULT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1428"];
-pub const RESULT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1573"];
+pub const RESULT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1648"];
 pub const RETURNSTATEMENT_EXPECT: Expect = expect!["()"];
 pub const RETURNSTATEMENT_EXPECT_DEBUG: Expect = expect!["()"];
 pub const RETURNSTATEMENT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const RETURNSTATEMENT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const RETURNSTATEMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const RETURNSTATEMENT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const SPECIALIZATIONS_EXPECT: Expect = expect!["()"];
 pub const SPECIALIZATIONS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const SPECIALIZATIONS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 4540"];
 pub const SPECIALIZATIONS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 3106"];
-pub const SPECIALIZATIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 7939"];
+pub const SPECIALIZATIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 8014"];
 pub const STRING_EXPECT: Expect = expect![[r#"
     FooBar
     interpolated: FooBar
@@ -456,7 +457,7 @@ pub const TERNARY_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const TERNARY_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const TERNARY_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const TERNARY_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const TERNARY_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const TUPLE_EXPECT: Expect = expect![[r#"
     Tuple: (Id, 0, 1.0)
     Unpacked: Id, 0, 1.0
@@ -488,12 +489,12 @@ pub const TYPEDECLARATIONS_EXPECT: Expect = expect!["()"];
 pub const TYPEDECLARATIONS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const TYPEDECLARATIONS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const TYPEDECLARATIONS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const TYPEDECLARATIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const TYPEDECLARATIONS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const UNIT_EXPECT: Expect = expect!["()"];
 pub const UNIT_EXPECT_DEBUG: Expect = expect!["()"];
 pub const UNIT_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const UNIT_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const UNIT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const UNIT_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const VARIABLES_EXPECT: Expect = expect![[r#"
     Immutable Int: 42
     Mutable Int: 43
@@ -510,17 +511,17 @@ pub const VARIABLES_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const VARIABLES_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const VARIABLES_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const VARIABLES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const VARIABLES_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const WHILELOOPS_EXPECT: Expect = expect!["()"];
 pub const WHILELOOPS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const WHILELOOPS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const WHILELOOPS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const WHILELOOPS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const WHILELOOPS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const WITHINAPPLY_EXPECT: Expect = expect!["()"];
 pub const WITHINAPPLY_EXPECT_DEBUG: Expect = expect!["()"];
 pub const WITHINAPPLY_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 87"];
 pub const WITHINAPPLY_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 1278"];
-pub const WITHINAPPLY_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1547"];
+pub const WITHINAPPLY_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1622"];
 pub const CLASSCONSTRAINTS_EXPECT: Expect = expect![[r#"
     true
     false
@@ -539,9 +540,9 @@ pub const CLASSCONSTRAINTS_EXPECT_DEBUG: Expect = expect![[r#"
     ()"#]];
 pub const CLASSCONSTRAINTS_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const CLASSCONSTRAINTS_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const CLASSCONSTRAINTS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const CLASSCONSTRAINTS_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];
 pub const TESTATTRIBUTE_EXPECT: Expect = expect!["()"];
 pub const TESTATTRIBUTE_EXPECT_DEBUG: Expect = expect!["()"];
 pub const TESTATTRIBUTE_EXPECT_CIRCUIT: Expect = expect!["generated circuit of length 0"];
 pub const TESTATTRIBUTE_EXPECT_QIR_ADAPTIVE_RIF: Expect = expect!["generated QIR of length 960"];
-pub const TESTATTRIBUTE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 987"];
+pub const TESTATTRIBUTE_EXPECT_QIR_ADAPTIVE: Expect = expect!["generated QIR of length 1062"];


### PR DESCRIPTION
By using a specific set of attributes we can mark __quantum__rt__read_result as safe to optimize. Most of this change is snapshot updates for the new attributes at the bottom of the file and the [#2](https://github.com/microsoft/qdk/issues/2) that it adds to the declaration of the function.

Fixes #3687