### PR TITLE
Add canary test for internal Jupyter APIs

### DIFF
--- a/.github/workflows/jupyter-api-contract.yml
+++ b/.github/workflows/jupyter-api-contract.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   NODE_VERSION: "22.14.0"
+  PYTHON_VERSION: "3.11"
 
 jobs:
   jupyter-api-contract:
@@ -20,6 +21,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: npm ci
       - name: Check Jupyter API contract

--- a/.github/workflows/jupyter-api-contract.yml
+++ b/.github/workflows/jupyter-api-contract.yml
@@ -1,0 +1,26 @@
+name: Jupyter API Contract
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "22.14.0"
+
+jobs:
+  jupyter-api-contract:
+    name: Check Jupyter API contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Check Jupyter API contract
+        run: xvfb-run -a npm run test:jupyter-api-contract --workspace=./source/vscode

--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -1704,6 +1704,7 @@
     "build:watch": "node build.mjs --watch",
     "start": "npm exec --no -- @vscode/test-web --extensionDevelopmentPath . ../../samples",
     "test": "node ./test/runTests.mjs -- ",
+    "test:jupyter-api-contract": "node ./test/buildTests.mjs && node ./test/runTests.mjs --suite=jupyter-api-contract",
     "pretest": "npm exec --no playwright install chromium && node ./test/buildTests.mjs",
     "tsc:check:main": "node ../../node_modules/typescript/bin/tsc -p ./tsconfig.json",
     "tsc:check:view": "node ../../node_modules/typescript/bin/tsc -p ./src/webview/tsconfig.json",

