### PR TITLE
Simplify STIM-to-QIR snapshot tests

### DIFF
--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -247,7 +247,8 @@ block_c{pauli}_exit:
 
     fn write_declarations(&mut self) {
         writeln!(self);
-        let decls: Vec<String> = self.used_intrinsics.values().cloned().collect();
+        let mut decls: Vec<String> = self.used_intrinsics.values().cloned().collect();
+        decls.sort_unstable();
         for decl in decls {
             writeln!(self, "{decl}");
         }

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -254,7 +254,8 @@ block_c{pauli}_exit:
     }
 
     fn write_definitions(&mut self) {
-        let definitions: Vec<String> = self.defined_functions.values().cloned().collect();
+        let mut definitions: Vec<String> = self.defined_functions.values().cloned().collect();
+        definitions.sort_unstable();
         for definition in definitions {
             writeln!(self);
             writeln!(self, "{definition}");

--- a/source/compiler/stim_compiler/src/qir.rs
+++ b/source/compiler/stim_compiler/src/qir.rs
@@ -274,13 +274,11 @@ block_c{pauli}_exit:
             "attributes #0 = {{ \"entry_point\" \"output_labeling_schema\" \"qir_profiles\"=\"adaptive_profile\" \"required_num_qubits\"=\"{num_qubits}\" \"required_num_results\"=\"{num_results}\" }}"
         );
         writeln!(self, "attributes #1 = {{ \"irreversible\" }}");
-        writeln!(self);
-        writeln!(self, "; module flags");
-        writeln!(self);
         if self.has_noise_intrinsic {
             writeln!(self, "attributes #2 = {{ \"qdk_noise\" }}");
-            writeln!(self);
         }
+        writeln!(self);
+        writeln!(self, "; module flags");
         writeln!(
             self,
             "!llvm.module.flags = !{{!0, !1, !2, !3, !4, !5, !6, !7}}"

--- a/source/compiler/stim_compiler/src/qir/tests.rs
+++ b/source/compiler/stim_compiler/src/qir/tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod boilerplate;
 mod collapsing_gates;
 mod collapsing_gates_broadcasting;
 mod generalized_pauli_product_gates;
@@ -19,61 +20,135 @@ mod two_qubit_gates;
 mod two_qubit_gates_broadcasting;
 mod unsupported_instructions;
 
-use expect_test::{Expect, expect};
+use expect_test::Expect;
+use indoc::formatdoc;
 use qdk_simulators::noise_config::NoiseConfig;
 
 use crate::format_stim_errors;
 
+// QIR boilerplate omitted from most snapshots is covered by dedicated tests.
+const BOILERPLATE_BODY_LINES: [&str; 2] = [
+    "call void @__quantum__rt__initialize(ptr null)",
+    "ret i64 0",
+];
+const BOILERPLATE_OUTPUT_CALLS: [&str; 2] = [
+    "call void @__quantum__rt__array_record_output(",
+    "call void @__quantum__rt__result_record_output(",
+];
+const BOILERPLATE_DECLARATIONS: [&str; 3] = [
+    "declare void @__quantum__rt__array_record_output(i64, ptr)",
+    "declare void @__quantum__rt__initialize(ptr)",
+    "declare void @__quantum__rt__result_record_output(ptr, ptr)",
+];
+
+// This formats the QIR output to only include parts that aren't boilerplate,
+// and to make it easier to read and compare in tests. It also includes the
+// noise configuration, if noise instructions were used.
+fn format_qir(qir: &str, noise: &NoiseConfig<f64, f64>) -> String {
+    let (body, remainder) = qir
+        .strip_prefix("define i64 @ENTRYPOINT__main() #0 {\n")
+        .and_then(|qir| qir.split_once("\n}\n"))
+        .expect("QIR boilerplate should contain the entry-point definition");
+
+    let definitions = remainder
+        .split_once("declare ")
+        .map(|(definitions, _)| definitions.trim())
+        .expect("QIR boilerplate should contain declarations");
+
+    let required_num_qubits = extract_parameter(qir, "required_num_qubits");
+    let required_num_results = extract_parameter(qir, "required_num_results");
+
+    let body = indent_lines(body.lines().filter(|line| {
+        let line = line.trim_start();
+        !BOILERPLATE_BODY_LINES.contains(&line)
+            && !BOILERPLATE_OUTPUT_CALLS
+                .iter()
+                .any(|call| line.starts_with(call))
+    }));
+    let body = if body.is_empty() {
+        String::new()
+    } else {
+        format!("body:\n{body}\n\n")
+    };
+
+    let mut declarations = qir
+        .lines()
+        .filter(|line| line.starts_with("declare "))
+        .filter(|line| !BOILERPLATE_DECLARATIONS.contains(line))
+        .collect::<Vec<_>>();
+    declarations.sort_unstable();
+    let declarations = indent_lines(declarations);
+    let declarations = if declarations.is_empty() {
+        String::new()
+    } else {
+        format!("declarations:\n{declarations}\n\n")
+    };
+
+    let definitions = if definitions.is_empty() {
+        String::new()
+    } else {
+        format!("definitions:\n{}\n\n", indent_lines(definitions.lines()))
+    };
+
+    let uses_noise = if qir.contains("\"qdk_noise\"") {
+        "uses_noise: true\n"
+    } else {
+        ""
+    };
+
+    let noise_config = if noise.is_noiseless() {
+        String::new()
+    } else {
+        noise.to_string()
+    };
+
+    formatdoc! {"
+        {body}\
+        {definitions}\
+        {declarations}\
+        required_num_qubits: {required_num_qubits}
+        required_num_results: {required_num_results}
+        {uses_noise}
+        {noise_config}
+    "}
+    .trim_end()
+    .to_string()
+}
+
+fn extract_parameter(qir: &str, name: &str) -> String {
+    let marker = format!("\"{name}\"=\"");
+    qir.split_once(&marker)
+        .and_then(|(_, value)| value.split_once('"'))
+        .map(|(value, _)| value.to_string())
+        .unwrap_or_else(|| panic!("QIR boilerplate should contain the {name} parameter"))
+}
+
+fn indent_lines<'a>(lines: impl IntoIterator<Item = &'a str>) -> String {
+    lines
+        .into_iter()
+        .map(|line| {
+            if line.is_empty() {
+                String::new()
+            } else {
+                format!("  {line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Check that a stim source compiles to the
-/// expected QIR or yields the expected errors.
+/// expected formatted QIR or yields the expected errors.
 fn check(source: &str, expect: &Expect) {
     let mut noise = NoiseConfig::NOISELESS;
     match crate::compile(source, &mut noise) {
         Ok(qir) => {
-            let actual = if noise.is_noiseless() {
-                qir
-            } else {
-                noise.to_string() + "\n" + &qir
-            };
-            expect.assert_eq(&actual);
+            let formatted_qir = format_qir(&qir, &noise);
+            expect.assert_eq(&formatted_qir);
         }
         Err(errors) => {
             let errors = format_stim_errors(errors);
             expect.assert_eq(&errors);
         }
     }
-}
-
-#[test]
-fn empty_src() {
-    check(
-        "",
-        &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
-    );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/boilerplate.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/boilerplate.rs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use expect_test::{Expect, expect};
+use qdk_simulators::noise_config::NoiseConfig;
+
+use crate::format_stim_errors;
+
+fn check(source: &str, expect: &Expect) {
+    let mut noise = NoiseConfig::NOISELESS;
+    match crate::compile(source, &mut noise) {
+        Ok(qir) => expect.assert_eq(&qir),
+        Err(errors) => {
+            let errors = format_stim_errors(errors);
+            expect.assert_eq(&errors);
+        }
+    }
+}
+
+// Check that the QIR boilerplate is generally correct
+#[test]
+fn empty_src() {
+    check(
+        "",
+        &expect![[r#"
+            define i64 @ENTRYPOINT__main() #0 {
+              call void @__quantum__rt__initialize(ptr null)
+              call void @__quantum__rt__array_record_output(i64 0, ptr null)
+              ret i64 0
+            }
+
+            declare void @__quantum__rt__array_record_output(i64, ptr)
+            declare void @__quantum__rt__initialize(ptr)
+            declare void @__quantum__rt__result_record_output(ptr, ptr)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+            !0 = !{i32 1, !"qir_major_version", i32 2}
+            !1 = !{i32 7, !"qir_minor_version", i32 1}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 5, !"int_computations", !{!"i64"}}
+            !5 = !{i32 5, !"float_computations", !{!"double"}}
+            !6 = !{i32 7, !"backwards_branching", i2 3}
+            !7 = !{i32 1, !"arrays", i1 true}
+        "#]],
+    );
+}
+
+// Checks the result_record_output calls are correctly generated
+#[test]
+fn measured_qir_has_expected_boilerplate() {
+    check(
+        "M 0 1",
+        &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+          call void @__quantum__rt__array_record_output(i64 2, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__qis__m__body(ptr, ptr)
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]],
+    );
+}
+
+// Checks that the qdk_noise attribute is correctly generated whenever there is noise.
+#[test]
+fn noisy_qir_has_expected_boilerplate() {
+    check(
+        "M(0.1) 0",
+        &expect![[r#"
+        define i64 @ENTRYPOINT__main() #0 {
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__rt__array_record_output(i64 1, ptr null)
+          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
+          ret i64 0
+        }
+
+        declare void @__quantum__qis__m__body(ptr, ptr)
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+        declare void @__quantum__rt__initialize(ptr)
+        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
+        declare void @__quantum__rt__result_record_output(ptr, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+        attributes #2 = { "qdk_noise" }
+
+        ; module flags
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+    "#]],
+    );
+}

--- a/source/compiler/stim_compiler/src/qir/tests/collapsing_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/collapsing_gates.rs
@@ -10,35 +10,14 @@ fn m_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -47,39 +26,17 @@ fn m_gate_with_readout_noise_yields_expected_qir() {
     check(
         "M(0.1) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -88,35 +45,14 @@ fn m_gate_with_zero_readout_noise_emits_no_noise_call() {
     check(
         "M(0.0) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -125,39 +61,17 @@ fn m_gate_with_max_readout_noise_yields_expected_qir() {
     check(
         "M(1.0) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 1.0, double 1.0, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 1.0, double 1.0, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -228,35 +142,14 @@ fn mr_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -265,39 +158,17 @@ fn mr_gate_with_readout_noise_yields_expected_qir() {
     check(
         "MR(0.1) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -307,38 +178,17 @@ fn mrx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -347,42 +197,20 @@ fn mrx_gate_with_readout_noise_yields_expected_qir() {
     check(
         "MRX(0.1) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -392,42 +220,21 @@ fn mry_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -436,46 +243,24 @@ fn mry_gate_with_readout_noise_yields_expected_qir() {
     check(
         "MRY(0.1) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -485,35 +270,14 @@ fn mrz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -523,38 +287,17 @@ fn mx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -563,42 +306,20 @@ fn mx_gate_with_readout_noise_yields_expected_qir() {
     check(
         "MX(0.1) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -608,42 +329,21 @@ fn my_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -652,46 +352,24 @@ fn my_gate_with_readout_noise_yields_expected_qir() {
     check(
         "MY(0.1) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -701,35 +379,14 @@ fn mz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -739,34 +396,14 @@ fn r_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__reset__body(ptr)
+            declarations:
+              declare void @__quantum__qis__reset__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -776,36 +413,16 @@ fn rx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__reset__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__reset__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -815,38 +432,18 @@ fn ry_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__reset__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__reset__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -856,38 +453,17 @@ fn m_gate_with_negated_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -897,41 +473,20 @@ fn mx_gate_with_negated_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -940,45 +495,23 @@ fn mx_gate_with_negated_target_and_readout_noise_yields_expected_qir() {
     check(
         "MX(0.1) !0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -988,45 +521,24 @@ fn my_gate_with_negated_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -1036,37 +548,16 @@ fn mr_gate_with_negated_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -1076,40 +567,19 @@ fn mrx_gate_with_negated_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -1119,44 +589,23 @@ fn mry_gate_with_negated_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -1166,33 +615,13 @@ fn rz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__reset__body(ptr)
+            declarations:
+              declare void @__quantum__qis__reset__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/collapsing_gates_broadcasting.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/collapsing_gates_broadcasting.rs
@@ -10,37 +10,15 @@ fn m_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -49,42 +27,19 @@ fn m_gate_with_readout_noise_yields_expected_qir() {
     check(
         "M(0.1) 0 1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.1, double 0.1, ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2
+            uses_noise: true"#]],
     );
 }
 
@@ -94,37 +49,15 @@ fn mr_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -134,42 +67,20 @@ fn mrx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -179,48 +90,26 @@ fn mry_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -230,37 +119,15 @@ fn mrz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__mresetz__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -270,42 +137,20 @@ fn mx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -315,48 +160,26 @@ fn my_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -366,37 +189,15 @@ fn mz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -406,35 +207,15 @@ fn r_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__reset__body(ptr)
+            declarations:
+              declare void @__quantum__qis__reset__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -444,38 +225,18 @@ fn rx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__reset__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__reset__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -485,41 +246,21 @@ fn ry_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__reset__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__reset__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -529,34 +270,14 @@ fn rz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__reset__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__reset__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__reset__body(ptr)
+            declarations:
+              declare void @__quantum__qis__reset__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/generalized_pauli_product_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/generalized_pauli_product_gates.rs
@@ -11,38 +11,17 @@ fn mpp_single_x_yields_expected_qir() {
     check(
         "MPP X0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -52,42 +31,21 @@ fn mpp_single_y_yields_expected_qir() {
     check(
         "MPP Y0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -97,35 +55,14 @@ fn mpp_single_z_yields_expected_qir() {
     check(
         "MPP Z0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -135,38 +72,17 @@ fn mpp_negated_single_pauli_yields_expected_qir() {
     check(
         "MPP !Z5",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -175,47 +91,26 @@ fn mpp_two_factor_product_yields_expected_qir() {
     check(
         "MPP X1*Y2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -225,40 +120,19 @@ fn mpp_three_factor_product_yields_expected_qir() {
     check(
         "MPP Z3*Z4*Z5",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 1"#]],
     );
 }
 
@@ -267,49 +141,28 @@ fn mpp_product_of_all_three_bases_yields_expected_qir() {
     check(
         "MPP X0*Y1*Z2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 1"#]],
     );
 }
 
@@ -319,43 +172,22 @@ fn mpp_negated_product_yields_expected_qir() {
     check(
         "MPP !Z3*Z4*Z5",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 1"#]],
     );
 }
 
@@ -364,50 +196,29 @@ fn mpp_negation_on_later_factor_negates_whole_product() {
     check(
         "MPP X0*!Y1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -416,47 +227,26 @@ fn mpp_double_negation_cancels() {
     check(
         "MPP !X0*!Y1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -466,38 +256,17 @@ fn mpp_repeated_qubit_folds_to_single_pauli() {
     check(
         "MPP X0*X0*X0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -507,41 +276,20 @@ fn mpp_repeated_qubit_folding_to_minus_one_negates_result() {
     check(
         "MPP X0*Y0*X1*Y1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -551,38 +299,17 @@ fn mpp_explicit_negation_cancels_folded_minus_one() {
     check(
         "MPP !X0*Y0*X1*Y1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -592,49 +319,28 @@ fn mpp_non_adjacent_repeated_qubits_are_folded_together() {
     check(
         "MPP X0*Z1*Z0*X1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -644,38 +350,17 @@ fn mpp_qubits_folding_to_identity_are_dropped_from_the_product() {
     check(
         "MPP Y0*Y0*Z1*Z1*X2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -684,56 +369,34 @@ fn mpp_multiple_products_in_one_instruction_yields_expected_qir() {
     check(
         "MPP X1*Y2 !Z3*Z4*Z5",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="5" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 5
+            required_num_results: 2"#]],
     );
 }
 
@@ -742,49 +405,27 @@ fn mpp_mixed_single_and_product_targets_yields_expected_qir() {
     check(
         "MPP X0 Y1*Z2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 2"#]],
     );
 }
 
@@ -880,42 +521,20 @@ fn mpp_with_readout_noise_yields_expected_qir() {
     check(
         "MPP(0.01) Z1*Z2",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -968,34 +587,14 @@ fn spp_single_z_yields_expected_qir() {
     check(
         "SPP Z1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1004,37 +603,17 @@ fn spp_single_x_yields_expected_qir() {
     check(
         "SPP X1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1043,37 +622,17 @@ fn spp_negated_single_x_yields_expected_qir() {
     check(
         "SPP !X1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1082,42 +641,22 @@ fn spp_two_factor_product_yields_expected_qir() {
     check(
         "SPP X1*X2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1126,50 +665,30 @@ fn spp_multiple_products_in_one_instruction_yield_expected_qir() {
     check(
         "SPP Y1*Y2 !Z1*Z2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1178,47 +697,27 @@ fn spp_negated_three_factor_product_yields_expected_qir() {
     check(
         "SPP !X1*Y2*Z3",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }
 
@@ -1227,47 +726,27 @@ fn spp_mixed_basis_product_yields_expected_qir() {
     check(
         "SPP X0*Y1*Z2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }
 
@@ -1276,37 +755,17 @@ fn spp_folded_minus_one_negates_correctly() {
     check(
         "SPP X0*Y0*X1*Y1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1319,32 +778,8 @@ fn spp_identity_products_are_noops() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -1385,34 +820,14 @@ fn spp_dag_single_z_yields_expected_qir() {
     check(
         "SPP_DAG Z1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1421,37 +836,17 @@ fn spp_dag_single_x_yields_expected_qir() {
     check(
         "SPP_DAG X1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1460,37 +855,17 @@ fn spp_dag_negated_single_x_yields_expected_qir() {
     check(
         "SPP_DAG !X1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1499,42 +874,22 @@ fn spp_dag_two_factor_product_yields_expected_qir() {
     check(
         "SPP_DAG X1*X2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1543,50 +898,30 @@ fn spp_dag_multiple_products_in_one_instruction_yield_expected_qir() {
     check(
         "SPP_DAG Y1*Y2 !Z1*Z2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1595,46 +930,26 @@ fn spp_dag_negated_three_factor_product_yields_expected_qir() {
     check(
         "SPP_DAG !X1*Y2*Z3",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/measurement_record_targets.rs
@@ -14,49 +14,29 @@ fn cx_with_rec_control_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cx(ptr %result, ptr %qubit) {
-            block_cx_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-            block_cx_apply:
-              call void @__quantum__qis__x__body(ptr %qubit)
-              br label %block_cx_exit
-            block_cx_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -69,49 +49,29 @@ fn cnot_with_rec_control_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cx(ptr %result, ptr %qubit) {
-            block_cx_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-            block_cx_apply:
-              call void @__quantum__qis__x__body(ptr %qubit)
-              br label %block_cx_exit
-            block_cx_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -124,49 +84,29 @@ fn zcx_with_rec_control_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cx(ptr %result, ptr %qubit) {
-            block_cx_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-            block_cx_apply:
-              call void @__quantum__qis__x__body(ptr %qubit)
-              br label %block_cx_exit
-            block_cx_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -180,51 +120,30 @@ fn cx_with_older_rec_control_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__rt__array_record_output(i64 2, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
 
-            define void @classical_control_cx(ptr %result, ptr %qubit) {
-            block_cx_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-            block_cx_apply:
-              call void @__quantum__qis__x__body(ptr %qubit)
-              br label %block_cx_exit
-            block_cx_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 2"#]],
     );
 }
 
@@ -237,51 +156,31 @@ fn cx_with_mixed_quantum_and_classical_pairs_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-            define void @classical_control_cx(ptr %result, ptr %qubit) {
-            block_cx_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-            block_cx_apply:
-              call void @__quantum__qis__x__body(ptr %qubit)
-              br label %block_cx_exit
-            block_cx_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 4
+            required_num_results: 1"#]],
     );
 }
 
@@ -295,52 +194,31 @@ fn cx_with_multiple_classical_pairs_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @classical_control_cx(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr))
-              call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__rt__array_record_output(i64 2, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 3 to ptr))
 
-            define void @classical_control_cx(ptr %result, ptr %qubit) {
-            block_cx_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-            block_cx_apply:
-              call void @__quantum__qis__x__body(ptr %qubit)
-              br label %block_cx_exit
-            block_cx_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 4
+            required_num_results: 2"#]],
     );
 }
 
@@ -456,49 +334,29 @@ fn cy_with_rec_control_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cy(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cy(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cy(ptr %result, ptr %qubit) {
-            block_cy_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cy_apply, label %block_cy_exit
-            block_cy_apply:
-              call void @__quantum__qis__y__body(ptr %qubit)
-              br label %block_cy_exit
-            block_cy_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cy(ptr %result, ptr %qubit) {
+              block_cy_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cy_apply, label %block_cy_exit
+              block_cy_apply:
+                call void @__quantum__qis__y__body(ptr %qubit)
+                br label %block_cy_exit
+              block_cy_exit:
+                ret void
+              }
 
-            declare void @__quantum__qis__y__body(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__y__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -511,49 +369,29 @@ fn zcy_with_rec_control_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cy(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cy(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cy(ptr %result, ptr %qubit) {
-            block_cy_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cy_apply, label %block_cy_exit
-            block_cy_apply:
-              call void @__quantum__qis__y__body(ptr %qubit)
-              br label %block_cy_exit
-            block_cy_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cy(ptr %result, ptr %qubit) {
+              block_cy_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cy_apply, label %block_cy_exit
+              block_cy_apply:
+                call void @__quantum__qis__y__body(ptr %qubit)
+                br label %block_cy_exit
+              block_cy_exit:
+                ret void
+              }
 
-            declare void @__quantum__qis__y__body(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__y__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -608,49 +446,29 @@ fn cz_with_rec_on_first_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cz(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cz(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cz(ptr %result, ptr %qubit) {
-            block_cz_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cz_apply, label %block_cz_exit
-            block_cz_apply:
-              call void @__quantum__qis__z__body(ptr %qubit)
-              br label %block_cz_exit
-            block_cz_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cz(ptr %result, ptr %qubit) {
+              block_cz_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cz_apply, label %block_cz_exit
+              block_cz_apply:
+                call void @__quantum__qis__z__body(ptr %qubit)
+                br label %block_cz_exit
+              block_cz_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__z__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -663,49 +481,29 @@ fn cz_with_rec_on_second_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cz(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cz(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-            define void @classical_control_cz(ptr %result, ptr %qubit) {
-            block_cz_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cz_apply, label %block_cz_exit
-            block_cz_apply:
-              call void @__quantum__qis__z__body(ptr %qubit)
-              br label %block_cz_exit
-            block_cz_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cz(ptr %result, ptr %qubit) {
+              block_cz_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cz_apply, label %block_cz_exit
+              block_cz_apply:
+                call void @__quantum__qis__z__body(ptr %qubit)
+                br label %block_cz_exit
+              block_cz_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__z__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -718,49 +516,29 @@ fn zcz_with_rec_on_first_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cz(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cz(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cz(ptr %result, ptr %qubit) {
-            block_cz_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cz_apply, label %block_cz_exit
-            block_cz_apply:
-              call void @__quantum__qis__z__body(ptr %qubit)
-              br label %block_cz_exit
-            block_cz_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cz(ptr %result, ptr %qubit) {
+              block_cz_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cz_apply, label %block_cz_exit
+              block_cz_apply:
+                call void @__quantum__qis__z__body(ptr %qubit)
+                br label %block_cz_exit
+              block_cz_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__z__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -773,49 +551,29 @@ fn zcz_with_rec_on_second_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cz(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cz(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-            define void @classical_control_cz(ptr %result, ptr %qubit) {
-            block_cz_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cz_apply, label %block_cz_exit
-            block_cz_apply:
-              call void @__quantum__qis__z__body(ptr %qubit)
-              br label %block_cz_exit
-            block_cz_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cz(ptr %result, ptr %qubit) {
+              block_cz_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cz_apply, label %block_cz_exit
+              block_cz_apply:
+                call void @__quantum__qis__z__body(ptr %qubit)
+                br label %block_cz_exit
+              block_cz_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__z__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -893,49 +651,29 @@ fn xcz_with_rec_on_second_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cx(ptr %result, ptr %qubit) {
-            block_cx_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-            block_cx_apply:
-              call void @__quantum__qis__x__body(ptr %qubit)
-              br label %block_cx_exit
-            block_cx_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -990,49 +728,29 @@ fn ycz_with_rec_on_second_target_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @classical_control_cy(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cy(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cy(ptr %result, ptr %qubit) {
-            block_cy_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cy_apply, label %block_cy_exit
-            block_cy_apply:
-              call void @__quantum__qis__y__body(ptr %qubit)
-              br label %block_cy_exit
-            block_cy_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cy(ptr %result, ptr %qubit) {
+              block_cy_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cy_apply, label %block_cy_exit
+              block_cy_apply:
+                call void @__quantum__qis__y__body(ptr %qubit)
+                br label %block_cy_exit
+              block_cy_exit:
+                ret void
+              }
 
-            declare void @__quantum__qis__y__body(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__y__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -1089,51 +807,31 @@ fn cx_with_rec_control_crossing_select_boundary() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              br label %select_0
-            select_0:
-              call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                br label %select_0
+              select_0:
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            define void @classical_control_cx(ptr %result, ptr %qubit) {
-            block_cx_entry:
-              %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-              br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-            block_cx_apply:
-              call void @__quantum__qis__x__body(ptr %qubit)
-              br label %block_cx_exit
-            block_cx_exit:
-              ret void
-            }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -1148,50 +846,30 @@ fn top_level_classical_control_reaches_into_select() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        define void @classical_control_cx(ptr %result, ptr %qubit) {
-        block_cx_entry:
-          %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-          br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-        block_cx_apply:
-          call void @__quantum__qis__x__body(ptr %qubit)
-          br label %block_cx_exit
-        block_cx_exit:
-          ret void
-        }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/noise_channels.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/noise_channels.rs
@@ -11,43 +11,21 @@ fn e_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    X: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    X: 0.01"#]],
     );
 }
 
@@ -57,43 +35,21 @@ fn correlated_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    X: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    X: 0.01"#]],
     );
 }
 
@@ -165,43 +121,21 @@ fn correlated_error_with_probability_of_exactly_one_is_valid() {
     check(
         source,
         &expect![[r#"
-        NoiseConfig:
-        intrinsics:
-            0: NoiseTable:
-                qubits: 1
-                X: 1
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
 
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
 
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
 
-        declare void @noise_intrinsic_0(ptr) #2
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            NoiseConfig:
+            intrinsics:
+                0: NoiseTable:
+                    qubits: 1
+                    X: 1"#]],
     );
 }
 
@@ -217,45 +151,23 @@ fn correlated_error_chain_with_input_probabilities_summing_above_one_is_valid() 
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
                     X: 0.5
                     Y: 0.25
-                    Z: 0.125
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    Z: 0.125"#]],
     );
 }
 
@@ -290,45 +202,23 @@ fn correlated_error_chain_with_common_qubit_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr, ptr, ptr) #2
+
+            required_num_qubits: 3
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 3
                     XII: 0.01
                     ZLI: 0.0198
-                    XZY: 0.029105999999999996
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr, ptr, ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    XZY: 0.029105999999999996"#]],
     );
 }
 
@@ -342,45 +232,23 @@ fn correlated_error_chain_with_disjoint_qubits_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 4 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr, ptr, ptr, ptr, ptr) #2
+
+            required_num_qubits: 5
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 5
                     XIIII: 0.01
                     IZLII: 0.0198
-                    IIIYZ: 0.029105999999999996
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 4 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr, ptr, ptr, ptr, ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="5" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    IIIYZ: 0.029105999999999996"#]],
     );
 }
 
@@ -394,45 +262,23 @@ fn else_correlated_error_with_preceding_else_correlated_error_yields_expected_qi
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
                     X: 0.01
                     Y: 0.0198
-                    Z: 0.029105999999999996
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    Z: 0.029105999999999996"#]],
     );
 }
 
@@ -507,45 +353,23 @@ fn depolarize1_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
                     X: 0.0033333333333333335
                     Y: 0.0033333333333333335
-                    Z: 0.0033333333333333335
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    Z: 0.0033333333333333335"#]],
     );
 }
 
@@ -618,6 +442,16 @@ fn depolarize2_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr, ptr) #2
+
+            required_num_qubits: 2
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
@@ -636,39 +470,7 @@ fn depolarize2_yields_expected_qir() {
                     ZI: 0.0006666666666666666
                     ZX: 0.0006666666666666666
                     ZY: 0.0006666666666666666
-                    ZZ: 0.0006666666666666666
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr, ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    ZZ: 0.0006666666666666666"#]],
     );
 }
 
@@ -738,32 +540,8 @@ fn i_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -785,32 +563,8 @@ fn ii_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -837,45 +591,23 @@ fn pauli_channel_1_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        NoiseConfig:
-        intrinsics:
-            0: NoiseTable:
-                qubits: 1
-                X: 0.1
-                Y: 0.2
-                Z: 0.3
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
 
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
 
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
 
-        declare void @noise_intrinsic_0(ptr) #2
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            NoiseConfig:
+            intrinsics:
+                0: NoiseTable:
+                    qubits: 1
+                    X: 0.1
+                    Y: 0.2
+                    Z: 0.3"#]],
     );
 }
 
@@ -920,45 +652,23 @@ fn pauli_channel_1_with_probabilities_summing_to_exactly_one_is_valid() {
     check(
         source,
         &expect![[r#"
-        NoiseConfig:
-        intrinsics:
-            0: NoiseTable:
-                qubits: 1
-                X: 0.2
-                Y: 0.3
-                Z: 0.5
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
 
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
 
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
 
-        declare void @noise_intrinsic_0(ptr) #2
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            NoiseConfig:
+            intrinsics:
+                0: NoiseTable:
+                    qubits: 1
+                    X: 0.2
+                    Y: 0.3
+                    Z: 0.5"#]],
     );
 }
 
@@ -1038,57 +748,35 @@ fn pauli_channel_2_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        NoiseConfig:
-        intrinsics:
-            0: NoiseTable:
-                qubits: 2
-                IX: 0
-                IY: 0
-                IZ: 0
-                XI: 0
-                XX: 0.1
-                XY: 0
-                XZ: 0
-                YI: 0
-                YX: 0
-                YY: 0
-                YZ: 0.2
-                ZI: 0
-                ZX: 0
-                ZY: 0
-                ZZ: 0
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
+            declarations:
+              declare void @noise_intrinsic_0(ptr, ptr) #2
 
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            required_num_qubits: 2
+            required_num_results: 0
+            uses_noise: true
 
-        declare void @noise_intrinsic_0(ptr, ptr) #2
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            NoiseConfig:
+            intrinsics:
+                0: NoiseTable:
+                    qubits: 2
+                    IX: 0
+                    IY: 0
+                    IZ: 0
+                    XI: 0
+                    XX: 0.1
+                    XY: 0
+                    XZ: 0
+                    YI: 0
+                    YX: 0
+                    YY: 0
+                    YZ: 0.2
+                    ZI: 0
+                    ZX: 0
+                    ZY: 0
+                    ZZ: 0"#]],
     );
 }
 
@@ -1149,43 +837,21 @@ fn x_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    X: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    X: 0.01"#]],
     );
 }
 
@@ -1229,43 +895,21 @@ fn y_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    Y: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    Y: 0.01"#]],
     );
 }
 
@@ -1292,43 +936,21 @@ fn z_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    Z: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    Z: 0.01"#]],
     );
 }
 
@@ -1355,43 +977,21 @@ fn loss_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 1
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    L: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    L: 0.01"#]],
     );
 }
 
@@ -1422,50 +1022,28 @@ X_ERROR(0.01) 2
     check(
         source,
         &expect![[r#"
-        NoiseConfig:
-        intrinsics:
-            0: NoiseTable:
-                qubits: 1
-                X: 0.01
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+                call void @noise_intrinsic_1(ptr inttoptr (i64 1 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 2 to ptr))
 
-            1: NoiseTable:
-                qubits: 1
-                X: 0.02
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+              declare void @noise_intrinsic_1(ptr) #2
 
+            required_num_qubits: 3
+            required_num_results: 0
+            uses_noise: true
 
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-          call void @noise_intrinsic_1(ptr inttoptr (i64 1 to ptr))
-          call void @noise_intrinsic_0(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            NoiseConfig:
+            intrinsics:
+                0: NoiseTable:
+                    qubits: 1
+                    X: 0.01
 
-        declare void @noise_intrinsic_1(ptr) #2
-        declare void @noise_intrinsic_0(ptr) #2
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+                1: NoiseTable:
+                    qubits: 1
+                    X: 0.02"#]],
     );
 }
 
@@ -1480,44 +1058,22 @@ fn correlated_error_chains_with_same_shape_are_memoized() {
     check(
         source,
         &expect![[r#"
-        NoiseConfig:
-        intrinsics:
-            0: NoiseTable:
-                qubits: 2
-                XZ: 0.01
-                YY: 0.0198
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
+            declarations:
+              declare void @noise_intrinsic_0(ptr, ptr) #2
 
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @noise_intrinsic_0(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            required_num_qubits: 4
+            required_num_results: 0
+            uses_noise: true
 
-        declare void @noise_intrinsic_0(ptr, ptr) #2
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            NoiseConfig:
+            intrinsics:
+                0: NoiseTable:
+                    qubits: 2
+                    XZ: 0.01
+                    YY: 0.0198"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/noise_channels_broadcasting.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/noise_channels_broadcasting.rs
@@ -11,46 +11,24 @@ fn depolarize1_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 2
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
                     X: 0.0033333333333333335
                     Y: 0.0033333333333333335
-                    Z: 0.0033333333333333335
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    Z: 0.0033333333333333335"#]],
     );
 }
 
@@ -77,6 +55,17 @@ fn depolarize2_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr, ptr) #2
+
+            required_num_qubits: 4
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
@@ -95,40 +84,7 @@ fn depolarize2_yields_expected_qir() {
                     ZI: 0.0006666666666666666
                     ZX: 0.0006666666666666666
                     ZY: 0.0006666666666666666
-                    ZZ: 0.0006666666666666666
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @noise_intrinsic_0(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr, ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    ZZ: 0.0006666666666666666"#]],
     );
 }
 
@@ -198,32 +154,8 @@ fn i_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -245,32 +177,8 @@ fn ii_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -297,46 +205,24 @@ fn pauli_channel_1_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        NoiseConfig:
-        intrinsics:
-            0: NoiseTable:
-                qubits: 1
-                X: 0.1
-                Y: 0.2
-                Z: 0.3
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
 
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
 
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-          call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            required_num_qubits: 2
+            required_num_results: 0
+            uses_noise: true
 
-        declare void @noise_intrinsic_0(ptr) #2
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            NoiseConfig:
+            intrinsics:
+                0: NoiseTable:
+                    qubits: 1
+                    X: 0.1
+                    Y: 0.2
+                    Z: 0.3"#]],
     );
 }
 
@@ -363,58 +249,36 @@ fn pauli_channel_2_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        NoiseConfig:
-        intrinsics:
-            0: NoiseTable:
-                qubits: 2
-                IX: 0
-                IY: 0
-                IZ: 0
-                XI: 0
-                XX: 0.1
-                XY: 0
-                XZ: 0
-                YI: 0
-                YX: 0
-                YY: 0
-                YZ: 0.2
-                ZI: 0
-                ZX: 0
-                ZY: 0
-                ZZ: 0
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
+            declarations:
+              declare void @noise_intrinsic_0(ptr, ptr) #2
 
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @noise_intrinsic_0(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            required_num_qubits: 4
+            required_num_results: 0
+            uses_noise: true
 
-        declare void @noise_intrinsic_0(ptr, ptr) #2
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            NoiseConfig:
+            intrinsics:
+                0: NoiseTable:
+                    qubits: 2
+                    IX: 0
+                    IY: 0
+                    IZ: 0
+                    XI: 0
+                    XX: 0.1
+                    XY: 0
+                    XZ: 0
+                    YI: 0
+                    YX: 0
+                    YY: 0
+                    YZ: 0.2
+                    ZI: 0
+                    ZX: 0
+                    ZY: 0
+                    ZZ: 0"#]],
     );
 }
 
@@ -458,44 +322,22 @@ fn x_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 2
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    X: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    X: 0.01"#]],
     );
 }
 
@@ -505,44 +347,22 @@ fn y_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 2
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    Y: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    Y: 0.01"#]],
     );
 }
 
@@ -552,44 +372,22 @@ fn z_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 2
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    Z: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    Z: 0.01"#]],
     );
 }
 
@@ -599,43 +397,21 @@ fn loss_error_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
+            body:
+                call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
+                call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
+
+            declarations:
+              declare void @noise_intrinsic_0(ptr) #2
+
+            required_num_qubits: 2
+            required_num_results: 0
+            uses_noise: true
+
             NoiseConfig:
             intrinsics:
                 0: NoiseTable:
                     qubits: 1
-                    L: 0.01
-
-
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @noise_intrinsic_0(ptr inttoptr (i64 0 to ptr))
-              call void @noise_intrinsic_0(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @noise_intrinsic_0(ptr) #2
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+                    L: 0.01"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/non_clifford_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/non_clifford_gates.rs
@@ -10,34 +10,14 @@ fn t_gate_yields_expected_qir() {
     check(
         "T 0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__qis__t__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__t__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -46,34 +26,14 @@ fn t_dag_gate_yields_expected_qir() {
     check(
         "T_DAG 0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__t__adj(ptr)
+            declarations:
+              declare void @__quantum__qis__t__adj(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -152,34 +112,14 @@ fn tpp_single_z_yields_expected_qir() {
     check(
         "TPP Z0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__qis__t__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__t__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -188,37 +128,17 @@ fn tpp_single_x_yields_expected_qir() {
     check(
         "TPP X0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__qis__t__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__t__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -227,41 +147,21 @@ fn tpp_single_y_yields_expected_qir() {
     check(
         "TPP Y0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__s__body(ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__s__adj(ptr)
-            declare void @__quantum__qis__t__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__t__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -271,34 +171,14 @@ fn tpp_dag_single_z_yields_expected_qir() {
     check(
         "TPP_DAG Z0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__t__adj(ptr)
+            declarations:
+              declare void @__quantum__qis__t__adj(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -307,48 +187,28 @@ fn tpp_three_factor_product_yields_expected_qir() {
     check(
         "TPP X0*Y1*Z2",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__qis__s__body(ptr)
-            declare void @__quantum__qis__s__adj(ptr)
-            declare void @__quantum__qis__h__body(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__t__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__t__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }
 
@@ -357,34 +217,14 @@ fn tpp_negated_product_applies_inverse() {
     check(
         "TPP !Z0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__t__adj(ptr)
+            declarations:
+              declare void @__quantum__qis__t__adj(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -393,34 +233,14 @@ fn tpp_dag_negated_product_applies_inverse() {
     check(
         "TPP_DAG !Z0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__qis__t__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__t__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -429,40 +249,20 @@ fn tpp_negation_on_later_factor_negates_whole_product() {
     check(
         "TPP X0*!Z1",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__t__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__qis__t__adj(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__t__adj(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -471,40 +271,20 @@ fn tpp_double_negation_cancels() {
     check(
         "TPP !X0*!Z1",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__t__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__qis__t__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__t__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -517,32 +297,8 @@ fn tpp_identity_products_are_noops() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
-
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -599,37 +355,17 @@ fn ch_gate_yields_expected_qir() {
     check(
         "CH 0 1",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__ry__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__ry__body(double -0.7853981633974483, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__ry__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__ry__body(double -0.7853981633974483, ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__qis__ry__body(double, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__ry__body(double, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -638,37 +374,17 @@ fn ccz_gate_yields_expected_qir() {
     check(
         "CCZ 0 1 2",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__ccx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__ccx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__ccx__body(ptr, ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__ccx__body(ptr, ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }
 
@@ -677,34 +393,14 @@ fn ccx_gate_yields_expected_qir() {
     check(
         "CCX 0 1 2",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__ccx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__ccx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr))
 
-            declare void @__quantum__qis__ccx__body(ptr, ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__ccx__body(ptr, ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }
 
@@ -713,40 +409,20 @@ fn ccz_gate_broadcasts_over_triples() {
     check(
         "CCZ 0 1 2 3 4 5",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__ccx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__qis__ccx__body(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 5 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__ccx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__ccx__body(ptr inttoptr (i64 4 to ptr), ptr inttoptr (i64 5 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
 
-            declare void @__quantum__qis__ccx__body(ptr, ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__ccx__body(ptr, ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="6" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 6
+            required_num_results: 0"#]],
     );
 }
 
@@ -908,34 +584,14 @@ fn r_x_yields_expected_qir() {
     check(
         "R_X(0.25) 0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rx__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rx__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__rx__body(double, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__rx__body(double, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -944,34 +600,14 @@ fn r_x_with_angle_in_radians_yields_expected_qir() {
     check(
         "R_X(1rad) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__rx__body(double 1.0, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__rx__body(double 1.0, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__rx__body(double, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__rx__body(double, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -980,34 +616,14 @@ fn r_y_yields_expected_qir() {
     check(
         "R_Y(-0.375) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__ry__body(double -1.1780972450961724, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__ry__body(double -1.1780972450961724, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__ry__body(double, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__ry__body(double, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1016,34 +632,14 @@ fn r_z_yields_expected_qir() {
     check(
         "R_Z(123.432) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__rz__body(double 387.77306441789534, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__rz__body(double 387.77306441789534, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__rz__body(double, ptr)
+            declarations:
+              declare void @__quantum__qis__rz__body(double, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1052,36 +648,16 @@ fn r_x_broadcasts_over_targets() {
     check(
         "R_X(0.125) 0 1 2",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__rx__body(double 0.39269908169872414, ptr inttoptr (i64 2 to ptr))
 
-            declare void @__quantum__qis__rx__body(double, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__rx__body(double, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }
 
@@ -1138,37 +714,17 @@ fn u3_yields_expected_qir() {
     check(
         "U3(0.1, 0.2, 0.3) 0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rz__body(double 0.9424777960769379, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__ry__body(double 0.3141592653589793, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__rz__body(double 0.6283185307179586, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rz__body(double 0.9424777960769379, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__ry__body(double 0.3141592653589793, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__rz__body(double 0.6283185307179586, ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__ry__body(double, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__rz__body(double, ptr)
+            declarations:
+              declare void @__quantum__qis__ry__body(double, ptr)
+              declare void @__quantum__qis__rz__body(double, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1177,37 +733,17 @@ fn u_alias_yields_expected_qir() {
     check(
         "U(0.1, 0.2, 0.3) 0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rz__body(double 0.9424777960769379, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__ry__body(double 0.3141592653589793, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__rz__body(double 0.6283185307179586, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rz__body(double 0.9424777960769379, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__ry__body(double 0.3141592653589793, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__rz__body(double 0.6283185307179586, ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__ry__body(double, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__rz__body(double, ptr)
+            declarations:
+              declare void @__quantum__qis__ry__body(double, ptr)
+              declare void @__quantum__qis__rz__body(double, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1216,37 +752,17 @@ fn u3_with_mixed_angle_units_yields_expected_qir() {
     check(
         "U3(0.1, -0.2rad, 3e-1rad) 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__rz__body(double 0.3, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__ry__body(double 0.3141592653589793, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__rz__body(double -0.2, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__rz__body(double 0.3, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__ry__body(double 0.3141592653589793, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__rz__body(double -0.2, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__ry__body(double, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__rz__body(double, ptr)
+            declarations:
+              declare void @__quantum__qis__ry__body(double, ptr)
+              declare void @__quantum__qis__rz__body(double, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1343,34 +859,14 @@ fn r_xx_yields_expected_qir() {
     check(
         "R_XX(0.25) 0 1",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rxx__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rxx__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__rxx__body(double, ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__rxx__body(double, ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1379,34 +875,14 @@ fn r_yy_yields_expected_qir() {
     check(
         "R_YY(-0.6) 0 1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__ryy__body(double -1.8849555921538759, ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__ryy__body(double -1.8849555921538759, ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__ryy__body(double, ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__ryy__body(double, ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1415,34 +891,14 @@ fn r_zz_yields_expected_qir() {
     check(
         "R_ZZ(0.25) 0 1",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rzz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rzz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            declare void @__quantum__qis__rzz__body(double, ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__rzz__body(double, ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1451,35 +907,15 @@ fn r_zz_broadcasts_over_pairs() {
     check(
         "R_ZZ(0.25) 0 1 2 3",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rzz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__rzz__body(double 0.7853981633974483, ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rzz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__rzz__body(double 0.7853981633974483, ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-            declare void @__quantum__qis__rzz__body(double, ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__rzz__body(double, ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -1537,34 +973,14 @@ fn r_pauli_single_z_yields_expected_qir() {
     check(
         "R_PAULI(0.25) Z0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__rz__body(double, ptr)
+            declarations:
+              declare void @__quantum__qis__rz__body(double, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1573,37 +989,17 @@ fn r_pauli_single_x_yields_expected_qir() {
     check(
         "R_PAULI(0.25) X0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__h__body(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__qis__rz__body(double, ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__rz__body(double, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1612,41 +1008,21 @@ fn r_pauli_single_y_yields_expected_qir() {
     check(
         "R_PAULI(0.25) Y0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__rz__body(double, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__s__adj(ptr)
-            declare void @__quantum__qis__s__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__rz__body(double, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1655,48 +1031,28 @@ fn r_pauli_mixed_basis_product_yields_expected_qir() {
     check(
         "R_PAULI(0.25) X0*Y1*Z2",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__rz__body(double 0.7853981633974483, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__qis__s__adj(ptr)
-            declare void @__quantum__qis__rz__body(double, ptr)
-            declare void @__quantum__qis__s__body(ptr)
-            declare void @__quantum__qis__h__body(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__rz__body(double, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }
 
@@ -1705,34 +1061,14 @@ fn r_pauli_negated_product_negates_angle() {
     check(
         "R_PAULI(0.25) !Z0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__rz__body(double -0.7853981633974483, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__rz__body(double -0.7853981633974483, ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__rz__body(double, ptr)
+            declarations:
+              declare void @__quantum__qis__rz__body(double, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 

--- a/source/compiler/stim_compiler/src/qir/tests/pair_measurements.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/pair_measurements.rs
@@ -10,41 +10,20 @@ fn mxx_measurement_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -54,44 +33,23 @@ fn mxx_with_negated_target_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -100,45 +58,23 @@ fn mxx_with_readout_noise_yields_correct_qir() {
     check(
         "MXX(0.01) 0 1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -208,48 +144,27 @@ fn myy_measurement_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -259,51 +174,30 @@ fn myy_with_negated_target_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__qis__z__body(ptr)
-            declare void @__quantum__qis__s__body(ptr)
-            declare void @__quantum__qis__h__body(ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -312,52 +206,30 @@ fn myy_with_readout_noise_yields_correct_qir() {
     check(
         "MYY(0.01) 0 1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -367,38 +239,17 @@ fn mzz_measurement_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -408,41 +259,20 @@ fn mzz_with_negated_target_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -451,41 +281,19 @@ fn mzz_with_readout_noise_yields_correct_qir() {
     check(
         "MZZ(0.01) 0 1",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/pair_measurements_broadcasting.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/pair_measurements_broadcasting.rs
@@ -10,47 +10,25 @@ fn mxx_measurement_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 2"#]],
     );
 }
 
@@ -60,50 +38,28 @@ fn mxx_with_negated_target_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__rt__array_record_output(i64 2, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 4
+            required_num_results: 2"#]],
     );
 }
 
@@ -112,52 +68,29 @@ fn mxx_with_readout_noise_yields_correct_qir() {
     check(
         "MXX(0.01) 0 1 2 3",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 2
+            uses_noise: true"#]],
     );
 }
 
@@ -167,59 +100,37 @@ fn myy_measurement_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 2"#]],
     );
 }
 
@@ -229,62 +140,40 @@ fn myy_with_negated_target_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__z__body(ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__rt__array_record_output(i64 2, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__qis__z__body(ptr)
-            declare void @__quantum__qis__s__body(ptr)
-            declare void @__quantum__qis__h__body(ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 4
+            required_num_results: 2"#]],
     );
 }
 
@@ -293,64 +182,41 @@ fn myy_with_readout_noise_yields_correct_qir() {
     check(
         "MYY(0.01) 0 1 2 3",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 2
+            uses_noise: true"#]],
     );
 }
 
@@ -360,42 +226,20 @@ fn mzz_measurement_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 2"#]],
     );
 }
 
@@ -405,45 +249,23 @@ fn mzz_with_negated_target_yields_correct_qir() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-              call void @__quantum__rt__array_record_output(i64 2, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 4
+            required_num_results: 2"#]],
     );
 }
 
@@ -452,47 +274,24 @@ fn mzz_with_readout_noise_yields_correct_qir() {
     check(
         "MZZ(0.01) 0 1 2 3",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.01, double 0.01, ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        attributes #2 = { "qdk_noise" }
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 2
+            uses_noise: true"#]],
     );
 }
 

--- a/source/compiler/stim_compiler/src/qir/tests/peek_loss.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/peek_loss.rs
@@ -10,35 +10,14 @@ fn peek_loss_single_qubit() {
     check(
         "PEEK_LOSS 0",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__peek_loss__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__peek_loss__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -47,39 +26,16 @@ fn peek_loss_broadcasts_over_multiple_qubits() {
     check(
         "PEEK_LOSS 0 1 2",
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 3, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__peek_loss__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__peek_loss__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 3"#]],
     );
 }
 
@@ -88,39 +44,17 @@ fn peek_loss_with_readout_noise_yields_expected_qir() {
     check(
         "PEEK_LOSS(0.5) 0",
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__readout_noise(double 0.5, double 0.5, ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__rt__readout_noise(double 0.5, double 0.5, ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__readout_noise(double, double, ptr) #2
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__peek_loss__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__peek_loss__body(ptr, ptr)
+              declare void @__quantum__rt__readout_noise(double, double, ptr) #2
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            attributes #2 = { "qdk_noise" }
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1
+            uses_noise: true"#]],
     );
 }
 
@@ -217,49 +151,29 @@ fn peek_loss_referenced_by_classical_control() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        define void @classical_control_cx(ptr %result, ptr %qubit) {
-        block_cx_entry:
-          %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-          br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-        block_cx_apply:
-          call void @__quantum__qis__x__body(ptr %qubit)
-          br label %block_cx_exit
-        block_cx_exit:
-          ret void
-        }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__peek_loss__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__peek_loss__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -298,44 +212,23 @@ fn peek_loss_referenced_by_require_in_select_block() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          %restart_0 = or i1 %l_0, %r_0
-          br i1 %restart_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__peek_loss__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__peek_loss__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -349,40 +242,17 @@ fn peek_loss_interleaved_with_measurements() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 3, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__m__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__peek_loss__body(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__peek_loss__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 3"#]],
     );
 }
 
@@ -423,50 +293,28 @@ fn require_allows_peek_record_mixed_with_measurement() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-          %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          %loss_0 = or i1 %l_0, %l_1
-          %parity_0 = xor i1 %r_0, %r_1
-          %restart_0 = or i1 %loss_0, %parity_0
-          br i1 %restart_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__peek_loss__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %loss_0 = or i1 %l_0, %l_1
+                %parity_0 = xor i1 %r_0, %r_1
+                %restart_0 = or i1 %loss_0, %parity_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-        declare void @__quantum__qis__peek_loss__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__peek_loss__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/repeat.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/repeat.rs
@@ -37,36 +37,16 @@ fn repeat_with_tag() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -212,34 +192,14 @@ fn repeat_single_iteration() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -253,36 +213,16 @@ fn repeat_three_iterations() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -295,32 +235,8 @@ fn repeat_empty_body_yields_no_operations() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -336,41 +252,21 @@ fn repeat_multiple_gates() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -384,39 +280,19 @@ fn repeat_broadcast() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 0"#]],
     );
 }
 
@@ -430,39 +306,16 @@ fn repeat_with_measurement() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 3, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="3" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 3"#]],
     );
 }
 
@@ -477,55 +330,33 @@ fn repeat_with_classically_controlled_gate() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @classical_control_cx(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @classical_control_cx(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 3, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        define void @classical_control_cx(ptr %result, ptr %qubit) {
-        block_cx_entry:
-          %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-          br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-        block_cx_apply:
-          call void @__quantum__qis__x__body(ptr %qubit)
-          br label %block_cx_exit
-        block_cx_exit:
-          ret void
-        }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="3" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 3"#]],
     );
 }
 
@@ -543,54 +374,33 @@ fn repeat_with_classically_controlled_gate_after_loop() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @classical_control_cx(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        define void @classical_control_cx(ptr %result, ptr %qubit) {
-        block_cx_entry:
-          %result_val = call i1 @__quantum__rt__read_result(ptr %result)
-          br i1 %result_val, label %block_cx_apply, label %block_cx_exit
-        block_cx_apply:
-          call void @__quantum__qis__x__body(ptr %qubit)
-          br label %block_cx_exit
-        block_cx_exit:
-          ret void
-        }
+            definitions:
+              define void @classical_control_cx(ptr %result, ptr %qubit) {
+              block_cx_entry:
+                %result_val = call i1 @__quantum__rt__read_result(ptr %result)
+                br i1 %result_val, label %block_cx_apply, label %block_cx_exit
+              block_cx_apply:
+                call void @__quantum__qis__x__body(ptr %qubit)
+                br label %block_cx_exit
+              block_cx_exit:
+                ret void
+              }
 
-        declare void @__quantum__qis__h__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 2"#]],
     );
 }
 
@@ -606,39 +416,19 @@ fn nested_repeat() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -654,41 +444,17 @@ fn nested_repeat_with_measurement() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 4, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 3 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="4" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 4"#]],
     );
 }
 
@@ -705,39 +471,19 @@ fn sequential_repeats() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
+            declarations:
+              declare void @__quantum__qis__x__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -754,53 +500,31 @@ fn select_inside_repeat() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          %restart_0 = or i1 %l_0, %r_0
-          br i1 %restart_0, label %select_0, label %continue_0
-        continue_0:
-          br label %select_1
-        select_1:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-          %restart_1 = or i1 %l_1, %r_1
-          br i1 %restart_1, label %select_1, label %continue_1
-        continue_1:
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
+                br label %select_1
+              select_1:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %restart_1 = or i1 %l_1, %r_1
+                br i1 %restart_1, label %select_1, label %continue_1
+              continue_1:
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 2"#]],
     );
 }
 
@@ -817,48 +541,25 @@ fn repeat_inside_select() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-          %restart_0 = or i1 %l_0, %r_0
-          br i1 %restart_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 3, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="3" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 3"#]],
     );
 }
 

--- a/source/compiler/stim_compiler/src/qir/tests/select_block.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/select_block.rs
@@ -17,44 +17,23 @@ fn simple_select_block() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -74,61 +53,38 @@ fn long_select_block() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-              %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %loss_0 = or i1 %l_0, %l_1
-              %loss_1 = or i1 %loss_0, %l_2
-              %parity_0 = xor i1 %r_0, %r_1
-              %parity_1 = xor i1 %parity_0, %r_2
-              %restart_0 = or i1 %loss_1, %parity_1
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 3, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %loss_0 = or i1 %l_0, %l_1
+                %loss_1 = or i1 %loss_0, %l_2
+                %parity_0 = xor i1 %r_0, %r_1
+                %parity_1 = xor i1 %parity_0, %r_2
+                %restart_0 = or i1 %loss_1, %parity_1
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__qis__h__body(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__qis__x__body(ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 3"#]],
     );
 }
 
@@ -145,55 +101,33 @@ fn multiple_requires_in_block() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-              %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %loss_0 = or i1 %l_1, %l_2
-              %parity_0 = xor i1 %r_1, %r_2
-              %restart_1 = or i1 %loss_0, %parity_0
-              br i1 %restart_1, label %select_0, label %continue_1
-            continue_1:
-              call void @__quantum__rt__array_record_output(i64 2, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %loss_0 = or i1 %l_1, %l_2
+                %parity_0 = xor i1 %r_1, %r_2
+                %restart_1 = or i1 %loss_0, %parity_0
+                br i1 %restart_1, label %select_0, label %continue_1
+              continue_1:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -211,62 +145,38 @@ fn multiple_targets_in_require() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 3 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 3 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 3 to ptr))
-              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
-              %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-              %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-              %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              %l_3 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_3 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %loss_0 = or i1 %l_0, %l_1
-              %loss_1 = or i1 %loss_0, %l_2
-              %loss_2 = or i1 %loss_1, %l_3
-              %parity_0 = xor i1 %r_0, %r_1
-              %parity_1 = xor i1 %parity_0, %r_2
-              %parity_2 = xor i1 %parity_1, %r_3
-              %restart_0 = or i1 %loss_2, %parity_2
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 4, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 3 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 3 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 3 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 3 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+                %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %l_3 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_3 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %loss_0 = or i1 %l_0, %l_1
+                %loss_1 = or i1 %loss_0, %l_2
+                %loss_2 = or i1 %loss_1, %l_3
+                %parity_0 = xor i1 %r_0, %r_1
+                %parity_1 = xor i1 %parity_0, %r_2
+                %parity_2 = xor i1 %parity_1, %r_3
+                %restart_0 = or i1 %loss_2, %parity_2
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="4" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 4
+            required_num_results: 4"#]],
     );
 }
 
@@ -283,41 +193,18 @@ fn select_block_no_require() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
-              call void @__quantum__rt__array_record_output(i64 3, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
 
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 3"#]],
     );
 }
 
@@ -330,34 +217,12 @@ fn empty_select_block() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__rt__array_record_output(i64 0, ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -418,44 +283,23 @@ fn select_block_with_tag() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -470,45 +314,24 @@ fn require_with_negated_target() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %n_0 = xor i1 %r_0, true
-              %restart_0 = or i1 %l_0, %n_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %n_0 = xor i1 %r_0, true
+                %restart_0 = or i1 %l_0, %n_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -687,50 +510,28 @@ fn require_with_at_least_one_record_in_scope() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-          %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          %loss_0 = or i1 %l_0, %l_1
-          %parity_0 = xor i1 %r_0, %r_1
-          %restart_0 = or i1 %loss_0, %parity_0
-          br i1 %restart_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %loss_0 = or i1 %l_0, %l_1
+                %parity_0 = xor i1 %r_0, %r_1
+                %restart_0 = or i1 %loss_0, %parity_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -771,44 +572,23 @@ fn measure_reset_counts_as_measurement() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__mresetz__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__mresetz__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -823,47 +603,26 @@ fn pair_measurement_record_in_select() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-              call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__qis__cx__body(ptr, ptr)
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 1"#]],
     );
 }
 
@@ -908,53 +667,31 @@ fn nested_select_blocks() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              br label %select_1
-            select_1:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_1, label %continue_0
-            continue_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-              %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              %restart_1 = or i1 %l_1, %r_1
-              br i1 %restart_1, label %select_0, label %continue_1
-            continue_1:
-              call void @__quantum__rt__array_record_output(i64 2, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                br label %select_1
+              select_1:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_1, label %continue_0
+              continue_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %restart_1 = or i1 %l_1, %r_1
+                br i1 %restart_1, label %select_0, label %continue_1
+              continue_1:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -977,62 +714,39 @@ fn deeply_nested_select_blocks() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              br label %select_1
-            select_1:
-              br label %select_2
-            select_2:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_2, label %continue_0
-            continue_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-              %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              %restart_1 = or i1 %l_1, %r_1
-              br i1 %restart_1, label %select_1, label %continue_1
-            continue_1:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
-              %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
-              %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-              %restart_2 = or i1 %l_2, %r_2
-              br i1 %restart_2, label %select_0, label %continue_2
-            continue_2:
-              call void @__quantum__rt__array_record_output(i64 3, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                br label %select_1
+              select_1:
+                br label %select_2
+              select_2:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_2, label %continue_0
+              continue_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %restart_1 = or i1 %l_1, %r_1
+                br i1 %restart_1, label %select_1, label %continue_1
+              continue_1:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+                %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
+                %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+                %restart_2 = or i1 %l_2, %r_2
+                br i1 %restart_2, label %select_0, label %continue_2
+              continue_2:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 3
+            required_num_results: 3"#]],
     );
 }
 
@@ -1049,46 +763,25 @@ fn outer_select_reaches_into_inner_select() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              br label %select_1
-            select_1:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                br label %select_1
+              select_1:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -1107,48 +800,27 @@ fn outer_select_reaches_into_deeply_nested_inner_select() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              br label %select_1
-            select_1:
-              br label %select_2
-            select_2:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              call void @__quantum__rt__array_record_output(i64 1, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                br label %select_1
+              select_1:
+                br label %select_2
+              select_2:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -1193,53 +865,31 @@ fn sibling_select_blocks() {
     check(
         source,
         &expect![[r#"
-            define i64 @ENTRYPOINT__main() #0 {
-              call void @__quantum__rt__initialize(ptr null)
-              br label %select_0
-            select_0:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-              %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-              %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-              %restart_0 = or i1 %l_0, %r_0
-              br i1 %restart_0, label %select_0, label %continue_0
-            continue_0:
-              br label %select_1
-            select_1:
-              call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-              %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-              %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-              %restart_1 = or i1 %l_1, %r_1
-              br i1 %restart_1, label %select_1, label %continue_1
-            continue_1:
-              call void @__quantum__rt__array_record_output(i64 2, ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-              call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-              ret i64 0
-            }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
+                br label %select_1
+              select_1:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %restart_1 = or i1 %l_1, %r_1
+                br i1 %restart_1, label %select_1, label %continue_1
+              continue_1:
 
-            declare void @__quantum__rt__array_record_output(i64, ptr)
-            declare void @__quantum__rt__result_record_output(ptr, ptr)
-            declare i1 @__quantum__rt__read_loss(ptr)
-            declare i1 @__quantum__rt__read_result(ptr)
-            declare void @__quantum__rt__initialize(ptr)
-            declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-            !0 = !{i32 1, !"qir_major_version", i32 2}
-            !1 = !{i32 7, !"qir_minor_version", i32 1}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-            !4 = !{i32 5, !"int_computations", !{!"i64"}}
-            !5 = !{i32 5, !"float_computations", !{!"double"}}
-            !6 = !{i32 7, !"backwards_branching", i2 3}
-            !7 = !{i32 1, !"arrays", i1 true}
-        "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -1356,41 +1006,20 @@ fn simple_notleaked() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          br i1 %l_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 1, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                br i1 %l_0, label %select_0, label %continue_0
+              continue_0:
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 1"#]],
     );
 }
 
@@ -1408,53 +1037,29 @@ fn multiple_targets_in_notleaked() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 3 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 3 to ptr))
-          %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
-          %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %l_3 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          %loss_0 = or i1 %l_0, %l_1
-          %loss_1 = or i1 %loss_0, %l_2
-          %loss_2 = or i1 %loss_1, %l_3
-          br i1 %loss_2, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 4, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 3 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 3 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 3 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
+                %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %l_3 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %loss_0 = or i1 %l_0, %l_1
+                %loss_1 = or i1 %loss_0, %l_2
+                %loss_2 = or i1 %loss_1, %l_3
+                br i1 %loss_2, label %select_0, label %continue_0
+              continue_0:
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="4" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 4"#]],
     );
 }
 
@@ -1471,48 +1076,26 @@ fn multiple_notleakeds_in_block() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          br i1 %l_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          %loss_0 = or i1 %l_1, %l_2
-          br i1 %loss_0, label %select_0, label %continue_1
-        continue_1:
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                br i1 %l_0, label %select_0, label %continue_0
+              continue_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %loss_0 = or i1 %l_1, %l_2
+                br i1 %loss_0, label %select_0, label %continue_1
+              continue_1:
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -1552,45 +1135,23 @@ fn notleaked_with_at_least_one_record_in_scope() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          %loss_0 = or i1 %l_0, %l_1
-          br i1 %loss_0, label %select_0, label %continue_0
-        continue_0:
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %loss_0 = or i1 %l_0, %l_1
+                br i1 %loss_0, label %select_0, label %continue_0
+              continue_0:
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -1795,49 +1356,27 @@ fn require_and_notleaked_in_block() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-          %restart_0 = or i1 %l_0, %r_0
-          br i1 %restart_0, label %select_0, label %continue_0
-        continue_0:
-          %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          br i1 %l_1, label %select_0, label %continue_1
-        continue_1:
-          call void @__quantum__rt__array_record_output(i64 2, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %restart_0 = or i1 %l_0, %r_0
+                br i1 %restart_0, label %select_0, label %continue_0
+              continue_0:
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                br i1 %l_1, label %select_0, label %continue_1
+              continue_1:
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 2"#]],
     );
 }
 
@@ -1855,60 +1394,37 @@ fn require_and_notleaked_with_multiple_targets() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          br label %select_0
-        select_0:
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
-          %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
-          %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %loss_0 = or i1 %l_0, %l_1
-          br i1 %loss_0, label %select_0, label %continue_0
-        continue_0:
-          %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
-          %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-          %l_3 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
-          %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
-          %l_4 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
-          %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
-          %loss_1 = or i1 %l_2, %l_3
-          %loss_2 = or i1 %loss_1, %l_4
-          %parity_0 = xor i1 %r_0, %r_1
-          %parity_1 = xor i1 %parity_0, %r_2
-          %restart_0 = or i1 %loss_2, %parity_1
-          br i1 %restart_0, label %select_0, label %continue_1
-        continue_1:
-          call void @__quantum__rt__array_record_output(i64 3, ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 0 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
-          call void @__quantum__rt__result_record_output(ptr inttoptr (i64 2 to ptr), ptr null)
-          ret i64 0
-        }
+            body:
+                br label %select_0
+              select_0:
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__m__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+                %l_0 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
+                %l_1 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %loss_0 = or i1 %l_0, %l_1
+                br i1 %loss_0, label %select_0, label %continue_0
+              continue_0:
+                %l_2 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 2 to ptr))
+                %r_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+                %l_3 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 1 to ptr))
+                %r_1 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+                %l_4 = call i1 @__quantum__rt__read_loss(ptr inttoptr (i64 0 to ptr))
+                %r_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+                %loss_1 = or i1 %l_2, %l_3
+                %loss_2 = or i1 %loss_1, %l_4
+                %parity_0 = xor i1 %r_0, %r_1
+                %parity_1 = xor i1 %parity_0, %r_2
+                %restart_0 = or i1 %loss_2, %parity_1
+                br i1 %restart_0, label %select_0, label %continue_1
+              continue_1:
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare i1 @__quantum__rt__read_loss(ptr)
-        declare i1 @__quantum__rt__read_result(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__m__body(ptr, ptr)
+            declarations:
+              declare i1 @__quantum__rt__read_loss(ptr)
+              declare i1 @__quantum__rt__read_result(ptr)
+              declare void @__quantum__qis__m__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 3
+            required_num_results: 3"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/single_qubit_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/single_qubit_gates.rs
@@ -10,32 +10,8 @@ fn i_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -62,34 +38,14 @@ fn x_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -99,34 +55,14 @@ fn y_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__y__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__y__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__y__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__y__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -136,34 +72,14 @@ fn z_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -173,38 +89,18 @@ fn c_nxyz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -214,38 +110,18 @@ fn c_nzyx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -255,36 +131,16 @@ fn c_xnyz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -294,38 +150,18 @@ fn c_xynz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -335,36 +171,16 @@ fn c_xyz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -374,36 +190,16 @@ fn c_znyx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -413,38 +209,18 @@ fn c_zynx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -454,36 +230,16 @@ fn c_zyx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -493,34 +249,14 @@ fn h_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -530,34 +266,14 @@ fn h_xz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -567,36 +283,16 @@ fn h_nxy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -606,37 +302,17 @@ fn h_nxz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -646,36 +322,16 @@ fn h_nyz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__sx__body(ptr)
+            declarations:
+              declare void @__quantum__qis__sx__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -685,36 +341,16 @@ fn h_xy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -724,36 +360,16 @@ fn h_yz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__sx__body(ptr)
+            declarations:
+              declare void @__quantum__qis__sx__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -763,34 +379,14 @@ fn s_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -800,34 +396,14 @@ fn sqrt_z_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -837,34 +413,14 @@ fn sqrt_x_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__sx__body(ptr)
+            declarations:
+              declare void @__quantum__qis__sx__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -874,37 +430,17 @@ fn sqrt_x_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -914,36 +450,16 @@ fn sqrt_y_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -953,36 +469,16 @@ fn sqrt_y_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -992,34 +488,14 @@ fn s_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }
 
@@ -1029,33 +505,13 @@ fn sqrt_z_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 1
+            required_num_results: 0"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/single_qubit_gates_broadcasting.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/single_qubit_gates_broadcasting.rs
@@ -10,32 +10,8 @@ fn i_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -45,35 +21,15 @@ fn x_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -83,35 +39,15 @@ fn y_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__y__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__y__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__y__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__y__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__y__body(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__y__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -121,35 +57,15 @@ fn z_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -159,41 +75,21 @@ fn c_nxyz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -203,41 +99,21 @@ fn c_nzyx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -247,38 +123,18 @@ fn c_xnyz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -288,41 +144,21 @@ fn c_xynz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -332,38 +168,18 @@ fn c_xyz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -373,38 +189,18 @@ fn c_znyx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -414,41 +210,21 @@ fn c_zynx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -458,38 +234,18 @@ fn c_zyx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -499,35 +255,15 @@ fn h_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -537,35 +273,15 @@ fn h_xz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -575,38 +291,18 @@ fn h_nxy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -616,40 +312,20 @@ fn h_nxz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -659,38 +335,18 @@ fn h_nyz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__sx__body(ptr)
+            declarations:
+              declare void @__quantum__qis__sx__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -700,38 +356,18 @@ fn h_xy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__x__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__x__body(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
+              declare void @__quantum__qis__x__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -741,38 +377,18 @@ fn h_yz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__sx__body(ptr)
+            declarations:
+              declare void @__quantum__qis__sx__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -782,35 +398,15 @@ fn s_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -820,35 +416,15 @@ fn sqrt_z_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -858,35 +434,15 @@ fn sqrt_x_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__sx__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__sx__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__sx__body(ptr)
+            declarations:
+              declare void @__quantum__qis__sx__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -896,40 +452,20 @@ fn sqrt_x_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -939,38 +475,18 @@ fn sqrt_y_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -980,38 +496,18 @@ fn sqrt_y_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__z__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__z__body(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__z__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1021,35 +517,15 @@ fn s_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1059,34 +535,14 @@ fn sqrt_z_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/two_qubit_gates.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/two_qubit_gates.rs
@@ -10,34 +10,14 @@ fn cx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -63,34 +43,14 @@ fn cnot_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -100,34 +60,14 @@ fn zcx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -137,35 +77,15 @@ fn cxswap_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -175,34 +95,14 @@ fn cy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cy__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cy__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cy__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cy__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -212,34 +112,14 @@ fn zcy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cy__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cy__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cy__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cy__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -249,34 +129,14 @@ fn cz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__cz__body(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -286,34 +146,14 @@ fn zcz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__cz__body(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -323,38 +163,18 @@ fn czswap_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -364,38 +184,18 @@ fn swapcz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -405,32 +205,8 @@ fn ii_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -474,41 +250,21 @@ fn iswap_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -534,41 +290,21 @@ fn iswap_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -578,42 +314,22 @@ fn sqrt_xx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -623,42 +339,22 @@ fn sqrt_xx_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -668,47 +364,27 @@ fn sqrt_yy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -718,47 +394,27 @@ fn sqrt_yy_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -768,40 +424,20 @@ fn sqrt_zz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -811,40 +447,20 @@ fn sqrt_zz_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -854,34 +470,14 @@ fn swap_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__swap__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__swap__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__swap__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__swap__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -891,35 +487,15 @@ fn swapcx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -929,37 +505,17 @@ fn xcx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -969,41 +525,21 @@ fn xcy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1013,34 +549,14 @@ fn xcz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1050,41 +566,21 @@ fn ycx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1094,43 +590,23 @@ fn ycy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }
 
@@ -1140,37 +616,17 @@ fn ycz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 2
+            required_num_results: 0"#]],
     );
 }

--- a/source/compiler/stim_compiler/src/qir/tests/two_qubit_gates_broadcasting.rs
+++ b/source/compiler/stim_compiler/src/qir/tests/two_qubit_gates_broadcasting.rs
@@ -10,35 +10,15 @@ fn cx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -48,35 +28,15 @@ fn cnot_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -86,35 +46,15 @@ fn zcx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -124,37 +64,17 @@ fn cxswap_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -164,35 +84,15 @@ fn cy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cy__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cy__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cy__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cy__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cy__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cy__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -202,35 +102,15 @@ fn zcy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cy__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cy__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cy__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cy__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cy__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cy__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -240,35 +120,15 @@ fn cz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__cz__body(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -278,35 +138,15 @@ fn zcz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__cz__body(ptr, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cz__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -316,42 +156,22 @@ fn czswap_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -361,42 +181,22 @@ fn swapcz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -406,32 +206,8 @@ fn ii_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
-
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 0
+            required_num_results: 0"#]],
     );
 }
 
@@ -441,47 +217,27 @@ fn iswap_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -491,47 +247,27 @@ fn iswap_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -541,49 +277,29 @@ fn sqrt_xx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -593,49 +309,29 @@ fn sqrt_xx_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -645,58 +341,38 @@ fn sqrt_yy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -706,58 +382,38 @@ fn sqrt_yy_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -767,45 +423,25 @@ fn sqrt_zz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -815,45 +451,25 @@ fn sqrt_zz_dag_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -863,35 +479,15 @@ fn swap_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__swap__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__swap__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__swap__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__swap__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__swap__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__swap__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -901,37 +497,17 @@ fn swapcx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -941,40 +517,20 @@ fn xcx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -984,46 +540,26 @@ fn xcy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -1033,35 +569,15 @@ fn xcz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__initialize(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -1071,46 +587,26 @@ fn ycx_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -1120,50 +616,30 @@ fn ycy_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 1 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 3 to ptr))
+                call void @__quantum__qis__h__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 3 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__qis__h__body(ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__h__body(ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 
@@ -1173,41 +649,21 @@ fn ycz_gate_yields_expected_qir() {
     check(
         source,
         &expect![[r#"
-        define i64 @ENTRYPOINT__main() #0 {
-          call void @__quantum__rt__initialize(ptr null)
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
-          call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
-          call void @__quantum__rt__array_record_output(i64 0, ptr null)
-          ret i64 0
-        }
+            body:
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 0 to ptr))
+                call void @__quantum__qis__s__adj(ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__cx__body(ptr inttoptr (i64 3 to ptr), ptr inttoptr (i64 2 to ptr))
+                call void @__quantum__qis__s__body(ptr inttoptr (i64 2 to ptr))
 
-        declare void @__quantum__qis__cx__body(ptr, ptr)
-        declare void @__quantum__rt__result_record_output(ptr, ptr)
-        declare void @__quantum__qis__s__adj(ptr)
-        declare void @__quantum__qis__s__body(ptr)
-        declare void @__quantum__rt__initialize(ptr)
-        declare void @__quantum__rt__array_record_output(i64, ptr)
+            declarations:
+              declare void @__quantum__qis__cx__body(ptr, ptr)
+              declare void @__quantum__qis__s__adj(ptr)
+              declare void @__quantum__qis__s__body(ptr)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="4" "required_num_results"="0" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7}
-
-        !0 = !{i32 1, !"qir_major_version", i32 2}
-        !1 = !{i32 7, !"qir_minor_version", i32 1}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 5, !"int_computations", !{!"i64"}}
-        !5 = !{i32 5, !"float_computations", !{!"double"}}
-        !6 = !{i32 7, !"backwards_branching", i2 3}
-        !7 = !{i32 1, !"arrays", i1 true}
-    "#]],
+            required_num_qubits: 4
+            required_num_results: 0"#]],
     );
 }
 


### PR DESCRIPTION
This branch makes Stim-to-QIR snapshot tests smaller and easier to review by removing repeated QIR boilerplate from most expectations while retaining the generated instructions, helper definitions, declarations, resource counts, and noise details that distinguish each case. It also makes emitted QIR deterministic.

## QIR emission

- Sorts declarations and helper definitions for deterministic output.
- Places the optional `qdk_noise` attribute before module flags.

## Snapshot infrastructure

- Formats successful compilation output into focused `body`, `definitions`, and `declarations` sections, followed by required qubit and result counts.
- Omits standard entry-point initialization, output recording, runtime declarations, attributes, and module metadata from routine snapshots.
- Preserves noise behavior through a `uses_noise` marker and the effective noise configuration; compiler error expectations remain unchanged.
- Adds dedicated full-QIR checks for empty, measured, and noisy programs so shared entry-point boilerplate, output calls, runtime declarations, attributes, and module flags remain covered.