--- a/source/vscode/test/buildTests.mjs
+++ b/source/vscode/test/buildTests.mjs
@@ -37,6 +37,7 @@ const platformBuildOptions = {
     entryPoints: [
       join(thisDir, "suites", "language-service", "index.node.ts"),
       join(thisDir, "suites", "debugger", "index.node.ts"),
+      join(thisDir, "suites", "jupyter-api-contract", "index.node.ts"),
     ],
     platform: "node",
     outdir: join(thisDir, "out", "node"),

--- a/source/vscode/test/runTests.mjs
+++ b/source/vscode/test/runTests.mjs
@@ -23,7 +23,8 @@ import {
   runTests as runTestsElectron,
   runVSCodeCommand,
 } from "@vscode/test-electron";
-import { readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { SourceMap } from "node:module";
 import path, { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -99,17 +100,81 @@ async function runJupyterApiContractSuite() {
   const profilePath = join(cachePath, "jupyter-api-contract");
   const extensionsPath = join(profilePath, "extensions");
   const userDataPath = join(profilePath, "user-data");
+  const workspacePath = join(profilePath, "workspace");
+  const venvPath = join(workspacePath, ".venv");
+  const pythonPath = join(
+    venvPath,
+    process.platform === "win32" ? "Scripts" : "bin",
+    process.platform === "win32" ? "python.exe" : "python",
+  );
   const profileArgs = [
     `--extensions-dir=${extensionsPath}`,
     `--user-data-dir=${userDataPath}`,
   ];
 
   rmSync(profilePath, { recursive: true, force: true });
+  mkdirSync(join(workspacePath, ".vscode"), { recursive: true });
+  writeFileSync(
+    join(workspacePath, ".vscode", "settings.json"),
+    JSON.stringify({ "python.useEnvironmentsExtension": true }, null, 2),
+  );
+  writeFileSync(
+    join(workspacePath, "jupyter-api-contract.ipynb"),
+    JSON.stringify(
+      {
+        cells: [
+          {
+            cell_type: "code",
+            execution_count: null,
+            metadata: { language: "python" },
+            outputs: [],
+            source: ['print("Jupyter API contract")\n'],
+          },
+        ],
+        metadata: {
+          kernelspec: {
+            display_name: "Python 3",
+            language: "python",
+            name: "python3",
+          },
+          language_info: { name: "python" },
+        },
+        nbformat: 4,
+        nbformat_minor: 5,
+      },
+      null,
+      2,
+    ),
+  );
 
-  console.log("Installing the latest Jupyter extension from Marketplace...");
+  console.log("Creating the Jupyter API contract virtual environment...");
+  runCommand("python", ["-m", "venv", venvPath], workspacePath);
+  runCommand(
+    pythonPath,
+    [
+      "-m",
+      "pip",
+      "install",
+      "--disable-pip-version-check",
+      "--no-input",
+      "ipykernel>=6,<7",
+    ],
+    workspacePath,
+  );
+
+  console.log("Installing Python and Jupyter extensions from Marketplace...");
   // Note that this throws if installation fails
   const installResult = await runVSCodeCommand(
-    ["--install-extension", "ms-toolsai.jupyter", "--force", ...profileArgs],
+    [
+      "--install-extension",
+      "ms-python.python",
+      "--install-extension",
+      "ms-python.vscode-python-envs",
+      "--install-extension",
+      "ms-toolsai.jupyter",
+      "--force",
+      ...profileArgs,
+    ],
     { version: "stable", cachePath },
   );
   if (installResult.stdout.trim()) {
@@ -131,12 +196,28 @@ async function runJupyterApiContractSuite() {
       "jupyter-api-contract",
       "index.node.js",
     ),
-    launchArgs: [
-      join(thisDir, "suites", "empty", "test-workspace"),
-      "--log=info",
-      ...profileArgs,
-    ],
+    extensionTestsEnv: {
+      JUPYTER_API_TEST_PYTHON_PATH: pythonPath,
+    },
+    launchArgs: [workspacePath, "--log=info", ...profileArgs],
   });
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {string} cwd
+ */
+function runCommand(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed with exit code ${result.status ?? result.signal}`,
+    );
+  }
 }
 
 async function runSuite(name) {

--- a/source/vscode/test/runTests.mjs
+++ b/source/vscode/test/runTests.mjs
@@ -11,7 +11,7 @@
 // it in a headless instance of Chromium to run the integration test suite.
 //
 // Command-line arguments:
-// --suite=<name>           Run only the specified test suite (language-service or debugger)
+// --suite=<name>           Run only the specified test suite
 // --waitForDebugger=<port> Wait for debugger to attach on the specified port before running tests
 // --verbose                Enable verbose logging for VS Code and test web server
 //                          Note: This controls the VS Code and test web server logging level.
@@ -19,8 +19,11 @@
 //                          To control the Q# extension log level see: suites/extensionUtils.ts
 
 import { runTests as runTestsWeb } from "@vscode/test-web";
-import { runTests as runTestsElectron } from "@vscode/test-electron";
-import { readFileSync } from "node:fs";
+import {
+  runTests as runTestsElectron,
+  runVSCodeCommand,
+} from "@vscode/test-electron";
+import { readFileSync, rmSync } from "node:fs";
 import { SourceMap } from "node:module";
 import path, { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,37 +55,88 @@ const thisDir = dirname(fileURLToPath(import.meta.url));
 const extensionDevelopmentPath = join(thisDir, "..");
 
 try {
-  // Run the "empty" suite first to verify VS Code can be downloaded and launched.
-  // This catches flaky infrastructure failures (e.g. VS Code download issues)
-  // before running the real test suites. If it fails in CI, we skip the tests
-  // with a warning instead of failing the build.
-  console.log("Running empty suite to verify VS Code test environment...");
-  try {
-    await runSuite("empty");
-  } catch (err) {
-    if (isCI) {
-      console.warn(
-        "WARNING: VS Code test environment setup failed. " +
-          "Skipping integration tests in CI due to infrastructure issue.",
-      );
-      console.warn(`Error: ${err}`);
-      process.exit(0);
+  if (selectedSuite === "jupyter-api-contract") {
+    await runJupyterApiContractSuite();
+  } else {
+    // Run the "empty" suite first to verify VS Code can be downloaded and launched.
+    // This catches flaky infrastructure failures (e.g. VS Code download issues)
+    // before running the real test suites. If it fails in CI, we skip the tests
+    // with a warning instead of failing the build.
+    console.log("Running empty suite to verify VS Code test environment...");
+    try {
+      await runSuite("empty");
+    } catch (err) {
+      if (isCI) {
+        console.warn(
+          "WARNING: VS Code test environment setup failed. " +
+            "Skipping integration tests in CI due to infrastructure issue.",
+        );
+        console.warn(`Error: ${err}`);
+        process.exit(0);
+      }
+      throw err;
     }
-    throw err;
-  }
-  console.log("Empty suite succeeded.");
+    console.log("Empty suite succeeded.");
 
-  const suites = ["language-service", "debugger"];
-  const toRun =
-    selectedSuite && suites.includes(selectedSuite) ? [selectedSuite] : suites;
+    const suites = ["language-service", "debugger"];
+    const toRun =
+      selectedSuite && suites.includes(selectedSuite)
+        ? [selectedSuite]
+        : suites;
 
-  for (const suite of toRun) {
-    console.log(`Running suite: ${suite}`);
-    await runSuite(suite);
+    for (const suite of toRun) {
+      console.log(`Running suite: ${suite}`);
+      await runSuite(suite);
+    }
   }
-} catch {
-  console.error("Test run failed.");
+} catch (err) {
+  console.error("Test run failed.", err);
   process.exit(1);
+}
+
+async function runJupyterApiContractSuite() {
+  const cachePath = join(extensionDevelopmentPath, ".vscode-test");
+  const profilePath = join(cachePath, "jupyter-api-contract");
+  const extensionsPath = join(profilePath, "extensions");
+  const userDataPath = join(profilePath, "user-data");
+  const profileArgs = [
+    `--extensions-dir=${extensionsPath}`,
+    `--user-data-dir=${userDataPath}`,
+  ];
+
+  rmSync(profilePath, { recursive: true, force: true });
+
+  console.log("Installing the latest Jupyter extension from Marketplace...");
+  // Note that this throws if installation fails
+  const installResult = await runVSCodeCommand(
+    ["--install-extension", "ms-toolsai.jupyter", "--force", ...profileArgs],
+    { version: "stable", cachePath },
+  );
+  if (installResult.stdout.trim()) {
+    console.log(installResult.stdout.trim());
+  }
+  if (installResult.stderr.trim()) {
+    console.error(installResult.stderr.trim());
+  }
+
+  console.log("Running Jupyter API contract suite...");
+  await runTestsElectron({
+    version: "stable",
+    cachePath,
+    extensionDevelopmentPath,
+    extensionTestsPath: join(
+      thisDir,
+      "out",
+      "node",
+      "jupyter-api-contract",
+      "index.node.js",
+    ),
+    launchArgs: [
+      join(thisDir, "suites", "empty", "test-workspace"),
+      "--log=info",
+      ...profileArgs,
+    ],
+  });
 }
 
 async function runSuite(name) {

--- a/source/vscode/test/suites/jupyter-api-contract/index.node.ts
+++ b/source/vscode/test/suites/jupyter-api-contract/index.node.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { runMochaTests } from "../runNode";
+import { TEST_TIMEOUT_MS } from "../extensionUtils";
+
+export function run(): Promise<void> {
+  return runMochaTests(
+    () => {
+      require("./jupyter-api-contract.test"); // eslint-disable-line @typescript-eslint/no-require-imports
+    },
+    { timeout: TEST_TIMEOUT_MS },
+  );
+}

--- a/source/vscode/test/suites/jupyter-api-contract/jupyter-api-contract.test.ts
+++ b/source/vscode/test/suites/jupyter-api-contract/jupyter-api-contract.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { assert } from "chai";
+import * as vscode from "vscode";
+import { TEST_TIMEOUT_MS } from "../extensionUtils";
+
+suite("Jupyter API contract", function () {
+  this.timeout(TEST_TIMEOUT_MS);
+
+  let api: Record<string, unknown>;
+  let version: string;
+
+  suiteSetup(async () => {
+    const extension =
+      vscode.extensions.getExtension<unknown>("ms-toolsai.jupyter");
+    assert.isDefined(
+      extension,
+      "The Jupyter extension must be installed for this contract test",
+    );
+
+    version = String(extension.packageJSON.version ?? "unknown");
+    console.info(`Testing Jupyter extension API version ${version}`);
+
+    const exports: unknown = await extension.activate();
+    assert.isObject(
+      exports,
+      `Jupyter ${version} activation must return an API object`,
+    );
+    api = exports as Record<string, unknown>;
+  });
+
+  test("exports openNotebook", () => {
+    assert.isFunction(
+      api.openNotebook,
+      `Jupyter ${version} must export openNotebook`,
+    );
+  });
+
+  test("exports a Python environment change event", () => {
+    const onDidChangePythonEnvironment = getRequiredFunction(
+      "onDidChangePythonEnvironment",
+    );
+    let subscription: unknown;
+    try {
+      subscription = onDidChangePythonEnvironment(() => undefined);
+      assert.isObject(
+        subscription,
+        `Jupyter ${version} onDidChangePythonEnvironment must return a disposable`,
+      );
+      assert.isFunction(
+        (subscription as Record<string, unknown>).dispose,
+        `Jupyter ${version} event subscription must be disposable`,
+      );
+    } finally {
+      const subscriptionRecord = subscription as
+        | Record<string, unknown>
+        | undefined;
+      if (typeof subscriptionRecord?.dispose === "function") {
+        subscriptionRecord.dispose();
+      }
+    }
+  });
+
+  test("returns the expected Python environment shape", () => {
+    const getPythonEnvironment = getRequiredFunction("getPythonEnvironment");
+    const environment = getPythonEnvironment(
+      vscode.Uri.parse("untitled:jupyter-api-contract.ipynb"),
+    );
+    if (environment === undefined) {
+      return;
+    }
+
+    assert.isObject(
+      environment,
+      `Jupyter ${version} getPythonEnvironment must return an object or undefined`,
+    );
+    const environmentRecord = environment as Record<string, unknown>;
+    assert.isString(
+      environmentRecord.id,
+      `Jupyter ${version} Python environment ID must be a string`,
+    );
+    assert.isString(
+      environmentRecord.path,
+      `Jupyter ${version} Python environment path must be a string`,
+    );
+  });
+
+  function getRequiredFunction(name: string): (...args: unknown[]) => unknown {
+    const member = api[name];
+    assert.isFunction(member, `Jupyter ${version} must export ${name}`);
+    return member as (...args: unknown[]) => unknown;
+  }
+});

--- a/source/vscode/test/suites/jupyter-api-contract/jupyter-api-contract.test.ts
+++ b/source/vscode/test/suites/jupyter-api-contract/jupyter-api-contract.test.ts
@@ -90,19 +90,18 @@ suite("Jupyter API contract", function () {
     );
 
     let resolveEnvironmentChanged: () => void;
-    let rejectEnvironmentChanged: (reason: Error) => void;
+    let rejectEnvironmentChanged!: (reason: Error) => void;
     const environmentChanged = new Promise<void>((resolve, reject) => {
       resolveEnvironmentChanged = resolve;
       rejectEnvironmentChanged = reject;
     });
+    const environmentChangeTimeoutError = new Error(
+      `Jupyter ${version} did not report an environment change for the test notebook`,
+    );
     const eventTimeout = setTimeout(
-      () =>
-        rejectEnvironmentChanged(
-          new Error(
-            `Jupyter ${version} did not report an environment change for the test notebook`,
-          ),
-        ),
+      rejectEnvironmentChanged,
       60_000,
+      environmentChangeTimeoutError,
     );
 
     const subscription = onDidChangePythonEnvironment.call(

--- a/source/vscode/test/suites/jupyter-api-contract/jupyter-api-contract.test.ts
+++ b/source/vscode/test/suites/jupyter-api-contract/jupyter-api-contract.test.ts
@@ -8,7 +8,7 @@ import { TEST_TIMEOUT_MS } from "../extensionUtils";
 suite("Jupyter API contract", function () {
   this.timeout(TEST_TIMEOUT_MS);
 
-  let api: Record<string, unknown>;
+  let jupyterApi: Record<string, unknown>;
   let version: string;
 
   suiteSetup(async () => {
@@ -27,68 +27,175 @@ suite("Jupyter API contract", function () {
       exports,
       `Jupyter ${version} activation must return an API object`,
     );
-    api = exports as Record<string, unknown>;
+    jupyterApi = exports as Record<string, unknown>;
   });
 
-  test("exports openNotebook", () => {
-    assert.isFunction(
-      api.openNotebook,
-      `Jupyter ${version} must export openNotebook`,
+  test("opens a notebook with a Python environment", async () => {
+    const pythonPath = process.env.JUPYTER_API_TEST_PYTHON_PATH;
+    assert.isString(
+      pythonPath,
+      "The test runner must provide a Python environment path",
     );
-  });
 
-  test("exports a Python environment change event", () => {
+    const pythonExtension =
+      vscode.extensions.getExtension<unknown>("ms-python.python");
+    assert.isDefined(
+      pythonExtension,
+      "The Python extension must be installed for this contract test",
+    );
+    const pythonExports: unknown = await pythonExtension.activate();
+    assert.isObject(
+      pythonExports,
+      "Python extension activation must return an API object",
+    );
+    const pythonApi = pythonExports as Record<string, unknown>;
+    assert.isObject(
+      pythonApi.environments,
+      "The Python extension must export its environments API",
+    );
+    const environments = pythonApi.environments as Record<string, unknown>;
+    const resolveEnvironment = getRequiredFunction(
+      environments,
+      "resolveEnvironment",
+      "Python",
+    );
+    const resolvedEnvironment = await resolveEnvironment.call(
+      environments,
+      pythonPath,
+    );
+    assertEnvironment(resolvedEnvironment, "resolved Python environment");
+    const expectedEnvironment = resolvedEnvironment as Record<string, string>;
+
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.isDefined(workspaceFolder, "The test workspace must be open");
+    const notebookUri = vscode.Uri.joinPath(
+      workspaceFolder.uri,
+      "jupyter-api-contract.ipynb",
+    );
+
+    const openNotebook = getRequiredFunction(
+      jupyterApi,
+      "openNotebook",
+      `Jupyter ${version}`,
+    );
     const onDidChangePythonEnvironment = getRequiredFunction(
+      jupyterApi,
       "onDidChangePythonEnvironment",
+      `Jupyter ${version}`,
     );
-    let subscription: unknown;
+    const getPythonEnvironment = getRequiredFunction(
+      jupyterApi,
+      "getPythonEnvironment",
+      `Jupyter ${version}`,
+    );
+
+    let resolveEnvironmentChanged: () => void;
+    let rejectEnvironmentChanged: (reason: Error) => void;
+    const environmentChanged = new Promise<void>((resolve, reject) => {
+      resolveEnvironmentChanged = resolve;
+      rejectEnvironmentChanged = reject;
+    });
+    const eventTimeout = setTimeout(
+      () =>
+        rejectEnvironmentChanged(
+          new Error(
+            `Jupyter ${version} did not report an environment change for the test notebook`,
+          ),
+        ),
+      60_000,
+    );
+
+    const subscription = onDidChangePythonEnvironment.call(
+      jupyterApi,
+      (changedUri: unknown) => {
+        if (
+          typeof (changedUri as vscode.Uri | undefined)?.toString !== "function"
+        ) {
+          clearTimeout(eventTimeout);
+          rejectEnvironmentChanged(
+            new Error(
+              `Jupyter ${version} emitted an environment change without a URI`,
+            ),
+          );
+          return;
+        }
+        if ((changedUri as vscode.Uri).toString() === notebookUri.toString()) {
+          clearTimeout(eventTimeout);
+          resolveEnvironmentChanged();
+        }
+      },
+    );
+    assertDisposable(subscription);
+
     try {
-      subscription = onDidChangePythonEnvironment(() => undefined);
-      assert.isObject(
-        subscription,
-        `Jupyter ${version} onDidChangePythonEnvironment must return a disposable`,
+      await openNotebook.call(jupyterApi, notebookUri, {
+        id: expectedEnvironment.id,
+        path: expectedEnvironment.path,
+      });
+      await environmentChanged;
+
+      assert.equal(
+        vscode.window.activeNotebookEditor?.notebook.uri.toString(),
+        notebookUri.toString(),
+        `Jupyter ${version} must open the requested notebook`,
       );
-      assert.isFunction(
-        (subscription as Record<string, unknown>).dispose,
-        `Jupyter ${version} event subscription must be disposable`,
+
+      const actualEnvironment = getPythonEnvironment.call(
+        jupyterApi,
+        notebookUri,
+      );
+      assertEnvironment(actualEnvironment, "notebook Python environment");
+      const actualEnvironmentRecord = actualEnvironment as Record<
+        string,
+        string
+      >;
+      assert.equal(actualEnvironmentRecord.id, expectedEnvironment.id);
+      assert.equal(
+        normalizePath(actualEnvironmentRecord.path),
+        normalizePath(expectedEnvironment.path),
       );
     } finally {
-      const subscriptionRecord = subscription as
-        | Record<string, unknown>
-        | undefined;
-      if (typeof subscriptionRecord?.dispose === "function") {
-        subscriptionRecord.dispose();
-      }
+      clearTimeout(eventTimeout);
+      (subscription as { dispose(): void }).dispose();
     }
   });
 
-  test("returns the expected Python environment shape", () => {
-    const getPythonEnvironment = getRequiredFunction("getPythonEnvironment");
-    const environment = getPythonEnvironment(
-      vscode.Uri.parse("untitled:jupyter-api-contract.ipynb"),
-    );
-    if (environment === undefined) {
-      return;
-    }
-
-    assert.isObject(
-      environment,
-      `Jupyter ${version} getPythonEnvironment must return an object or undefined`,
-    );
+  function assertEnvironment(environment: unknown, description: string): void {
+    assert.isObject(environment, `The ${description} must be an object`);
     const environmentRecord = environment as Record<string, unknown>;
     assert.isString(
       environmentRecord.id,
-      `Jupyter ${version} Python environment ID must be a string`,
+      `The ${description} ID must be a string`,
     );
     assert.isString(
       environmentRecord.path,
-      `Jupyter ${version} Python environment path must be a string`,
+      `The ${description} path must be a string`,
     );
-  });
+  }
 
-  function getRequiredFunction(name: string): (...args: unknown[]) => unknown {
-    const member = api[name];
-    assert.isFunction(member, `Jupyter ${version} must export ${name}`);
+  function assertDisposable(disposable: unknown): void {
+    assert.isObject(
+      disposable,
+      `Jupyter ${version} onDidChangePythonEnvironment must return a disposable`,
+    );
+    assert.isFunction(
+      (disposable as Record<string, unknown>).dispose,
+      `Jupyter ${version} event subscription must be disposable`,
+    );
+  }
+
+  function getRequiredFunction(
+    target: Record<string, unknown>,
+    name: string,
+    owner: string,
+  ): (...args: unknown[]) => unknown {
+    const member = target[name];
+    assert.isFunction(member, `${owner} must export ${name}`);
     return member as (...args: unknown[]) => unknown;
+  }
+
+  function normalizePath(value: string): string {
+    const path = vscode.Uri.file(value).fsPath;
+    return process.platform === "win32" ? path.toLowerCase() : path;
   }
 });


### PR DESCRIPTION
The two commits in this PR show two different approaches.  The first minimally confirms that the APIs are accessible.  The second actually uses them.