### PR TITLE
Support mutable fixed size arrays in Adaptive Profile QIR emission

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -5928,8 +5928,8 @@ fn array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed_emits_
         block_0:
           %var_2 = alloca i64
           %var_5 = alloca i64
-          %var_8 = alloca i64
-          %var_9 = alloca [2 x i64]
+          %var_9 = alloca i64
+          %var_10 = alloca [2 x i64]
           call void @__quantum__rt__initialize(ptr null)
           call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
           %var_0 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
@@ -5952,27 +5952,27 @@ fn array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed_emits_
           br label %block_6
         block_6:
           call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 2 to ptr))
-          %var_6 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
-          br i1 %var_6, label %block_7, label %block_8
+          %var_7 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+          br i1 %var_7, label %block_7, label %block_8
         block_7:
-          store i64 1, ptr %var_8
+          store i64 1, ptr %var_9
           br label %block_9
         block_8:
-          store i64 0, ptr %var_8
+          store i64 0, ptr %var_9
           br label %block_9
         block_9:
-          %var_14 = load i64, ptr %var_2
-          %var_15 = load i64, ptr %var_5
-          %var_9_0 = getelementptr [2 x i64], ptr %var_9, i64 0, i64 0
-          store i64 %var_14, ptr %var_9_0
-          %var_9_1 = getelementptr [2 x i64], ptr %var_9, i64 0, i64 1
-          store i64 %var_15, ptr %var_9_1
-          %var_17 = load i64, ptr %var_8
-          %var_10_offset_chk = icmp slt i64 %var_17, 0
-          %var_10_offset = select i1 %var_10_offset_chk, i64 1, i64 0
-          %var_10 = getelementptr [2 x i64], ptr %var_9, i64 %var_10_offset, i64 %var_17
-          %var_18 = load i64, ptr %var_10
-          call void @__quantum__rt__int_record_output(i64 %var_18, ptr @0)
+          %var_15 = load i64, ptr %var_2
+          %var_16 = load i64, ptr %var_5
+          %var_10_0 = getelementptr [2 x i64], ptr %var_10, i64 0, i64 0
+          store i64 %var_15, ptr %var_10_0
+          %var_10_1 = getelementptr [2 x i64], ptr %var_10, i64 0, i64 1
+          store i64 %var_16, ptr %var_10_1
+          %var_18 = load i64, ptr %var_9
+          %var_11_offset_chk = icmp slt i64 %var_18, 0
+          %var_11_offset = select i1 %var_11_offset_chk, i64 1, i64 0
+          %var_11 = getelementptr [2 x i64], ptr %var_10, i64 %var_11_offset, i64 %var_18
+          %var_19 = load i64, ptr %var_11
+          call void @__quantum__rt__int_record_output(i64 %var_19, ptr @0)
           ret i64 0
         }
 
@@ -6219,6 +6219,208 @@ fn nested_array_with_dynamic_contents_passed_as_argument_and_dynamically_indexed
         declare void @__quantum__rt__int_record_output(i64, ptr)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="6" }
+        attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+        !8 = !{i32 1, !"ir_functions", i1 true}
+    "#]].assert_eq(&qir);
+}
+
+#[test]
+fn mutable_fixed_size_arrays_in_entry_point() {
+    let source = indoc::indoc! {r#"
+        operation Main() : Bool[] {
+            mutable results = [false, false];
+            use q = Qubit[2];
+            if M(q[0]) == One {
+                results[0] = true;
+            }
+            if M(q[1]) == One {
+                results[1] = true;
+            }
+            results
+        }
+    "#};
+    let qir = compile_source_to_qir(source, Profile::Adaptive.into());
+    expect![[r#"
+        @0 = internal constant [4 x i8] c"0_a\00"
+        @1 = internal constant [6 x i8] c"1_a0b\00"
+        @2 = internal constant [6 x i8] c"2_a1b\00"
+
+        define i64 @ENTRYPOINT__main() #0 {
+        block_0:
+          %var_0 = alloca [2 x i1]
+          %var_8 = alloca [2 x i1]
+          call void @__quantum__rt__initialize(ptr null)
+          %var_0_0 = getelementptr [2 x i1], ptr %var_0, i64 0, i64 0
+          store i1 false, ptr %var_0_0
+          %var_0_1 = getelementptr [2 x i1], ptr %var_0, i64 0, i64 1
+          store i1 false, ptr %var_0_1
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          %var_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+          br i1 %var_2, label %block_1, label %block_2
+        block_1:
+          %var_17_offset_chk = icmp slt i64 0, 0
+          %var_17_offset = select i1 %var_17_offset_chk, i64 1, i64 0
+          %var_17 = getelementptr [2 x i1], ptr %var_0, i64 %var_17_offset, i64 0
+          store i1 true, ptr %var_17
+          br label %block_2
+        block_2:
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+          %var_5 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+          br i1 %var_5, label %block_3, label %block_4
+        block_3:
+          %var_16_offset_chk = icmp slt i64 1, 0
+          %var_16_offset = select i1 %var_16_offset_chk, i64 1, i64 0
+          %var_16 = getelementptr [2 x i1], ptr %var_0, i64 %var_16_offset, i64 1
+          store i1 true, ptr %var_16
+          br label %block_4
+        block_4:
+          %var_12 = load [2 x i1], ptr %var_0
+          store [2 x i1] %var_12, ptr %var_8
+          %var_9_offset_chk = icmp slt i64 0, 0
+          %var_9_offset = select i1 %var_9_offset_chk, i64 1, i64 0
+          %var_9 = getelementptr [2 x i1], ptr %var_8, i64 %var_9_offset, i64 0
+          %var_14 = load i1, ptr %var_9
+          %var_10_offset_chk = icmp slt i64 1, 0
+          %var_10_offset = select i1 %var_10_offset_chk, i64 1, i64 0
+          %var_10 = getelementptr [2 x i1], ptr %var_8, i64 %var_10_offset, i64 1
+          %var_15 = load i1, ptr %var_10
+          call void @__quantum__rt__array_record_output(i64 2, ptr @0)
+          call void @__quantum__rt__bool_record_output(i1 %var_14, ptr @1)
+          call void @__quantum__rt__bool_record_output(i1 %var_15, ptr @2)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__initialize(ptr)
+
+        declare void @__quantum__qis__m__body(ptr, ptr) #1
+
+        declare i1 @__quantum__rt__read_result(ptr) #2
+
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+
+        declare void @__quantum__rt__bool_record_output(i1, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
+        attributes #1 = { "irreversible" }
+        attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8}
+
+        !0 = !{i32 1, !"qir_major_version", i32 2}
+        !1 = !{i32 7, !"qir_minor_version", i32 1}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 5, !"int_computations", !{!"i64"}}
+        !5 = !{i32 5, !"float_computations", !{!"double"}}
+        !6 = !{i32 7, !"backwards_branching", i2 3}
+        !7 = !{i32 1, !"arrays", i1 true}
+        !8 = !{i32 1, !"ir_functions", i1 true}
+    "#]].assert_eq(&qir);
+}
+
+#[test]
+fn mutable_fixed_size_arrays_in_callable_varying_by_input_params() {
+    let source = indoc::indoc! {r#"
+        operation Foo(r1 : Result, r2 : Result) : Bool[] {
+            mutable results = [false, false];
+            if r1 == One {
+                results[0] = true;
+            }
+            if r2 == One {
+                results[1] = true;
+            }
+            results
+        }
+        operation Main() : (Bool[], Bool[]) {
+            use q = Qubit[2];
+            (Foo(M(q[0]), M(q[1])), Foo(Zero, One))
+        }
+    "#};
+    let qir = compile_source_to_qir(source, Profile::Adaptive.into());
+    expect![[r#"
+        @0 = internal constant [4 x i8] c"0_t\00"
+        @1 = internal constant [6 x i8] c"1_t0a\00"
+        @2 = internal constant [8 x i8] c"2_t0a0b\00"
+        @3 = internal constant [8 x i8] c"3_t0a1b\00"
+        @4 = internal constant [6 x i8] c"4_t1a\00"
+        @5 = internal constant [8 x i8] c"5_t1a0b\00"
+        @6 = internal constant [8 x i8] c"6_t1a1b\00"
+
+        define i64 @ENTRYPOINT__main() #0 {
+        block_0:
+          %var_1 = alloca [2 x i1]
+          call void @__quantum__rt__initialize(ptr null)
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+          call void @__quantum__qis__m__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+          %var_1_0 = getelementptr [2 x i1], ptr %var_1, i64 0, i64 0
+          store i1 false, ptr %var_1_0
+          %var_1_1 = getelementptr [2 x i1], ptr %var_1, i64 0, i64 1
+          store i1 false, ptr %var_1_1
+          %var_2 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+          br i1 %var_2, label %block_1, label %block_2
+        block_1:
+          %var_12_offset_chk = icmp slt i64 0, 0
+          %var_12_offset = select i1 %var_12_offset_chk, i64 1, i64 0
+          %var_12 = getelementptr [2 x i1], ptr %var_1, i64 %var_12_offset, i64 0
+          store i1 true, ptr %var_12
+          br label %block_2
+        block_2:
+          %var_4 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+          br i1 %var_4, label %block_3, label %block_4
+        block_3:
+          %var_11_offset_chk = icmp slt i64 1, 0
+          %var_11_offset = select i1 %var_11_offset_chk, i64 1, i64 0
+          %var_11 = getelementptr [2 x i1], ptr %var_1, i64 %var_11_offset, i64 1
+          store i1 true, ptr %var_11
+          br label %block_4
+        block_4:
+          %var_6_offset_chk = icmp slt i64 0, 0
+          %var_6_offset = select i1 %var_6_offset_chk, i64 1, i64 0
+          %var_6 = getelementptr [2 x i1], ptr %var_1, i64 %var_6_offset, i64 0
+          %var_9 = load i1, ptr %var_6
+          %var_7_offset_chk = icmp slt i64 1, 0
+          %var_7_offset = select i1 %var_7_offset_chk, i64 1, i64 0
+          %var_7 = getelementptr [2 x i1], ptr %var_1, i64 %var_7_offset, i64 1
+          %var_10 = load i1, ptr %var_7
+          call void @__quantum__rt__tuple_record_output(i64 2, ptr @0)
+          call void @__quantum__rt__array_record_output(i64 2, ptr @1)
+          call void @__quantum__rt__bool_record_output(i1 %var_9, ptr @2)
+          call void @__quantum__rt__bool_record_output(i1 %var_10, ptr @3)
+          call void @__quantum__rt__array_record_output(i64 2, ptr @4)
+          call void @__quantum__rt__bool_record_output(i1 false, ptr @5)
+          call void @__quantum__rt__bool_record_output(i1 true, ptr @6)
+          ret i64 0
+        }
+
+        declare void @__quantum__rt__initialize(ptr)
+
+        declare void @__quantum__qis__m__body(ptr, ptr) #1
+
+        declare i1 @__quantum__rt__read_result(ptr) #2
+
+        declare void @__quantum__rt__tuple_record_output(i64, ptr)
+
+        declare void @__quantum__rt__array_record_output(i64, ptr)
+
+        declare void @__quantum__rt__bool_record_output(i1, ptr)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
         attributes #1 = { "irreversible" }
         attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
 

--- a/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
+++ b/source/compiler/qsc/src/codegen/tests/adaptive_profile.rs
@@ -1738,9 +1738,9 @@ fn qubit_array_allocating_callable_emits_ir_function_when_dynamic_alloc_enabled(
 
         declare ptr @__quantum__rt__qubit_allocate()
 
-        define internal void @X(ptr %var_3) {
+        define internal void @X(ptr %var_4) {
         block_2:
-          call void @__quantum__qis__x__body(ptr %var_3)
+          call void @__quantum__qis__x__body(ptr %var_4)
           ret void
         }
 

--- a/source/compiler/qsc_circuit/src/rir_to_circuit.rs
+++ b/source/compiler/qsc_circuit/src/rir_to_circuit.rs
@@ -552,10 +552,13 @@ fn process_variables(
         }
         instruction @ (Instruction::Store(..)
         | Instruction::StoreArray(..)
+        | Instruction::StoreIndex(..)
         | Instruction::BitwiseNot(..)
         | Instruction::Alloca(..)
         | Instruction::Load(..)
-        | Instruction::Index(..)) => {
+        | Instruction::Index(..)
+        | Instruction::CopyArray(..)
+        | Instruction::SliceArray(..)) => {
             return Err(Error::UnsupportedFeature(format!(
                 "unsupported instruction in block: {instruction:?}"
             )));

--- a/source/compiler/qsc_codegen/src/qir/v1.rs
+++ b/source/compiler/qsc_codegen/src/qir/v1.rs
@@ -221,7 +221,9 @@ impl ToQir<String> for rir::Instruction {
             rir::Instruction::Srem(lhs, rhs, variable) => {
                 binop_to_qir("srem", lhs, rhs, *variable, program)
             }
-            rir::Instruction::Store(_, _) | rir::Instruction::StoreArray(_, _) => {
+            rir::Instruction::Store(_, _)
+            | rir::Instruction::StoreArray(_, _)
+            | rir::Instruction::StoreIndex(_, _, _) => {
                 unimplemented!("store should be removed by pass")
             }
             rir::Instruction::Sub(lhs, rhs, variable) => {
@@ -229,7 +231,9 @@ impl ToQir<String> for rir::Instruction {
             }
             rir::Instruction::Alloca(..)
             | rir::Instruction::Load(..)
-            | rir::Instruction::Index(..) => {
+            | rir::Instruction::Index(..)
+            | rir::Instruction::CopyArray(..)
+            | rir::Instruction::SliceArray(..) => {
                 unimplemented!("advanced instructions are not supported in QIR v1 generation")
             }
         }

--- a/source/compiler/qsc_codegen/src/qir/v2.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2.rs
@@ -239,6 +239,16 @@ impl ToQir<String> for rir::Instruction {
             rir::Instruction::Index(array_op, index_op, result_var) => {
                 index_to_qir(array_op, index_op, result_var, program)
             }
+            rir::Instruction::CopyArray(src, dest) => {
+                // A direct copy of an array can be represented as a single store instruction in the IR.
+                store_to_qir(rir::Operand::Variable(*src), *dest, program)
+            }
+            rir::Instruction::SliceArray(array, start, step, end, var) => {
+                slice_array_to_qir(*array, *start, *step, *end, *var, program)
+            }
+            rir::Instruction::StoreIndex(..) => {
+                unreachable!("StoreIndex instructions should be eliminated by passes")
+            }
         }
     }
 }
@@ -349,6 +359,59 @@ fn store_array_to_qir(
         )
         .expect("writing to string should succeed");
         if i != final_operand_idx {
+            writeln!(qir).expect("writing to string should succeed");
+        }
+    }
+    qir
+}
+
+fn slice_array_to_qir(
+    array: rir::Variable,
+    start: i64,
+    step: i64,
+    end: i64,
+    var: rir::Variable,
+    program: &rir::Program,
+) -> String {
+    // To avoid introducing a loop, we emit explicit individual store instructions into the returned QIR string for reading
+    // each element of the original array and storing it into the expected location of the new array representing the slice.
+    // This produces 4N instructions for an array slice of N elements:
+    // 1. Get the pointer offset into the original array.
+    // 2. Load the element from the original array.
+    // 3. Get the pointer offset into the new array representing the slice.
+    // 4. Store the element into the new array.
+    let var_str = ToQir::<String>::to_qir(&var.variable_id, program);
+    let array_ty = get_variable_ty(array);
+    let var_ty = get_variable_ty(var);
+    let elem_ty = if let rir::Ty::Array(_, elem_ty) = array.ty {
+        get_prim_ty(elem_ty)
+    } else {
+        panic!("expected array type for variable {array:?}");
+    };
+    let array_str = ToQir::<String>::to_qir(&array.variable_id, program);
+    let mut qir = String::new();
+    let mut idx = start;
+    let mut new_idx = 0;
+    while (step > 0 && idx <= end) || (step < 0 && idx >= end) {
+        let temp_var = format!("{var_str}_{new_idx}");
+        let offset = i32::from(idx < 0);
+        writeln!(
+            qir,
+            "  {temp_var}_src = getelementptr {array_ty}, ptr {array_str}, i64 {offset}, i64 {idx}"
+        )
+        .expect("writing to string should succeed");
+        writeln!(qir, "  {temp_var} = load {elem_ty}, ptr {temp_var}_src")
+            .expect("writing to string should succeed");
+        writeln!(
+            qir,
+            "  {temp_var}_dst = getelementptr {var_ty}, ptr {var_str}, i64 0, i64 {new_idx}"
+        )
+        .expect("writing to string should succeed");
+        write!(qir, "  store {elem_ty} {temp_var}, ptr {temp_var}_dst")
+            .expect("writing to string should succeed");
+        idx += step;
+        new_idx += 1;
+        if (step > 0 && idx <= end) || (step < 0 && idx >= end) {
             writeln!(qir).expect("writing to string should succeed");
         }
     }
@@ -689,7 +752,10 @@ impl ToQir<String> for rir::Block {
     fn to_qir(&self, program: &rir::Program) -> String {
         self.0
             .iter()
-            .map(|instr| ToQir::<String>::to_qir(instr, program))
+            .filter_map(|instr| {
+                let s = ToQir::<String>::to_qir(instr, program);
+                if s.is_empty() { None } else { Some(s) }
+            })
             .collect::<Vec<_>>()
             .join("\n")
     }

--- a/source/compiler/qsc_codegen/src/qir/v2/instruction_tests.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2/instruction_tests.rs
@@ -3,9 +3,12 @@
 
 mod alloca;
 mod bool;
+mod copy_array;
 mod double;
 mod index;
 mod int;
 mod invalid;
 mod load;
+mod slice_array;
 mod store;
+mod store_array;

--- a/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/alloca.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/alloca.rs
@@ -28,3 +28,13 @@ fn alloca_pointer_without_size() {
     let inst = rir::Instruction::Alloca(rir::Variable::new_ptr(rir::VariableId(0)));
     expect!["  %var_0 = alloca ptr"].assert_eq(&inst.to_qir(&rir::Program::default()));
 }
+
+#[test]
+fn alloca_array_with_size() {
+    let inst = rir::Instruction::Alloca(rir::Variable::new_array(
+        rir::VariableId(0),
+        2,
+        rir::Prim::Integer,
+    ));
+    expect!["  %var_0 = alloca [2 x i64]"].assert_eq(&inst.to_qir(&rir::Program::default()));
+}

--- a/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/copy_array.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/copy_array.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::qir::v2::ToQir;
+use expect_test::expect;
+use qsc_rir::rir;
+
+#[test]
+fn copy_existing_array_into_new_array() {
+    let inst = rir::Instruction::CopyArray(
+        rir::Variable::new_array(rir::VariableId(0), 2, rir::Prim::Integer),
+        rir::Variable::new_array(rir::VariableId(1), 2, rir::Prim::Integer),
+    );
+    let qir = &inst.to_qir(&rir::Program::default());
+    expect!["  store [2 x i64] %var_0, ptr %var_1"].assert_eq(qir);
+}

--- a/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/load.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/load.rs
@@ -40,3 +40,13 @@ fn load_pointer_from_pointer() {
     );
     expect!["  %var_0 = load ptr, ptr %var_1"].assert_eq(&inst.to_qir(&rir::Program::default()));
 }
+
+#[test]
+fn load_array_from_pointer() {
+    let inst = rir::Instruction::Load(
+        rir::Variable::new_ptr(rir::VariableId(1)),
+        rir::Variable::new_array(rir::VariableId(0), 2, rir::Prim::Integer),
+    );
+    expect!["  %var_0 = load [2 x i64], ptr %var_1"]
+        .assert_eq(&inst.to_qir(&rir::Program::default()));
+}

--- a/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/slice_array.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/slice_array.rs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::qir::v2::ToQir;
+use expect_test::expect;
+use qsc_rir::rir;
+
+#[test]
+fn slice_array_variable() {
+    let inst = rir::Instruction::SliceArray(
+        rir::Variable::new_array(rir::VariableId(0), 4, rir::Prim::Integer),
+        0,
+        2,
+        3,
+        rir::Variable::new_array(rir::VariableId(1), 2, rir::Prim::Integer),
+    );
+    // Each slice array produces 4N lines, where N is the size of the slice (or destination array).
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_1_0_src = getelementptr [4 x i64], ptr %var_0, i64 0, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_0 = load i64, ptr %var_1_0_src"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_0_dst = getelementptr [2 x i64], ptr %var_1, i64 0, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1_0, ptr %var_1_0_dst"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1_src = getelementptr [4 x i64], ptr %var_0, i64 0, i64 2"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1 = load i64, ptr %var_1_1_src"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1_dst = getelementptr [2 x i64], ptr %var_1, i64 0, i64 1"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1_1, ptr %var_1_1_dst"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
+}
+
+#[test]
+fn slice_array_variable_reversed() {
+    let inst = rir::Instruction::SliceArray(
+        rir::Variable::new_array(rir::VariableId(0), 4, rir::Prim::Integer),
+        3,
+        -2,
+        0,
+        rir::Variable::new_array(rir::VariableId(1), 2, rir::Prim::Integer),
+    );
+    // Each slice array produces 4N lines, where N is the size of the slice (or destination array).
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_1_0_src = getelementptr [4 x i64], ptr %var_0, i64 0, i64 3"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_0 = load i64, ptr %var_1_0_src"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_0_dst = getelementptr [2 x i64], ptr %var_1, i64 0, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1_0, ptr %var_1_0_dst"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1_src = getelementptr [4 x i64], ptr %var_0, i64 0, i64 1"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1 = load i64, ptr %var_1_1_src"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1_dst = getelementptr [2 x i64], ptr %var_1, i64 0, i64 1"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1_1, ptr %var_1_1_dst"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
+}
+
+#[test]
+fn slice_array_variable_negative_index() {
+    let inst = rir::Instruction::SliceArray(
+        rir::Variable::new_array(rir::VariableId(0), 4, rir::Prim::Integer),
+        -4,
+        2,
+        -1,
+        rir::Variable::new_array(rir::VariableId(1), 2, rir::Prim::Integer),
+    );
+    // Each slice array produces 4N lines, where N is the size of the slice (or destination array).
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_1_0_src = getelementptr [4 x i64], ptr %var_0, i64 1, i64 -4"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_0 = load i64, ptr %var_1_0_src"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_0_dst = getelementptr [2 x i64], ptr %var_1, i64 0, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1_0, ptr %var_1_0_dst"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1_src = getelementptr [4 x i64], ptr %var_0, i64 1, i64 -2"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1 = load i64, ptr %var_1_1_src"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1_dst = getelementptr [2 x i64], ptr %var_1, i64 0, i64 1"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1_1, ptr %var_1_1_dst"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
+}
+
+#[test]
+fn slice_array_variable_negative_index_reversed() {
+    let inst = rir::Instruction::SliceArray(
+        rir::Variable::new_array(rir::VariableId(0), 4, rir::Prim::Integer),
+        -1,
+        -2,
+        -4,
+        rir::Variable::new_array(rir::VariableId(1), 2, rir::Prim::Integer),
+    );
+    // Each slice array produces 4N lines, where N is the size of the slice (or destination array).
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_1_0_src = getelementptr [4 x i64], ptr %var_0, i64 1, i64 -1"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_0 = load i64, ptr %var_1_0_src"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_0_dst = getelementptr [2 x i64], ptr %var_1, i64 0, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1_0, ptr %var_1_0_dst"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1_src = getelementptr [4 x i64], ptr %var_0, i64 1, i64 -3"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1 = load i64, ptr %var_1_1_src"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_1_1_dst = getelementptr [2 x i64], ptr %var_1, i64 0, i64 1"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1_1, ptr %var_1_1_dst"]
+        .assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
+}

--- a/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/store_array.rs
+++ b/source/compiler/qsc_codegen/src/qir/v2/instruction_tests/store_array.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::qir::v2::ToQir;
+use expect_test::expect;
+use qsc_rir::rir;
+
+#[test]
+fn store_integer_literals_to_array_variable() {
+    let inst = rir::Instruction::StoreArray(
+        vec![
+            rir::Operand::Literal(rir::Literal::Integer(5)),
+            rir::Operand::Literal(rir::Literal::Integer(6)),
+        ],
+        rir::Variable::new_array(rir::VariableId(0), 2, rir::Prim::Integer),
+    );
+    // Each store array produces 2N lines, where N is the size of the array.
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_0_0 = getelementptr [2 x i64], ptr %var_0, i64 0, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 5, ptr %var_0_0"].assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0_1 = getelementptr [2 x i64], ptr %var_0, i64 0, i64 1"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 6, ptr %var_0_1"].assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
+}
+
+#[test]
+fn store_mix_of_integer_literal_and_variable_to_array_variable() {
+    let inst = rir::Instruction::StoreArray(
+        vec![
+            rir::Operand::Literal(rir::Literal::Integer(5)),
+            rir::Operand::Variable(rir::Variable::new_integer(rir::VariableId(1))),
+        ],
+        rir::Variable::new_array(rir::VariableId(0), 2, rir::Prim::Integer),
+    );
+    // Each store array produces 2N lines, where N is the size of the array.
+    let qir = inst.to_qir(&rir::Program::default());
+    let mut lines = qir.lines();
+    expect!["  %var_0_0 = getelementptr [2 x i64], ptr %var_0, i64 0, i64 0"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 5, ptr %var_0_0"].assert_eq(lines.next().expect("line should exist"));
+    expect!["  %var_0_1 = getelementptr [2 x i64], ptr %var_0, i64 0, i64 1"]
+        .assert_eq(lines.next().expect("line should exist"));
+    expect!["  store i64 %var_1, ptr %var_0_1"].assert_eq(lines.next().expect("line should exist"));
+    assert_eq!(lines.next(), None);
+}

--- a/source/compiler/qsc_eval/src/val.rs
+++ b/source/compiler/qsc_eval/src/val.rs
@@ -237,6 +237,18 @@ pub enum VarTy {
     Integer,
     Double,
     Qubit,
+    // An array carries the constant size of the array in the type.
+    Array(usize),
+}
+
+impl VarTy {
+    #[must_use]
+    pub fn is_primitive_ty(&self) -> bool {
+        match self {
+            Self::Boolean | Self::Integer | Self::Double | Self::Qubit => true,
+            Self::Array(_) => false,
+        }
+    }
 }
 
 impl Display for VarTy {
@@ -246,6 +258,7 @@ impl Display for VarTy {
             Self::Integer => write!(f, "Integer"),
             Self::Double => write!(f, "Double"),
             Self::Qubit => write!(f, "Qubit"),
+            Self::Array(size) => write!(f, "Array[{size}]"),
         }
     }
 }

--- a/source/compiler/qsc_fir/src/fir.rs
+++ b/source/compiler/qsc_fir/src/fir.rs
@@ -354,6 +354,30 @@ impl From<(PackageId, StmtId)> for StoreStmtId {
     }
 }
 
+/// A key to uniquely identify the context an expression or variable usage occurs in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum StoreItemSpecializationKey {
+    /// The expression comes from a top-level context outside of any one specific item.
+    /// This only occurs in Python interop scenarios.
+    TopLevel,
+    /// The expression comes from the context of a specific item specialization.
+    Item {
+        /// The store item ID.
+        id: StoreItemId,
+        /// The specific specialization of the expression.
+        spec: FunctorSetValue,
+    },
+}
+
+impl From<(StoreItemId, FunctorSetValue)> for StoreItemSpecializationKey {
+    fn from(tuple: (StoreItemId, FunctorSetValue)) -> Self {
+        Self::Item {
+            id: tuple.0,
+            spec: tuple.1,
+        }
+    }
+}
+
 /// A trait to find elements in a package store.
 pub trait PackageStoreLookup {
     /// Gets a block.

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -34,8 +34,8 @@ use qsc_fir::{
         self, BinOp, Block, BlockId, CallableDecl, CallableImpl, ExecGraph, ExecGraphConfig, Expr,
         ExprId, ExprKind, Field, Functor, Global, Ident, LocalVarId, Mutability, PackageId,
         PackageStore, PackageStoreLookup, Pat, PatId, PatKind, PrimField, Res, SpecDecl, SpecImpl,
-        Stmt, StmtId, StmtKind, StoreBlockId, StoreExprId, StoreItemId, StorePatId, StoreStmtId,
-        StringComponent, UnOp,
+        Stmt, StmtId, StmtKind, StoreBlockId, StoreExprId, StoreItemId, StoreItemSpecializationKey,
+        StorePatId, StoreStmtId, StringComponent, UnOp,
     },
     ty::{FunctorSetValue, Prim, Ty},
 };
@@ -43,8 +43,9 @@ use qsc_fir::{
 pub use qsc_data_structures::intrinsic_names::is_codegen_noop_intrinsic;
 use qsc_lowerer::{map_fir_package_span_to_hir, map_hir_package_to_fir};
 use qsc_rca::{
-    ComputeKind, ComputePropertiesLookup, ItemComputeProperties, PackageStoreComputeProperties,
-    RuntimeFeatureFlags, ValueKind,
+    ComputeKind, ComputePropertiesLookup, ItemComputeProperties,
+    MutableFixedSizeArraysParamApplication, PackageStoreComputeProperties, RuntimeFeatureFlags,
+    ValueKind,
     errors::{
         Error as CapabilityError, generate_errors_from_runtime_features,
         get_missing_runtime_features,
@@ -335,7 +336,7 @@ impl<'a> PartialEvaluator<'a> {
         let pat = self.get_pat(pat_id);
         match &pat.kind {
             PatKind::Bind(ident) => {
-                self.bind_value_to_ident(mutability, ident, value);
+                self.bind_value_to_ident(mutability, ident, value, &pat.ty);
             }
             PatKind::Tuple(pats) => {
                 let tuple = value.unwrap_tuple();
@@ -350,18 +351,68 @@ impl<'a> PartialEvaluator<'a> {
         }
     }
 
-    fn bind_value_to_ident(&mut self, mutability: Mutability, ident: &Ident, value: Value) {
+    fn bind_value_to_ident(
+        &mut self,
+        mutability: Mutability,
+        ident: &Ident,
+        value: Value,
+        ty: &Ty,
+    ) {
         // We do slightly different things depending on the mutability of the identifier.
         match mutability {
-            Mutability::Mutable => self.bind_value_to_mutable_ident(ident, value),
+            Mutability::Mutable => self.bind_value_to_mutable_ident(ident, value, ty),
             Mutability::Immutable => {
                 let current_scope = self.eval_context.get_current_scope();
                 if matches!(value, Value::Var(var) if current_scope.get_static_value(var.id.into()).is_none())
                 {
                     // An immutable identifier is being bound to a dynamic value, so treat the identifier as mutable.
                     // This allows it to represent a point-in-time copy of the mutable value during evaluation.
-                    self.bind_value_to_mutable_ident(ident, value);
+                    self.bind_value_to_mutable_ident(ident, value, ty);
                 } else {
+                    if self
+                        .program
+                        .config
+                        .capabilities
+                        .contains(TargetCapabilityFlags::StaticSizedArrays)
+                        && let Value::Array(array) = &value
+                        && array.iter().any(|elem| matches!(elem, Value::Var(val::Var {ty, ..}) if ty.is_primitive_ty()))
+                        && self
+                            .eval_context
+                            .get_current_scope()
+                            .arrays
+                            .iter()
+                            .all(|(cached_array, _)| !Rc::ptr_eq(cached_array, array))
+                    {
+                        // This target allows for static-sized arrays and this array has variable contents and is not currently cached,
+                        // so speculatively emit a store array to cache it for later dynamic use. This instruction will be optimized
+                        // out of the RIR if the resulting variable is never used.
+                        let var_id = self.resource_manager.next_var();
+                        self.eval_context
+                            .get_current_scope_mut()
+                            .arrays
+                            .push((Rc::clone(array), Some(var_id)));
+                        let operands = array
+                            .iter()
+                            .map(|value| self.map_eval_value_to_rir_operand(value))
+                            .collect::<Vec<_>>();
+                        let rir::Ty::Prim(elem_ty) = operands
+                            .first()
+                            .expect("array should have at least one element")
+                            .get_type()
+                        else {
+                            panic!("array element type should be a primitive type");
+                        };
+                        self.get_current_rir_block_mut()
+                            .0
+                            .push(Instruction::StoreArray(
+                                operands,
+                                rir::Variable {
+                                    variable_id: var_id,
+                                    ty: rir::Ty::Array(array.len(), elem_ty),
+                                },
+                            ));
+                    }
+
                     // The value is static, so bind it to the classical map.
                     self.bind_value_to_immutable_ident(ident, value);
                 }
@@ -379,14 +430,14 @@ impl<'a> PartialEvaluator<'a> {
         self.bind_value_in_hybrid_map(ident, value);
     }
 
-    fn bind_value_to_mutable_ident(&mut self, ident: &Ident, value: Value) {
+    fn bind_value_to_mutable_ident(&mut self, ident: &Ident, value: Value, ty: &Ty) {
         // If the value is not a variable, bind it to the classical map.
         if !matches!(value, Value::Var(_)) {
             self.bind_value_in_classical_map(ident, &value);
         }
 
         // Always bind the value to the hybrid map but do it differently depending of the value type.
-        if let Some((var_id, literal)) = self.try_create_mutable_variable(ident.id, &value) {
+        if let Some((var_id, literal)) = self.try_create_mutable_variable(ident.id, &value, ty) {
             // If the variable maps to a know static literal, track that mapping.
             if let Some(literal) = literal {
                 self.eval_context
@@ -1239,7 +1290,7 @@ impl<'a> PartialEvaluator<'a> {
                     bin_op_expr_span,
                 )
             }
-            VarTy::Qubit => Err(Error::Unexpected(
+            VarTy::Qubit | VarTy::Array(..) => Err(Error::Unexpected(
                 format!(
                     "unsupported LHS variable type {} in binary operation",
                     lhs_eval_var.ty
@@ -1487,17 +1538,70 @@ impl<'a> PartialEvaluator<'a> {
         let ExprKind::Var(Res::Local(array_loc_id), _) = &array_expr.kind else {
             panic!("array expression in assign index expression is expected to be a variable");
         };
-        let array = self
-            .eval_context
-            .get_current_scope()
-            .get_classical_local_value(*array_loc_id)
-            .clone()
-            .unwrap_array();
+        if self.is_mutable_fixed_size_array(*array_loc_id) {
+            // Try to evaluate the index and update expressions to get their value, short-circuiting execution if any of the
+            // expressions is a return.
+            let index_expr_package_span = self.get_expr_package_span(index_expr_id);
+            let index_control_flow = self.try_eval_expr(index_expr_id)?;
+            let EvalControlFlow::Continue(index_value) = index_control_flow else {
+                return Err(Error::Unexpected(
+                    "embedded return in index expression".to_string(),
+                    index_expr_package_span,
+                ));
+            };
+            if matches!(index_value, Value::Range(..)) {
+                return Err(Error::Unimplemented(
+                    "range indexing for mutation of fixed size array".to_string(),
+                    index_expr_package_span,
+                ));
+            }
+            let index_operand = self.map_eval_value_to_rir_operand(&index_value);
+            let update_control_flow = self.try_eval_expr(update_expr_id)?;
+            let EvalControlFlow::Continue(update_value) = update_control_flow else {
+                return Err(Error::Unexpected(
+                    "embedded return in update expression".to_string(),
+                    self.get_expr_package_span(update_expr_id),
+                ));
+            };
+            let update_operand = self.map_eval_value_to_rir_operand(&update_value);
 
-        // Evaluate the updated array and update the corresponding bindings.
-        let new_array_value =
-            self.eval_array_update_index(&array, index_expr_id, update_expr_id)?;
-        self.update_bindings(array_expr_id, new_array_value)?;
+            let Value::Var(array_var) = self
+                .eval_context
+                .get_current_scope()
+                .get_hybrid_local_value(*array_loc_id)
+            else {
+                panic!("mutable fixed size array should be backed by variable");
+            };
+            let VarTy::Array(array_size) = array_var.ty else {
+                panic!("mutable fixed size array should be backed by array type");
+            };
+            let rir::Ty::Prim(elem_ty) = update_operand.get_type() else {
+                panic!("update operand is expected to be of primitive type");
+            };
+            let array_variable = rir::Variable {
+                variable_id: array_var.id.into(),
+                ty: rir::Ty::Array(array_size, elem_ty),
+            };
+            self.get_current_rir_block_mut()
+                .0
+                .push(Instruction::StoreIndex(
+                    update_operand,
+                    index_operand,
+                    array_variable,
+                ));
+        } else {
+            let array = self
+                .eval_context
+                .get_current_scope()
+                .get_classical_local_value(*array_loc_id)
+                .clone()
+                .unwrap_array();
+
+            // Evaluate the updated array and update the corresponding bindings.
+            let new_array_value =
+                self.eval_array_update_index(&array, index_expr_id, update_expr_id)?;
+            self.update_bindings(array_expr_id, new_array_value)?;
+        }
         Ok(EvalControlFlow::Continue(Value::unit()))
     }
 
@@ -1968,18 +2072,23 @@ impl<'a> PartialEvaluator<'a> {
                 ),
                 callee_expr_span,
             )),
-            "Length" => {
-                let Value::Array(arr) = args_value else {
-                    return Err(Error::Unexpected(
-                        "length call on dynamically sized array".to_string(),
-                        callee_expr_span,
-                    ));
-                };
-                match arr.len().try_into() {
+            "Length" => match args_value {
+                Value::Array(arr) => match arr.len().try_into() {
                     Ok(len) => Ok(Value::Int(len)),
                     Err(_) => Err(EvalError::ArrayTooLarge(args_span).into()),
-                }
-            }
+                },
+                Value::Var(val::Var {
+                    ty: VarTy::Array(size),
+                    ..
+                }) => match size.try_into() {
+                    Ok(len) => Ok(Value::Int(len)),
+                    Err(_) => Err(EvalError::ArrayTooLarge(args_span).into()),
+                },
+                _ => Err(Error::Unexpected(
+                    "length call on dynamically sized array".to_string(),
+                    callee_expr_span,
+                )),
+            },
             "IntAsDouble" | "Truncate" => self.convert_value(&args_value, args_span),
 
             // These intrinsic functions should be evaluated immediately rather than emitted if all
@@ -2710,31 +2819,132 @@ impl<'a> PartialEvaluator<'a> {
         };
 
         // Get the value at the specified index.
-        let array = array_value.unwrap_array();
-        let index_package_span = self.get_expr_package_span(index_expr_id);
-        let array_package_span = self.get_expr_package_span(array_expr_id);
-        let value = match index_value {
-            Value::Int(index) => {
-                index_array(&array, index, index_package_span).map_err(Error::from)
-            }
-            Value::Range(range) => slice_array(
-                &array,
-                range.start,
-                range.step,
-                range.end,
-                index_package_span,
+        if let Value::Var(array_var) = array_value {
+            self.eval_expr_index_variable_array(
+                array_expr_id,
+                index_expr_id,
+                index_value,
+                array_var,
             )
-            .map_err(Error::from),
-            Value::Var(var) => {
-                let array_ty = &self.get_expr(array_expr_id).ty;
-                let Ty::Array(elem_ty) = array_ty else {
-                    panic!("expected array type in index expression");
-                };
-                self.eval_expr_dynamic_index(&array, var, array_package_span, elem_ty)
-            }
-            _ => panic!("invalid kind of value for index"),
-        }?;
-        Ok(EvalControlFlow::Continue(value))
+        } else {
+            let array = array_value.unwrap_array();
+            let index_package_span = self.get_expr_package_span(index_expr_id);
+            let array_package_span = self.get_expr_package_span(array_expr_id);
+            let value = match index_value {
+                Value::Int(index) => {
+                    index_array(&array, index, index_package_span).map_err(Error::from)
+                }
+                Value::Range(range) => slice_array(
+                    &array,
+                    range.start,
+                    range.step,
+                    range.end,
+                    index_package_span,
+                )
+                .map_err(Error::from),
+                Value::Var(var) => {
+                    let array_ty = &self.get_expr(array_expr_id).ty;
+                    let Ty::Array(elem_ty) = array_ty else {
+                        panic!("expected array type in index expression");
+                    };
+                    self.eval_expr_dynamic_index(&array, var, array_package_span, elem_ty)
+                }
+                _ => panic!("invalid kind of value for index"),
+            }?;
+            Ok(EvalControlFlow::Continue(value))
+        }
+    }
+
+    fn eval_expr_index_variable_array(
+        &mut self,
+        array_expr_id: ExprId,
+        index_expr_id: ExprId,
+        index_value: Value,
+        array_var: Var,
+    ) -> Result<EvalControlFlow, Error> {
+        let array_ty = &self.get_expr(array_expr_id).ty;
+        let VarTy::Array(array_size) = &array_var.ty else {
+            panic!("expected array type in index expression");
+        };
+        let array_package_span = self.get_expr_package_span(array_expr_id);
+        let Ty::Array(array_elem_ty) = array_ty else {
+            panic!("expected array type in index expression");
+        };
+        let Ok(rir::Ty::Prim(elem_rir_prim_ty)) = map_fir_type_to_rir_type(array_elem_ty) else {
+            return Err(Error::Unexpected(
+                "array with non-primitive RIR type".to_string(),
+                array_package_span,
+            ));
+        };
+        if matches!(index_value, Value::Var(_) | Value::Int(_)) {
+            // The index is a single value (either static int or variable int), so emit an index instruction.
+            let index_operand = self.map_eval_value_to_rir_operand(&index_value);
+            let array_operand = rir::Operand::Variable(rir::Variable {
+                variable_id: array_var.id.into(),
+                ty: rir::Ty::Array(*array_size, elem_rir_prim_ty),
+            });
+
+            let variable_id = self.resource_manager.next_var();
+            let rir_variable = rir::Variable {
+                variable_id,
+                ty: rir::Ty::Prim(elem_rir_prim_ty),
+            };
+
+            self.get_current_rir_block_mut().0.push(Instruction::Index(
+                array_operand,
+                index_operand,
+                rir_variable,
+            ));
+
+            Ok(EvalControlFlow::Continue(Value::Var(
+                map_rir_var_to_eval_var(rir_variable).map_err(|()| {
+                    Error::Unexpected(
+                        format!(
+                            "dynamic value of type {} in index expression",
+                            rir_variable.ty
+                        ),
+                        array_package_span,
+                    )
+                })?,
+            )))
+        } else {
+            // The index must be a range, so emit a slicing instruction.
+            let last_index = TryInto::<i64>::try_into(*array_size)
+                .map_err(|_| EvalError::ArrayTooLarge(self.get_expr_package_span(index_expr_id)))?
+                - 1;
+            let (range_start, range_step, range_end) = index_value.unwrap_range();
+            let (start, step, end) = (
+                range_start.unwrap_or(if range_step > 0 { 0 } else { last_index }),
+                range_step,
+                range_end.unwrap_or(if range_step > 0 { last_index } else { 0 }),
+            );
+            let slice_size = ((end - start + step) / step)
+                .max(0)
+                .try_into()
+                .expect("array size should fit into usize");
+            let new_array_rir_variable = rir::Variable {
+                variable_id: self.resource_manager.next_var(),
+                ty: rir::Ty::Array(slice_size, elem_rir_prim_ty),
+            };
+
+            self.get_current_rir_block_mut()
+                .0
+                .push(Instruction::SliceArray(
+                    rir::Variable {
+                        variable_id: array_var.id.into(),
+                        ty: rir::Ty::Array(*array_size, elem_rir_prim_ty),
+                    },
+                    start,
+                    step,
+                    end,
+                    new_array_rir_variable,
+                ));
+
+            Ok(EvalControlFlow::Continue(Value::Var(val::Var {
+                id: new_array_rir_variable.variable_id.into(),
+                ty: VarTy::Array(slice_size),
+            })))
+        }
     }
 
     fn eval_expr_field(
@@ -3534,6 +3744,102 @@ impl<'a> PartialEvaluator<'a> {
             .is_unresolved_callee_expr(store_expr_id, self.in_parallel_scope())
     }
 
+    fn is_mutable_fixed_size_array(&self, id: LocalVarId) -> bool {
+        let current_scope = self.eval_context.get_current_scope();
+        let current_package_id = self.get_current_package_id();
+        let key = match current_scope.callable {
+            None => StoreItemSpecializationKey::TopLevel,
+            Some((local_item_id, functor_app)) => (
+                (current_package_id, local_item_id).into(),
+                functor_app_to_functor_set_value(functor_app),
+            )
+                .into(),
+        };
+        let Some(entry) = self.compute_properties.get_mutable_fixed_size_array_entry(
+            key,
+            current_package_id,
+            self.in_parallel_scope(),
+        ) else {
+            // There is no analysis entry for this context, so the array cannot be considered mutable fixed-size.
+            return false;
+        };
+        if entry.inherent.contains(&id) {
+            // The analysis determined that the array is inherently mutable fixed-size, so short cut and return true immediately.
+            return true;
+        }
+        for (idx, arg) in current_scope.args_compute_kind.iter().enumerate() {
+            let ComputeKind::Dynamic {
+                runtime_features,
+                value_kind,
+            } = arg
+            else {
+                continue;
+            };
+            // Check the entry for the current parameter application to know if the array with this id is considered mutable fixed-size.
+            match entry
+                .param_application
+                .get(idx)
+                .expect("param applications should be present")
+            {
+                MutableFixedSizeArraysParamApplication::None => {}
+                MutableFixedSizeArraysParamApplication::Element(
+                    mutable_fixed_size_arrays_element_application,
+                ) => match value_kind {
+                    ValueKind::Constant => {
+                        if mutable_fixed_size_arrays_element_application
+                            .constant
+                            .contains(&id)
+                        {
+                            return true;
+                        }
+                    }
+                    ValueKind::Variable => {
+                        if mutable_fixed_size_arrays_element_application
+                            .variable
+                            .contains(&id)
+                        {
+                            return true;
+                        }
+                    }
+                },
+                MutableFixedSizeArraysParamApplication::Array(
+                    mutable_fixed_size_arrays_array_application,
+                ) => match value_kind {
+                    ValueKind::Variable
+                        if runtime_features
+                            .contains(RuntimeFeatureFlags::UseOfDynamicallySizedArray) =>
+                    {
+                        if mutable_fixed_size_arrays_array_application
+                            .dynamic_size
+                            .contains(&id)
+                        {
+                            return true;
+                        }
+                    }
+                    ValueKind::Variable => {
+                        if mutable_fixed_size_arrays_array_application
+                            .static_size
+                            .contains(&id)
+                        {
+                            return true;
+                        }
+                    }
+                    ValueKind::Constant => {
+                        if mutable_fixed_size_arrays_array_application
+                            .constant_content
+                            .contains(&id)
+                        {
+                            return true;
+                        }
+                    }
+                },
+            }
+        }
+
+        // If no other analysis determined this array is mutable fixed-size, return false.
+        false
+    }
+
     fn get_call_compute_kind(&self, callable_scope: &Scope) -> ComputeKind {
         let store_item_id = StoreItemId::from((
             callable_scope.package_id,
@@ -3573,9 +3879,23 @@ impl<'a> PartialEvaluator<'a> {
         &mut self,
         local_var_id: LocalVarId,
         value: &Value,
+        ty: &Ty,
     ) -> Option<(rir::VariableId, Option<Literal>)> {
         // Check if we can create a mutable variable for this value.
-        let var_ty = try_get_eval_var_type(value)?;
+        let var_ty = if self.is_mutable_fixed_size_array(local_var_id) {
+            // We need to get the size of the array to carry it in the variable type.
+            let size = match value {
+                Value::Array(array) => array.len(),
+                Value::Var(Var {
+                    ty: VarTy::Array(size),
+                    ..
+                }) => *size,
+                _ => panic!("expected array value for mutable array variable, found: {value:?}"),
+            };
+            VarTy::Array(size)
+        } else {
+            try_get_eval_var_type(value)?
+        };
 
         // Create an evaluator variable and insert it.
         let var_id = self.resource_manager.next_var();
@@ -3587,19 +3907,73 @@ impl<'a> PartialEvaluator<'a> {
             .get_current_scope_mut()
             .insert_hybrid_local_value(local_var_id, Value::Var(eval_var));
 
-        // Insert a store instruction.
-        let value_operand = self.map_eval_value_to_rir_operand(value);
-        let rir_var = map_eval_var_to_rir_var(eval_var);
-        let store_ins = Instruction::Store(value_operand, rir_var);
-        self.get_current_rir_block_mut().0.push(store_ins);
+        if let VarTy::Array(size) = var_ty {
+            match value {
+                Value::Array(array) => {
+                    // Insert a store array instruction to initialize the array variable with the given value.
+                    let operands = array
+                        .iter()
+                        .map(|value| self.map_eval_value_to_rir_operand(value))
+                        .collect::<Vec<_>>();
+                    let rir::Ty::Prim(elem_ty) = operands
+                        .first()
+                        .expect("array should have at least one element")
+                        .get_type()
+                    else {
+                        panic!("array element type should be a primitive type");
+                    };
+                    self.get_current_rir_block_mut()
+                        .0
+                        .push(Instruction::StoreArray(
+                            operands,
+                            rir::Variable {
+                                variable_id: var_id,
+                                ty: rir::Ty::Array(array.len(), elem_ty),
+                            },
+                        ));
+                }
+                Value::Var(var) => {
+                    // Use the passed Ty to determine the element type of the array variable.
+                    let Ty::Array(inner) = ty else {
+                        panic!("expected array type for mutable array variable, found: {ty}");
+                    };
+                    let rir::Ty::Prim(elem_ty) = map_fir_type_to_rir_type(inner).ok()? else {
+                        panic!("expected primitive type for array element type, found: {inner:?}")
+                    };
+                    self.get_current_rir_block_mut()
+                        .0
+                        .push(Instruction::CopyArray(
+                            rir::Variable {
+                                variable_id: var.id.into(),
+                                ty: rir::Ty::Array(size, elem_ty),
+                            },
+                            rir::Variable {
+                                variable_id: var_id,
+                                ty: rir::Ty::Array(size, elem_ty),
+                            },
+                        ));
+                }
+                _ => panic!(
+                    "expected array value for mutable array variable, found: {}",
+                    value.type_name()
+                ),
+            }
+            Some((var_id, None))
+        } else {
+            // Insert a store instruction.
+            let value_operand = self.map_eval_value_to_rir_operand(value);
+            let rir_var = map_eval_var_to_rir_var(eval_var);
+            let store_ins = Instruction::Store(value_operand, rir_var);
+            self.get_current_rir_block_mut().0.push(store_ins);
 
-        // Create a mutable variable, mapping it to the static value if any.
-        let static_value = match value_operand {
-            Operand::Literal(literal) => Some(literal),
-            Operand::Variable(_) => None,
-        };
+            // Create a mutable variable, mapping it to the static value if any.
+            let static_value = match value_operand {
+                Operand::Literal(literal) => Some(literal),
+                Operand::Variable(_) => None,
+            };
 
-        Some((var_id, static_value))
+            Some((var_id, static_value))
+        }
     }
 
     fn get_or_insert_callable(&mut self, callable: Callable) -> CallableId {
@@ -4088,22 +4462,34 @@ impl<'a> PartialEvaluator<'a> {
             .get_current_scope()
             .get_hybrid_local_value(local_var_id);
         if let Value::Var(var) = bound_value {
-            // Insert a store instruction when the value of a variable is updated.
-            let rhs_operand = self.map_eval_value_to_rir_operand(&value);
-            let rir_var = map_eval_var_to_rir_var(*var);
-            let store_ins = Instruction::Store(rhs_operand, rir_var);
-            self.get_current_rir_block_mut().0.push(store_ins);
+            if let Value::Var(rhs_var) = &value
+                && let VarTy::Array(lhs_size) = &var.ty
+                && let VarTy::Array(rhs_size) = &rhs_var.ty
+                && lhs_size != rhs_size
+            {
+                // This is a size update of a variable, which we can't emit a store instruction for.
+                // Instead, overwrite the variable in the hybrid maps.
+                self.eval_context
+                    .get_current_scope_mut()
+                    .insert_hybrid_local_value(local_var_id, value);
+            } else {
+                // Insert a store instruction when the value of a variable is updated.
+                let rhs_operand = self.map_eval_value_to_rir_operand(&value);
+                let rir_var = map_eval_var_to_rir_var(*var);
+                let store_ins = Instruction::Store(rhs_operand, rir_var);
+                self.get_current_rir_block_mut().0.push(store_ins);
 
-            // If this is a mutable variable, make sure to update whether it is static or dynamic.
-            let current_scope = self.eval_context.get_current_scope_mut();
-            match rhs_operand {
-                Operand::Literal(literal) => {
-                    // The variable maps to a static literal here, so track that literal value.
-                    current_scope.insert_static_var_mapping(rir_var.variable_id, literal);
-                }
-                Operand::Variable(_) => {
-                    // The variable is not known to be some literal value, so remove the static mapping.
-                    current_scope.remove_static_value(rir_var.variable_id);
+                // If this is a mutable variable, make sure to update whether it is static or dynamic.
+                let current_scope = self.eval_context.get_current_scope_mut();
+                match rhs_operand {
+                    Operand::Literal(literal) => {
+                        // The variable maps to a static literal here, so track that literal value.
+                        current_scope.insert_static_var_mapping(rir_var.variable_id, literal);
+                    }
+                    Operand::Variable(_) => {
+                        // The variable is not known to be some literal value, so remove the static mapping.
+                        current_scope.remove_static_value(rir_var.variable_id);
+                    }
                 }
             }
         } else {
@@ -4184,7 +4570,15 @@ impl<'a> PartialEvaluator<'a> {
             Value::Array(vals) => self.record_array(ty, &mut instrs, &vals, tag_root)?,
             Value::Tuple(vals, _) => self.record_tuple(ty, &mut instrs, &vals, tag_root)?,
             Value::Result(res) => self.record_result(&mut instrs, res, tag_root),
-            Value::Var(var) => self.record_variable(ty, &mut instrs, var, tag_root),
+            Value::Var(var) => match &var.ty {
+                VarTy::Array(size) => {
+                    let Ty::Array(elem_ty) = ty else {
+                        panic!("expected array type for array variable");
+                    };
+                    self.record_array_variable(elem_ty, &mut instrs, var, *size, tag_root)?;
+                }
+                _ => self.record_variable(ty, &mut instrs, var, tag_root),
+            },
             Value::Bool(val) => self.record_bool(&mut instrs, val, tag_root),
             Value::Int(val) => self.record_int(&mut instrs, val, tag_root),
             Value::Double(val) => self.record_double(&mut instrs, val, tag_root),
@@ -4264,7 +4658,7 @@ impl<'a> PartialEvaluator<'a> {
             Ty::Prim(Prim::Bool) => (self.get_bool_record_callable(), "b"),
             Ty::Prim(Prim::Int) => (self.get_int_record_callable(), "i"),
             Ty::Prim(Prim::Double) => (self.get_double_record_callable(), "d"),
-            _ => panic!("unsupported variable type in output recording"),
+            _ => panic!("unsupported variable type in output recording: {ty}"),
         };
         let tag = format!("{idx}_{tag_root}{tag_ty}");
         let len = tag.len();
@@ -4378,6 +4772,69 @@ impl<'a> PartialEvaluator<'a> {
                 elem_ty,
                 &new_tag_root,
             )?);
+        }
+
+        Ok(())
+    }
+
+    fn record_array_variable(
+        &mut self,
+        elem_ty: &Ty,
+        instrs: &mut Vec<Instruction>,
+        var: Var,
+        size: usize,
+        tag_root: &str,
+    ) -> Result<(), ()> {
+        let new_tag_root = format!("{tag_root}a");
+        let idx = self.program.tags.len();
+        let tag = format!("{idx}_{new_tag_root}");
+        let len = tag.len();
+        self.program.tags.push(tag);
+        let array_record_callable_id = self.get_array_record_callable();
+        instrs.push(Instruction::Call(
+            array_record_callable_id,
+            vec![
+                Operand::Literal(Literal::Integer(
+                    size.try_into().expect("array length should fit into i32"),
+                )),
+                Operand::Literal(Literal::Tag(idx, len)),
+            ],
+            None,
+            None,
+        ));
+        let rir::Ty::Prim(elem_prim_ty) =
+            map_fir_type_to_rir_type(elem_ty).expect("element type should map to RIR type")
+        else {
+            panic!("element type should map to RIR primitive type");
+        };
+        for idx in 0..size {
+            let new_tag_root = format!("{new_tag_root}{idx}");
+            let variable_id = self.resource_manager.next_var();
+            let rir_variable = rir::Variable {
+                variable_id,
+                ty: rir::Ty::Prim(elem_prim_ty),
+            };
+
+            self.get_current_rir_block_mut().0.push(Instruction::Index(
+                Operand::Variable(rir::Variable {
+                    variable_id: var.id.into(),
+                    ty: rir::Ty::Array(size, elem_prim_ty),
+                }),
+                Operand::Literal(Literal::Integer(
+                    idx.try_into().expect("index should fit into i32"),
+                )),
+                rir_variable,
+            ));
+            instrs.extend(
+                self.generate_output_recording_instructions(
+                    Value::Var(
+                        map_rir_var_to_eval_var(rir_variable)
+                            .expect("RIR variable should map to eval variable"),
+                    ),
+                    elem_ty,
+                    &new_tag_root,
+                )?,
+            );
         }
 
         Ok(())
@@ -5306,6 +5763,7 @@ fn map_eval_var_type_to_rir_type(var_ty: VarTy) -> rir::Ty {
         VarTy::Integer => rir::Ty::Prim(rir::Prim::Integer),
         VarTy::Double => rir::Ty::Prim(rir::Prim::Double),
         VarTy::Qubit => rir::Ty::Prim(rir::Prim::Qubit),
+        VarTy::Array(..) => rir::Ty::Prim(rir::Prim::Pointer),
     }
 }
 

--- a/source/compiler/qsc_partial_eval/src/tests/arrays.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/arrays.rs
@@ -8,11 +8,13 @@
 )]
 
 use super::{
-    assert_block_instructions, assert_callable, assert_error, get_partial_evaluation_error,
-    get_rir_program,
+    assert_block_instructions, assert_blocks, assert_callable, assert_error,
+    get_partial_evaluation_error, get_partial_evaluation_error_with_capabilities, get_rir_program,
+    get_rir_program_with_adaptive_profile,
 };
 use expect_test::expect;
 use indoc::indoc;
+use qsc_data_structures::target::Profile;
 use qsc_rir::rir::{BlockId, CallableId};
 
 #[test]
@@ -1105,4 +1107,437 @@ fn result_array_index_range_returns_length_as_end() {
             tags:
                 [0]: 0_i
     "#]].assert_eq(&program.to_string());
+}
+
+#[test]
+fn mutable_fixed_size_array_dynamic_index_update() {
+    let program = get_rir_program_with_adaptive_profile(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Int[] {
+            use qs = Qubit[4];
+            mutable arr = [0, size = Length(qs)];
+            for idx in 0..Length(qs)-1 {
+                if M(qs[idx]) == One {
+                    arr[idx] = 1;
+                }
+            }
+            arr
+        }
+    "#});
+    assert_blocks(
+        &program,
+        &expect![[r#"
+        Blocks:
+        Block 0:Block:
+            Call id(1), args( Pointer, )
+            Variable(0, Integer) = Store Integer(0)
+            Variable(0, Integer) = Store Integer(1)
+            Variable(0, Integer) = Store Integer(2)
+            Variable(0, Integer) = Store Integer(3)
+            Variable(0, Integer) = Store Integer(4)
+            Variable(1, Array(4, Integer)) = StoreArray [Integer(0), Integer(0), Integer(0), Integer(0)]
+            Variable(2, Integer) = Store Integer(0)
+            Jump(1)
+        Block 1:Block:
+            Variable(3, Boolean) = Icmp Sle, Variable(2, Integer), Integer(3)
+            Variable(4, Boolean) = Store Bool(true)
+            Branch Variable(3, Boolean), 3, 4
+        Block 2:Block:
+            Variable(9, Array(4, Integer)) = CopyArray Variable(1, Array(4, Integer))
+            Variable(10, Integer) = Index Variable(9, Array(4, Integer)), Integer(0)
+            Variable(11, Integer) = Index Variable(9, Array(4, Integer)), Integer(1)
+            Variable(12, Integer) = Index Variable(9, Array(4, Integer)), Integer(2)
+            Variable(13, Integer) = Index Variable(9, Array(4, Integer)), Integer(3)
+            Call id(4), args( Integer(4), Tag(0, 3), )
+            Call id(5), args( Variable(10, Integer), Tag(1, 5), )
+            Call id(5), args( Variable(11, Integer), Tag(2, 5), )
+            Call id(5), args( Variable(12, Integer), Tag(3, 5), )
+            Call id(5), args( Variable(13, Integer), Tag(4, 5), )
+            Return Integer(0)
+        Block 3:Block:
+            Branch Variable(4, Boolean), 5, 2
+        Block 4:Block:
+            Variable(4, Boolean) = Store Bool(false)
+            Jump(3)
+        Block 5:Block:
+            Variable(5, Qubit) = Index Array(0), Variable(2, Integer)
+            Call id(2), args( Variable(5, Qubit), Result(0), )
+            Variable(6, Boolean) = Call id(3), args( Result(0), )
+            Variable(7, Boolean) = Store Variable(6, Boolean)
+            Branch Variable(7, Boolean), 7, 6
+        Block 6:Block:
+            Variable(8, Integer) = Add Variable(2, Integer), Integer(1)
+            Variable(2, Integer) = Store Variable(8, Integer)
+            Jump(1)
+        Block 7:Block:
+            StoreIndex Integer(1), Variable(2, Integer), Variable(1, Array(4, Integer))
+            Jump(6)"#]],
+    );
+}
+
+#[test]
+fn mutable_fixed_size_array_dynamic_range_update() {
+    let error = get_partial_evaluation_error_with_capabilities(
+        indoc! {r#"
+        @EntryPoint()
+        operation Main() : Bool[] {
+            use qs = Qubit[2];
+            mutable arr = [false, size = 4];
+            arr[...2...] = Std.Convert.ResultArrayAsBoolArray(MResetEachZ(qs));
+            arr
+        }
+    "#},
+        Profile::Adaptive.into(),
+    );
+    expect![[r#"
+        Unimplemented(
+            "range indexing for mutation of fixed size array",
+            PackageSpan {
+                package: PackageId(
+                    2,
+                ),
+                span: Span {
+                    lo: 111,
+                    hi: 118,
+                },
+            },
+        )
+    "#]]
+    .assert_debug_eq(&error);
+}
+
+#[test]
+fn mutable_fixed_size_array_length_emitted_as_constant() {
+    let program = get_rir_program_with_adaptive_profile(indoc! {r#"
+        @EntryPoint()
+        operation Main() : (Int[], Int) {
+            use qs = Qubit[4];
+            mutable arr = [0, size = Length(qs)];
+            for idx in 0..Length(qs)-1 {
+                if M(qs[idx]) == One {
+                    arr[idx] = 1;
+                }
+            }
+            (arr, Length(arr))
+        }
+    "#});
+    assert_blocks(
+        &program,
+        &expect![[r#"
+        Blocks:
+        Block 0:Block:
+            Call id(1), args( Pointer, )
+            Variable(0, Integer) = Store Integer(0)
+            Variable(0, Integer) = Store Integer(1)
+            Variable(0, Integer) = Store Integer(2)
+            Variable(0, Integer) = Store Integer(3)
+            Variable(0, Integer) = Store Integer(4)
+            Variable(1, Array(4, Integer)) = StoreArray [Integer(0), Integer(0), Integer(0), Integer(0)]
+            Variable(2, Integer) = Store Integer(0)
+            Jump(1)
+        Block 1:Block:
+            Variable(3, Boolean) = Icmp Sle, Variable(2, Integer), Integer(3)
+            Variable(4, Boolean) = Store Bool(true)
+            Branch Variable(3, Boolean), 3, 4
+        Block 2:Block:
+            Variable(9, Integer) = Index Variable(1, Array(4, Integer)), Integer(0)
+            Variable(10, Integer) = Index Variable(1, Array(4, Integer)), Integer(1)
+            Variable(11, Integer) = Index Variable(1, Array(4, Integer)), Integer(2)
+            Variable(12, Integer) = Index Variable(1, Array(4, Integer)), Integer(3)
+            Call id(4), args( Integer(2), Tag(0, 3), )
+            Call id(5), args( Integer(4), Tag(1, 5), )
+            Call id(6), args( Variable(9, Integer), Tag(2, 7), )
+            Call id(6), args( Variable(10, Integer), Tag(3, 7), )
+            Call id(6), args( Variable(11, Integer), Tag(4, 7), )
+            Call id(6), args( Variable(12, Integer), Tag(5, 7), )
+            Call id(6), args( Integer(4), Tag(6, 5), )
+            Return Integer(0)
+        Block 3:Block:
+            Branch Variable(4, Boolean), 5, 2
+        Block 4:Block:
+            Variable(4, Boolean) = Store Bool(false)
+            Jump(3)
+        Block 5:Block:
+            Variable(5, Qubit) = Index Array(0), Variable(2, Integer)
+            Call id(2), args( Variable(5, Qubit), Result(0), )
+            Variable(6, Boolean) = Call id(3), args( Result(0), )
+            Variable(7, Boolean) = Store Variable(6, Boolean)
+            Branch Variable(7, Boolean), 7, 6
+        Block 6:Block:
+            Variable(8, Integer) = Add Variable(2, Integer), Integer(1)
+            Variable(2, Integer) = Store Variable(8, Integer)
+            Jump(1)
+        Block 7:Block:
+            StoreIndex Integer(1), Variable(2, Integer), Variable(1, Array(4, Integer))
+            Jump(6)"#]],
+    );
+}
+
+#[test]
+fn mutable_fixed_size_array_length_usable_in_ranges() {
+    let program = get_rir_program_with_adaptive_profile(indoc! {r#"
+        @EntryPoint()
+        operation Main() : (Int[], Int) {
+            use qs = Qubit[4];
+            mutable arr = [0, size = Length(qs)];
+            for idx in 0..Length(arr)-1 {
+                if M(qs[idx]) == One {
+                    arr[idx] = 1;
+                }
+            }
+            (arr, Length(arr))
+        }
+    "#});
+    assert_blocks(
+        &program,
+        &expect![[r#"
+        Blocks:
+        Block 0:Block:
+            Call id(1), args( Pointer, )
+            Variable(0, Integer) = Store Integer(0)
+            Variable(0, Integer) = Store Integer(1)
+            Variable(0, Integer) = Store Integer(2)
+            Variable(0, Integer) = Store Integer(3)
+            Variable(0, Integer) = Store Integer(4)
+            Variable(1, Array(4, Integer)) = StoreArray [Integer(0), Integer(0), Integer(0), Integer(0)]
+            Variable(2, Integer) = Store Integer(0)
+            Jump(1)
+        Block 1:Block:
+            Variable(3, Boolean) = Icmp Sle, Variable(2, Integer), Integer(3)
+            Variable(4, Boolean) = Store Bool(true)
+            Branch Variable(3, Boolean), 3, 4
+        Block 2:Block:
+            Variable(9, Integer) = Index Variable(1, Array(4, Integer)), Integer(0)
+            Variable(10, Integer) = Index Variable(1, Array(4, Integer)), Integer(1)
+            Variable(11, Integer) = Index Variable(1, Array(4, Integer)), Integer(2)
+            Variable(12, Integer) = Index Variable(1, Array(4, Integer)), Integer(3)
+            Call id(4), args( Integer(2), Tag(0, 3), )
+            Call id(5), args( Integer(4), Tag(1, 5), )
+            Call id(6), args( Variable(9, Integer), Tag(2, 7), )
+            Call id(6), args( Variable(10, Integer), Tag(3, 7), )
+            Call id(6), args( Variable(11, Integer), Tag(4, 7), )
+            Call id(6), args( Variable(12, Integer), Tag(5, 7), )
+            Call id(6), args( Integer(4), Tag(6, 5), )
+            Return Integer(0)
+        Block 3:Block:
+            Branch Variable(4, Boolean), 5, 2
+        Block 4:Block:
+            Variable(4, Boolean) = Store Bool(false)
+            Jump(3)
+        Block 5:Block:
+            Variable(5, Qubit) = Index Array(0), Variable(2, Integer)
+            Call id(2), args( Variable(5, Qubit), Result(0), )
+            Variable(6, Boolean) = Call id(3), args( Result(0), )
+            Variable(7, Boolean) = Store Variable(6, Boolean)
+            Branch Variable(7, Boolean), 7, 6
+        Block 6:Block:
+            Variable(8, Integer) = Add Variable(2, Integer), Integer(1)
+            Variable(2, Integer) = Store Variable(8, Integer)
+            Jump(1)
+        Block 7:Block:
+            StoreIndex Integer(1), Variable(2, Integer), Variable(1, Array(4, Integer))
+            Jump(6)"#]],
+    );
+}
+
+#[test]
+fn mutable_fixed_size_array_slicing() {
+    let program = get_rir_program_with_adaptive_profile(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Int[] {
+            use qs = Qubit[4];
+            mutable arr = [0, size = Length(qs)];
+            for idx in 0..Length(qs)-1 {
+                if M(qs[idx]) == One {
+                    arr[idx] = 1;
+                }
+            }
+            arr[...2...]
+        }
+    "#});
+    assert_blocks(
+        &program,
+        &expect![[r#"
+        Blocks:
+        Block 0:Block:
+            Call id(1), args( Pointer, )
+            Variable(0, Integer) = Store Integer(0)
+            Variable(0, Integer) = Store Integer(1)
+            Variable(0, Integer) = Store Integer(2)
+            Variable(0, Integer) = Store Integer(3)
+            Variable(0, Integer) = Store Integer(4)
+            Variable(1, Array(4, Integer)) = StoreArray [Integer(0), Integer(0), Integer(0), Integer(0)]
+            Variable(2, Integer) = Store Integer(0)
+            Jump(1)
+        Block 1:Block:
+            Variable(3, Boolean) = Icmp Sle, Variable(2, Integer), Integer(3)
+            Variable(4, Boolean) = Store Bool(true)
+            Branch Variable(3, Boolean), 3, 4
+        Block 2:Block:
+            Variable(9, Array(2, Integer)) = SliceArray Variable(1, Array(4, Integer)), 0, 2, 3
+            Variable(10, Array(2, Integer)) = CopyArray Variable(9, Array(2, Integer))
+            Variable(11, Integer) = Index Variable(10, Array(2, Integer)), Integer(0)
+            Variable(12, Integer) = Index Variable(10, Array(2, Integer)), Integer(1)
+            Call id(4), args( Integer(2), Tag(0, 3), )
+            Call id(5), args( Variable(11, Integer), Tag(1, 5), )
+            Call id(5), args( Variable(12, Integer), Tag(2, 5), )
+            Return Integer(0)
+        Block 3:Block:
+            Branch Variable(4, Boolean), 5, 2
+        Block 4:Block:
+            Variable(4, Boolean) = Store Bool(false)
+            Jump(3)
+        Block 5:Block:
+            Variable(5, Qubit) = Index Array(0), Variable(2, Integer)
+            Call id(2), args( Variable(5, Qubit), Result(0), )
+            Variable(6, Boolean) = Call id(3), args( Result(0), )
+            Variable(7, Boolean) = Store Variable(6, Boolean)
+            Branch Variable(7, Boolean), 7, 6
+        Block 6:Block:
+            Variable(8, Integer) = Add Variable(2, Integer), Integer(1)
+            Variable(2, Integer) = Store Variable(8, Integer)
+            Jump(1)
+        Block 7:Block:
+            StoreIndex Integer(1), Variable(2, Integer), Variable(1, Array(4, Integer))
+            Jump(6)"#]],
+    );
+}
+
+#[test]
+fn mutable_fixed_size_array_reverse_slicing() {
+    let program = get_rir_program_with_adaptive_profile(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Int[] {
+            use qs = Qubit[4];
+            mutable arr = [0, size = Length(qs)];
+            for idx in 0..Length(qs)-1 {
+                if M(qs[idx]) == One {
+                    arr[idx] = 1;
+                }
+            }
+            arr[...-2...]
+        }
+    "#});
+    assert_blocks(
+        &program,
+        &expect![[r#"
+        Blocks:
+        Block 0:Block:
+            Call id(1), args( Pointer, )
+            Variable(0, Integer) = Store Integer(0)
+            Variable(0, Integer) = Store Integer(1)
+            Variable(0, Integer) = Store Integer(2)
+            Variable(0, Integer) = Store Integer(3)
+            Variable(0, Integer) = Store Integer(4)
+            Variable(1, Array(4, Integer)) = StoreArray [Integer(0), Integer(0), Integer(0), Integer(0)]
+            Variable(2, Integer) = Store Integer(0)
+            Jump(1)
+        Block 1:Block:
+            Variable(3, Boolean) = Icmp Sle, Variable(2, Integer), Integer(3)
+            Variable(4, Boolean) = Store Bool(true)
+            Branch Variable(3, Boolean), 3, 4
+        Block 2:Block:
+            Variable(9, Array(2, Integer)) = SliceArray Variable(1, Array(4, Integer)), 3, -2, 0
+            Variable(10, Array(2, Integer)) = CopyArray Variable(9, Array(2, Integer))
+            Variable(11, Integer) = Index Variable(10, Array(2, Integer)), Integer(0)
+            Variable(12, Integer) = Index Variable(10, Array(2, Integer)), Integer(1)
+            Call id(4), args( Integer(2), Tag(0, 3), )
+            Call id(5), args( Variable(11, Integer), Tag(1, 5), )
+            Call id(5), args( Variable(12, Integer), Tag(2, 5), )
+            Return Integer(0)
+        Block 3:Block:
+            Branch Variable(4, Boolean), 5, 2
+        Block 4:Block:
+            Variable(4, Boolean) = Store Bool(false)
+            Jump(3)
+        Block 5:Block:
+            Variable(5, Qubit) = Index Array(0), Variable(2, Integer)
+            Call id(2), args( Variable(5, Qubit), Result(0), )
+            Variable(6, Boolean) = Call id(3), args( Result(0), )
+            Variable(7, Boolean) = Store Variable(6, Boolean)
+            Branch Variable(7, Boolean), 7, 6
+        Block 6:Block:
+            Variable(8, Integer) = Add Variable(2, Integer), Integer(1)
+            Variable(2, Integer) = Store Variable(8, Integer)
+            Jump(1)
+        Block 7:Block:
+            StoreIndex Integer(1), Variable(2, Integer), Variable(1, Array(4, Integer))
+            Jump(6)"#]],
+    );
+}
+
+#[test]
+fn immutable_array_dynamic_content_generates_store_array() {
+    let program = get_rir_program_with_adaptive_profile(indoc! {r#"
+        operation Main() : Bool[] {
+            use qs = Qubit[3];
+            mutable arr = [false, size = Length(qs) + 1];
+            let res = Std.Convert.ResultArrayAsBoolArray(MResetEachZ(qs));
+            for i in 0..Length(res)-1 {
+                arr[i + 1] = res[i];
+            }
+            arr
+        }
+    "#});
+    assert_blocks(
+        &program,
+        &expect![[r#"
+        Blocks:
+        Block 0:Block:
+            Call id(1), args( Pointer, )
+            Variable(0, Integer) = Store Integer(0)
+            Variable(0, Integer) = Store Integer(1)
+            Variable(0, Integer) = Store Integer(2)
+            Variable(0, Integer) = Store Integer(3)
+            Variable(1, Array(4, Boolean)) = StoreArray [Bool(false), Bool(false), Bool(false), Bool(false)]
+            Variable(2, Integer) = Store Integer(0)
+            Call id(2), args( Qubit(0), Result(0), )
+            Variable(2, Integer) = Store Integer(1)
+            Call id(2), args( Qubit(1), Result(1), )
+            Variable(2, Integer) = Store Integer(2)
+            Call id(2), args( Qubit(2), Result(2), )
+            Variable(2, Integer) = Store Integer(3)
+            Variable(3, Integer) = Store Integer(0)
+            Variable(4, Boolean) = Call id(3), args( Result(0), )
+            Variable(5, Boolean) = Store Variable(4, Boolean)
+            Variable(3, Integer) = Store Integer(1)
+            Variable(6, Boolean) = Call id(3), args( Result(1), )
+            Variable(7, Boolean) = Store Variable(6, Boolean)
+            Variable(3, Integer) = Store Integer(2)
+            Variable(8, Boolean) = Call id(3), args( Result(2), )
+            Variable(9, Boolean) = Store Variable(8, Boolean)
+            Variable(3, Integer) = Store Integer(3)
+            Variable(10, Array(3, Boolean)) = StoreArray [Variable(5, Boolean), Variable(7, Boolean), Variable(9, Boolean)]
+            Variable(11, Integer) = Store Integer(0)
+            Jump(1)
+        Block 1:Block:
+            Variable(12, Boolean) = Icmp Sle, Variable(11, Integer), Integer(2)
+            Variable(13, Boolean) = Store Bool(true)
+            Branch Variable(12, Boolean), 3, 4
+        Block 2:Block:
+            Variable(18, Array(4, Boolean)) = CopyArray Variable(1, Array(4, Boolean))
+            Variable(19, Boolean) = Index Variable(18, Array(4, Boolean)), Integer(0)
+            Variable(20, Boolean) = Index Variable(18, Array(4, Boolean)), Integer(1)
+            Variable(21, Boolean) = Index Variable(18, Array(4, Boolean)), Integer(2)
+            Variable(22, Boolean) = Index Variable(18, Array(4, Boolean)), Integer(3)
+            Call id(4), args( Integer(4), Tag(0, 3), )
+            Call id(5), args( Variable(19, Boolean), Tag(1, 5), )
+            Call id(5), args( Variable(20, Boolean), Tag(2, 5), )
+            Call id(5), args( Variable(21, Boolean), Tag(3, 5), )
+            Call id(5), args( Variable(22, Boolean), Tag(4, 5), )
+            Return Integer(0)
+        Block 3:Block:
+            Branch Variable(13, Boolean), 5, 2
+        Block 4:Block:
+            Variable(13, Boolean) = Store Bool(false)
+            Jump(3)
+        Block 5:Block:
+            Variable(14, Integer) = Add Variable(11, Integer), Integer(1)
+            Variable(15, Integer) = Store Variable(14, Integer)
+            Variable(16, Boolean) = Index Variable(10, Array(3, Boolean)), Variable(11, Integer)
+            StoreIndex Variable(16, Boolean), Variable(15, Integer), Variable(1, Array(4, Boolean))
+            Variable(17, Integer) = Add Variable(11, Integer), Integer(1)
+            Variable(11, Integer) = Store Variable(17, Integer)
+            Jump(1)"#]],
+    );
 }

--- a/source/compiler/qsc_partial_eval/src/tests/loops.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/loops.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::too_many_lines)]
+
 use crate::tests::{get_rir_program_with_adaptive_profile, get_rir_program_with_capabilities};
 
 use super::{assert_block_instructions, assert_blocks, assert_callable, get_rir_program};
@@ -1224,26 +1226,33 @@ fn rotation_call_within_a_while_loop_over_dynamic_array() {
             blocks:
                 Block 0: Block:
                     Call id(1), args( Pointer, )
+                    Variable(0, Array(3, Double)) = StoreArray [Double(0), Double(1), Double(2)]
                     Call id(2), args( Qubit(0), Result(0), )
-                    Variable(0, Boolean) = Call id(3), args( Result(0), )
-                    Variable(1, Boolean) = Store Variable(0, Boolean)
-                    Branch Variable(1, Boolean), 2, 3
+                    Variable(1, Boolean) = Call id(3), args( Result(0), )
+                    Variable(2, Boolean) = Store Variable(1, Boolean)
+                    Branch Variable(2, Boolean), 2, 3
                 Block 1: Block:
-                    Variable(3, Integer) = Store Integer(0)
-                    Call id(4), args( Double(0), Qubit(0), )
-                    Variable(3, Integer) = Store Integer(1)
-                    Call id(4), args( Variable(2, Double), Qubit(0), )
-                    Variable(3, Integer) = Store Integer(2)
-                    Call id(4), args( Double(2), Qubit(0), )
-                    Variable(3, Integer) = Store Integer(3)
-                    Call id(5), args( Integer(0), Tag(0, 3), )
-                    Return Integer(0)
+                    StoreIndex Variable(3, Double), Integer(1), Variable(0, Array(3, Double))
+                    Variable(4, Integer) = Store Integer(0)
+                    Jump(4)
                 Block 2: Block:
-                    Variable(2, Double) = Store Double(1.5)
+                    Variable(3, Double) = Store Double(1.5)
                     Jump(1)
                 Block 3: Block:
-                    Variable(2, Double) = Store Double(1)
+                    Variable(3, Double) = Store Double(1)
                     Jump(1)
+                Block 4: Block:
+                    Variable(5, Boolean) = Icmp Slt, Variable(4, Integer), Integer(3)
+                    Branch Variable(5, Boolean), 6, 5
+                Block 5: Block:
+                    Call id(5), args( Integer(0), Tag(0, 3), )
+                    Return Integer(0)
+                Block 6: Block:
+                    Variable(6, Double) = Index Variable(0, Array(3, Double)), Variable(4, Integer)
+                    Call id(4), args( Variable(6, Double), Qubit(0), )
+                    Variable(7, Integer) = Add Variable(4, Integer), Integer(1)
+                    Variable(4, Integer) = Store Variable(7, Integer)
+                    Jump(4)
             config: Config:
                 capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | StaticSizedArrays | CallSupport)
             num_qubits: 1

--- a/source/compiler/qsc_rca/src/applications.rs
+++ b/source/compiler/qsc_rca/src/applications.rs
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 
 use crate::{
-    ApplicationGeneratorSet, ComputeKind, RuntimeFeatureFlags, ValueKind,
+    ApplicationGeneratorSet, ComputeKind, MutableFixedSizeArraysParamApplication,
+    RuntimeFeatureFlags, ValueKind,
     common::{Local, LocalKind, LocalsLookup, initialize_locals_map},
     scaffolding::InternalPackageComputeProperties,
 };
 use qsc_data_structures::index_map::IndexMap;
 use qsc_fir::{
     extensions::{InputParam, InputParamIndex},
-    fir::{BlockId, ExprId, LocalVarId, StmtId},
+    fir::{BlockId, ExprId, LocalVarId, StmtId, StoreItemSpecializationKey},
     ty::Ty,
 };
 use rustc_hash::FxHashMap;
@@ -456,6 +457,215 @@ impl GeneratorSetsBuilder {
                 .unresolved_callee_exprs
                 .push(unresolved_callee_expr_id);
         }
+
+        // Save the mutable fixed size arrays.
+        save_mutable_fixed_size_arrays(
+            inherent_application_compute_properties,
+            dynamic_param_applications_compute_properties,
+            package_compute_properties,
+            input_params_count,
+        );
+    }
+}
+
+fn save_mutable_fixed_size_arrays(
+    inherent_application_compute_properties: &mut ApplicationInstanceComputeProperties,
+    dynamic_param_applications_compute_properties: &mut [ParamApplicationComputeProperties],
+    package_compute_properties: &mut InternalPackageComputeProperties,
+    input_params_count: usize,
+) {
+    // For each analyzed application of parameters, iterate through the mutable fixed-size arrays and save them into the corresponding
+    // package store compute properties. This allows later checks to identify when a particular application causes a given local variable
+    // id to require a mutable fixed-size array.
+    for (key, mutable_fixed_size_array) in inherent_application_compute_properties
+        .mutable_fixed_size_arrays
+        .drain(..)
+    {
+        let entry = package_compute_properties
+            .mutable_fixed_size_arrays
+            .entry(key)
+            .or_default();
+        entry.inherent.insert(mutable_fixed_size_array);
+        entry.param_application.resize_with(input_params_count, || {
+            MutableFixedSizeArraysParamApplication::None
+        });
+    }
+    for (idx, param_application) in dynamic_param_applications_compute_properties
+        .iter_mut()
+        .enumerate()
+    {
+        match param_application {
+            ParamApplicationComputeProperties::Element(
+                element_param_application_compute_properties,
+            ) => {
+                save_element_param_mutable_fixed_size_arrays(
+                    package_compute_properties,
+                    input_params_count,
+                    idx,
+                    element_param_application_compute_properties,
+                );
+            }
+            ParamApplicationComputeProperties::Array(
+                array_param_application_compute_properties,
+            ) => {
+                save_array_param_mutable_fixed_size_arrays(
+                    package_compute_properties,
+                    input_params_count,
+                    idx,
+                    array_param_application_compute_properties,
+                );
+            }
+        }
+    }
+}
+
+fn save_array_param_mutable_fixed_size_arrays(
+    package_compute_properties: &mut InternalPackageComputeProperties,
+    input_params_count: usize,
+    idx: usize,
+    array_param_application_compute_properties: &mut Box<ArrayParamApplicationComputeProperties>,
+) {
+    for (key, mutable_fixed_size_array) in array_param_application_compute_properties
+        .constant_content
+        .mutable_fixed_size_arrays
+        .drain(..)
+    {
+        let mutable_fixed_size_arrays_param_application = &mut package_compute_properties
+            .mutable_fixed_size_arrays
+            .entry(key)
+            .or_default()
+            .param_application;
+        if mutable_fixed_size_arrays_param_application.is_empty() {
+            mutable_fixed_size_arrays_param_application.resize_with(input_params_count, || {
+                MutableFixedSizeArraysParamApplication::None
+            });
+        }
+        let entry = mutable_fixed_size_arrays_param_application
+            .get_mut(idx)
+            .expect("expected an array param application entry");
+        if matches!(entry, MutableFixedSizeArraysParamApplication::None) {
+            *entry = MutableFixedSizeArraysParamApplication::Array(Default::default());
+        }
+        let MutableFixedSizeArraysParamApplication::Array(array_entry) = entry else {
+            panic!("expected an array param application entry");
+        };
+        array_entry
+            .constant_content
+            .insert(mutable_fixed_size_array);
+    }
+    for (key, mutable_fixed_size_array) in array_param_application_compute_properties
+        .static_size
+        .mutable_fixed_size_arrays
+        .drain(..)
+    {
+        let mutable_fixed_size_arrays_param_application = &mut package_compute_properties
+            .mutable_fixed_size_arrays
+            .entry(key)
+            .or_default()
+            .param_application;
+        if mutable_fixed_size_arrays_param_application.is_empty() {
+            mutable_fixed_size_arrays_param_application.resize_with(input_params_count, || {
+                MutableFixedSizeArraysParamApplication::None
+            });
+        }
+        let entry = mutable_fixed_size_arrays_param_application
+            .get_mut(idx)
+            .expect("expected an array param application entry");
+        if matches!(entry, MutableFixedSizeArraysParamApplication::None) {
+            *entry = MutableFixedSizeArraysParamApplication::Array(Default::default());
+        }
+        let MutableFixedSizeArraysParamApplication::Array(array_entry) = entry else {
+            panic!("expected an array param application entry");
+        };
+        array_entry.static_size.insert(mutable_fixed_size_array);
+    }
+    for (key, mutable_fixed_size_array) in array_param_application_compute_properties
+        .dynamic_size
+        .mutable_fixed_size_arrays
+        .drain(..)
+    {
+        let mutable_fixed_size_arrays_param_application = &mut package_compute_properties
+            .mutable_fixed_size_arrays
+            .entry(key)
+            .or_default()
+            .param_application;
+        if mutable_fixed_size_arrays_param_application.is_empty() {
+            mutable_fixed_size_arrays_param_application.resize_with(input_params_count, || {
+                MutableFixedSizeArraysParamApplication::None
+            });
+        }
+        let entry = mutable_fixed_size_arrays_param_application
+            .get_mut(idx)
+            .expect("expected an array param application entry");
+        if matches!(entry, MutableFixedSizeArraysParamApplication::None) {
+            *entry = MutableFixedSizeArraysParamApplication::Array(Default::default());
+        }
+        let MutableFixedSizeArraysParamApplication::Array(array_entry) = entry else {
+            panic!("expected an array param application entry");
+        };
+        array_entry.dynamic_size.insert(mutable_fixed_size_array);
+    }
+}
+
+fn save_element_param_mutable_fixed_size_arrays(
+    package_compute_properties: &mut InternalPackageComputeProperties,
+    input_params_count: usize,
+    idx: usize,
+    element_param_application_compute_properties: &mut Box<
+        ElementParamApplicationComputeProperties,
+    >,
+) {
+    for (key, mutable_fixed_size_array) in element_param_application_compute_properties
+        .constant
+        .mutable_fixed_size_arrays
+        .drain(..)
+    {
+        let mutable_fixed_size_arrays_param_application = &mut package_compute_properties
+            .mutable_fixed_size_arrays
+            .entry(key)
+            .or_default()
+            .param_application;
+        if mutable_fixed_size_arrays_param_application.is_empty() {
+            mutable_fixed_size_arrays_param_application.resize_with(input_params_count, || {
+                MutableFixedSizeArraysParamApplication::None
+            });
+        }
+        let entry = mutable_fixed_size_arrays_param_application
+            .get_mut(idx)
+            .expect("expected an element param application entry");
+        if matches!(entry, MutableFixedSizeArraysParamApplication::None) {
+            *entry = MutableFixedSizeArraysParamApplication::Element(Default::default());
+        }
+        let MutableFixedSizeArraysParamApplication::Element(element_entry) = entry else {
+            panic!("expected an element param application entry");
+        };
+        element_entry.constant.insert(mutable_fixed_size_array);
+    }
+    for (key, mutable_fixed_size_array) in element_param_application_compute_properties
+        .variable
+        .mutable_fixed_size_arrays
+        .drain(..)
+    {
+        let mutable_fixed_size_arrays_param_application = &mut package_compute_properties
+            .mutable_fixed_size_arrays
+            .entry(key)
+            .or_default()
+            .param_application;
+        if mutable_fixed_size_arrays_param_application.is_empty() {
+            mutable_fixed_size_arrays_param_application.resize_with(input_params_count, || {
+                MutableFixedSizeArraysParamApplication::None
+            });
+        }
+        let entry = mutable_fixed_size_arrays_param_application
+            .get_mut(idx)
+            .expect("expected an element param application entry");
+        if matches!(entry, MutableFixedSizeArraysParamApplication::None) {
+            *entry = MutableFixedSizeArraysParamApplication::Element(Default::default());
+        }
+        let MutableFixedSizeArraysParamApplication::Element(element_entry) = entry else {
+            panic!("expected an element param application entry");
+        };
+        element_entry.variable.insert(mutable_fixed_size_array);
     }
 }
 
@@ -479,6 +689,8 @@ pub struct ApplicationInstance {
     /// The compute kind of the expressions related to the application instance.
     exprs: Vec<(ExprId, ComputeKind)>,
     pub unresolved_callee_exprs: Vec<ExprId>,
+    /// The local variable ids of any mutable fixed size arrays detected during analysis.
+    pub mutable_fixed_size_arrays: Vec<(StoreItemSpecializationKey, LocalVarId)>,
 }
 
 // Default starting capacities for the per-callable application instance data structures.
@@ -579,6 +791,7 @@ impl ApplicationInstance {
             stmts: Vec::with_capacity(INITIAL_STMTS_CAPACITY),
             exprs: Vec::with_capacity(INITIAL_EXPRS_CAPACITY),
             unresolved_callee_exprs: Vec::new(),
+            mutable_fixed_size_arrays: Vec::new(),
         }
     }
 
@@ -635,6 +848,7 @@ impl ApplicationInstance {
             exprs: self.exprs.into_iter().collect(),
             unresolved_callee_exprs: self.unresolved_callee_exprs,
             value_kind,
+            mutable_fixed_size_arrays: self.mutable_fixed_size_arrays,
         }
     }
 }
@@ -687,6 +901,7 @@ struct ApplicationInstanceComputeProperties {
     exprs: FxHashMap<ExprId, ComputeKind>,
     value_kind: Option<ValueKind>,
     unresolved_callee_exprs: Vec<ExprId>,
+    mutable_fixed_size_arrays: Vec<(StoreItemSpecializationKey, LocalVarId)>,
 }
 
 impl ApplicationInstanceComputeProperties {

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -23,8 +23,8 @@ use qsc_fir::{
         Attr, BinOp, Block, BlockId, CallableDecl, CallableImpl, CallableKind, Expr, ExprId,
         ExprKind, FieldAssign, Global, Ident, Item, ItemKind, LocalVarId, Mutability, Package,
         PackageId, PackageLookup, PackageStore, PackageStoreLookup, Pat, PatId, PatKind, Res,
-        SpecDecl, SpecImpl, Stmt, StmtId, StmtKind, StoreExprId, StoreItemId, StorePatId,
-        StringComponent,
+        SpecDecl, SpecImpl, Stmt, StmtId, StmtKind, StoreExprId, StoreItemId,
+        StoreItemSpecializationKey, StorePatId, StringComponent,
     },
     ty::{Arrow, FunctorSetValue, Prim, Ty},
     visit::{Visitor, walk_block, walk_expr, walk_stmt},
@@ -196,13 +196,27 @@ impl<'a> Analyzer<'a> {
         let mut default_value_kind = ValueKind::Constant;
         // If we are within a dynamic scope, the compute kind of the assign index expression must be variable and an additional
         // runtime feature is used to mark the array itself as dynamic.
-        if !application_instance.active_dynamic_scopes.is_empty() {
+        let mutable_fixed_size_array_key = if application_instance.active_dynamic_scopes.is_empty()
+        {
+            if replacement_value_compute_kind.is_variable_value_kind()
+                && self
+                    .target_capabilities
+                    .contains(TargetCapabilityFlags::StaticSizedArrays)
+            {
+                // Static sized arrays are supported, so generate a key to store this use of the variable as a mutable fixed-size array.
+                Some(self.get_item_specialization_key())
+            } else {
+                None
+            }
+        } else {
             default_value_kind = ValueKind::Variable;
             replacement_value_compute_kind.aggregate(ComputeKind::Dynamic {
                 runtime_features: RuntimeFeatureFlags::UseOfDynamicArray,
                 value_kind: ValueKind::Constant,
             });
-        }
+            // This update requires a dynamic array, so generate a key to store this as a mutable dynamic array.
+            Some(self.get_item_specialization_key())
+        };
 
         let mut updated_compute_kind = ComputeKind::Static;
         updated_compute_kind
@@ -223,6 +237,11 @@ impl<'a> Analyzer<'a> {
         application_instance
             .locals_map
             .aggregate_compute_kind(*local_var_id, updated_compute_kind);
+        if let Some(key) = mutable_fixed_size_array_key {
+            application_instance
+                .mutable_fixed_size_arrays
+                .push((key, *local_var_id));
+        }
 
         // The compute kind of this expression is determined by aggregating the runtime features of the index and
         // replacement expressions.
@@ -244,6 +263,20 @@ impl<'a> Analyzer<'a> {
             );
         }
         compute_kind
+    }
+
+    fn get_item_specialization_key(&mut self) -> StoreItemSpecializationKey {
+        match self.get_current_context() {
+            AnalysisContext::TopLevel(_) => StoreItemSpecializationKey::TopLevel,
+            AnalysisContext::Item(item_context) => (
+                item_context.id,
+                item_context
+                    .current_spec_context
+                    .as_ref()
+                    .map_or(FunctorSetValue::Empty, |s| s.functor_set_value),
+            )
+                .into(),
+        }
     }
 
     fn analyze_expr_bin_op(
@@ -1247,7 +1280,11 @@ impl<'a> Analyzer<'a> {
         let mut should_emit_classical_loop =
             self.should_emit_classical_loops() && !self.in_parallel_expr;
         let mut cached_locals_map = if should_emit_classical_loop {
-            Some(self.get_current_application_instance().locals_map.clone())
+            let application_instance = self.get_current_application_instance();
+            Some((
+                application_instance.locals_map.clone(),
+                application_instance.mutable_fixed_size_arrays.clone(),
+            ))
         } else {
             None
         };
@@ -1323,9 +1360,12 @@ impl<'a> Analyzer<'a> {
                 // Revert the calculated compute kinds and re-analyze marking the loop.
                 ClearComputeKinds::new(self).visit_expr(condition_expr_id);
                 ClearComputeKinds::new(self).visit_block(block_id);
-                self.get_current_application_instance_mut().locals_map = cached_locals_map.take().expect(
+                let (cached_locals_map, cached_mutable_fixed_size_arrays) = cached_locals_map.take().expect(
                     "cached locals map should exist when re-analyzing while loop with classical emission",
                 );
+                let application_instance = self.get_current_application_instance_mut();
+                application_instance.locals_map = cached_locals_map;
+                application_instance.mutable_fixed_size_arrays = cached_mutable_fixed_size_arrays;
                 should_emit_classical_loop = false;
             } else {
                 break (condition_expr_compute_kind, compute_kind);

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -22,6 +22,7 @@ use bitflags::bitflags;
 use indenter::indented;
 use qsc_data_structures::display::core::set_indentation;
 use qsc_data_structures::{index_map::IndexMap, target::TargetCapabilityFlags};
+use qsc_fir::fir::{LocalVarId, StoreItemSpecializationKey};
 use qsc_fir::{
     fir::{
         BlockId, ExprId, LocalItemId, PackageId, StmtId, StoreBlockId, StoreExprId, StoreItemId,
@@ -29,7 +30,7 @@ use qsc_fir::{
     },
     ty::Ty,
 };
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use std::{
     cmp::Ord,
@@ -144,6 +145,18 @@ impl PackageStoreComputeProperties {
             .unresolved_callee_exprs
             .contains(&id.expr)
     }
+
+    #[must_use]
+    pub fn get_mutable_fixed_size_array_entry(
+        &self,
+        key: StoreItemSpecializationKey,
+        package_id: PackageId,
+        parallel: bool,
+    ) -> Option<&MutableFixedSizeArraysEntry> {
+        self.get(package_id, parallel)
+            .mutable_fixed_size_arrays
+            .get(&key)
+    }
 }
 
 /// The compute properties of a package.
@@ -159,6 +172,9 @@ pub struct PackageComputeProperties {
     pub exprs: IndexMap<ExprId, ApplicationGeneratorSet>,
     /// The expressions that were unresolved callees at analysis time.
     pub unresolved_callee_exprs: FxHashSet<ExprId>,
+    /// The mutable fixed size arrays for each package item and specialization.
+    pub mutable_fixed_size_arrays:
+        FxHashMap<StoreItemSpecializationKey, MutableFixedSizeArraysEntry>,
 }
 
 impl Default for PackageComputeProperties {
@@ -169,6 +185,7 @@ impl Default for PackageComputeProperties {
             stmts: IndexMap::new(),
             exprs: IndexMap::new(),
             unresolved_callee_exprs: FxHashSet::default(),
+            mutable_fixed_size_arrays: FxHashMap::default(),
         }
     }
 }
@@ -206,18 +223,11 @@ impl Display for PackageComputeProperties {
 }
 
 impl PackageComputeProperties {
-    pub fn clear(&mut self) {
+    pub(crate) fn clear(&mut self) {
         self.items.clear();
         self.blocks.clear();
         self.stmts.clear();
         self.exprs.clear();
-    }
-
-    #[must_use]
-    pub fn get_block(&self, id: BlockId) -> &ApplicationGeneratorSet {
-        self.blocks
-            .get(id)
-            .expect("block compute properties not found")
     }
 
     #[must_use]
@@ -226,20 +236,32 @@ impl PackageComputeProperties {
             .get(id)
             .expect("expression compute properties not found")
     }
+}
 
-    #[must_use]
-    pub fn get_item(&self, id: LocalItemId) -> &ItemComputeProperties {
-        self.items
-            .get(id)
-            .expect("item compute properties not found")
-    }
+#[derive(Clone, Debug, Default)]
+pub struct MutableFixedSizeArraysEntry {
+    pub inherent: FxHashSet<LocalVarId>,
+    pub param_application: Vec<MutableFixedSizeArraysParamApplication>,
+}
 
-    #[must_use]
-    pub fn get_stmt(&self, id: StmtId) -> &ApplicationGeneratorSet {
-        self.stmts
-            .get(id)
-            .expect("statement compute properties not found")
-    }
+#[derive(Clone, Debug)]
+pub enum MutableFixedSizeArraysParamApplication {
+    None,
+    Element(MutableFixedSizeArraysElementApplication),
+    Array(MutableFixedSizeArraysArrayApplication),
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MutableFixedSizeArraysElementApplication {
+    pub constant: FxHashSet<LocalVarId>,
+    pub variable: FxHashSet<LocalVarId>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MutableFixedSizeArraysArrayApplication {
+    pub constant_content: FxHashSet<LocalVarId>,
+    pub static_size: FxHashSet<LocalVarId>,
+    pub dynamic_size: FxHashSet<LocalVarId>,
 }
 
 /// The compute properties of an item.
@@ -766,11 +788,7 @@ impl RuntimeFeatureFlags {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicArray) {
-            // capabilities |= TargetCapabilityFlags::StaticSizedArrays;
-
-            // For now, we are treating any dynamic array as requiriing higher level constructs,
-            // so that we can reject loops over arrays with dynamic contents.
-            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::StaticSizedArrays;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicallySizedArray) {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;

--- a/source/compiler/qsc_rca/src/scaffolding.rs
+++ b/source/compiler/qsc_rca/src/scaffolding.rs
@@ -3,17 +3,18 @@
 
 use crate::{
     ApplicationGeneratorSet, CallableComputeProperties, ComputePropertiesLookup,
-    ItemComputeProperties, PackageComputeProperties, PackageStoreComputeProperties,
-    common::GlobalSpecId,
+    ItemComputeProperties, MutableFixedSizeArraysEntry, PackageComputeProperties,
+    PackageStoreComputeProperties, common::GlobalSpecId,
 };
 use qsc_data_structures::index_map::IndexMap;
 use qsc_fir::{
     fir::{
         self, BlockId, ExprId, LocalItemId, PackageId, StmtId, StoreBlockId, StoreExprId,
-        StoreItemId, StoreStmtId,
+        StoreItemId, StoreItemSpecializationKey, StoreStmtId,
     },
     ty::FunctorSetValue,
 };
+use rustc_hash::FxHashMap;
 
 /// Scaffolding used to build the package store compute properties.
 #[derive(Debug)]
@@ -43,6 +44,10 @@ impl From<PackageStoreComputeProperties> for InternalPackageStoreComputeProperti
                     .unresolved_callee_exprs
                     .into_iter()
                     .collect(),
+                mutable_fixed_size_arrays: package_compute_properties
+                    .mutable_fixed_size_arrays
+                    .into_iter()
+                    .collect(),
             };
             scaffolding.insert(package_id, package_compute_properties);
         }
@@ -61,6 +66,10 @@ impl From<PackageStoreComputeProperties> for InternalPackageStoreComputeProperti
                 exprs: package_compute_properties.exprs,
                 unresolved_callee_exprs: package_compute_properties
                     .unresolved_callee_exprs
+                    .into_iter()
+                    .collect(),
+                mutable_fixed_size_arrays: package_compute_properties
+                    .mutable_fixed_size_arrays
                     .into_iter()
                     .collect(),
             };
@@ -94,6 +103,10 @@ impl From<InternalPackageStoreComputeProperties> for PackageStoreComputeProperti
                     .unresolved_callee_exprs
                     .into_iter()
                     .collect(),
+                mutable_fixed_size_arrays: package_scaffolding
+                    .mutable_fixed_size_arrays
+                    .into_iter()
+                    .collect(),
             };
             package_store_compute_properties.insert(package_id, package_compute_properties);
         }
@@ -113,6 +126,10 @@ impl From<InternalPackageStoreComputeProperties> for PackageStoreComputeProperti
                 exprs: package_scaffolding.exprs,
                 unresolved_callee_exprs: package_scaffolding
                     .unresolved_callee_exprs
+                    .into_iter()
+                    .collect(),
+                mutable_fixed_size_arrays: package_scaffolding
+                    .mutable_fixed_size_arrays
                     .into_iter()
                     .collect(),
             };
@@ -293,6 +310,9 @@ pub struct InternalPackageComputeProperties {
     pub exprs: IndexMap<ExprId, ApplicationGeneratorSet>,
     /// The expressions that were unresolved callees at analysis time.
     pub unresolved_callee_exprs: Vec<ExprId>,
+    /// The mutable fixed size arrays for each package item and specialization.
+    pub mutable_fixed_size_arrays:
+        FxHashMap<StoreItemSpecializationKey, MutableFixedSizeArraysEntry>,
 }
 
 /// Scaffolding used to build the compute properties of an item.

--- a/source/compiler/qsc_rir/src/passes/insert_alloca_load.rs
+++ b/source/compiler/qsc_rir/src/passes/insert_alloca_load.rs
@@ -110,6 +110,33 @@ fn add_alloca_load_to_block(
                 *next_var_id = next_var_id.successor();
                 continue;
             }
+            Instruction::CopyArray(src, dest) => {
+                vars_to_alloca.insert(dest.variable_id, *dest);
+                let new_src = map_or_load_variable(
+                    *src,
+                    &mut var_map,
+                    &mut block.0,
+                    next_var_id,
+                    vars_to_alloca.contains_key(src.variable_id),
+                );
+                block.0.push(Instruction::CopyArray(new_src, *dest));
+                // Drop the cached load for this variable so a later read in this
+                // block reloads the freshly stored value instead of a stale one.
+                var_map.remove(&dest.variable_id);
+                *next_var_id = next_var_id.successor();
+                continue;
+            }
+            Instruction::SliceArray(array, start, step, end, dest) => {
+                vars_to_alloca.insert(dest.variable_id, *dest);
+                block
+                    .0
+                    .push(Instruction::SliceArray(*array, *start, *step, *end, *dest));
+                // Drop the cached load for this variable so a later read in this
+                // block reloads the freshly stored value instead of a stale one.
+                var_map.remove(&dest.variable_id);
+                *next_var_id = next_var_id.successor();
+                continue;
+            }
 
             // Replace any arguments with the new values of stored variables.
             Instruction::Call(_, args, _, _) => {
@@ -203,6 +230,37 @@ fn add_alloca_load_to_block(
                     .0
                     .push(Instruction::Index(*array, *operand, *variable));
                 load_from_variable(variable, &mut var_map, &mut block.0, next_var_id);
+                // Continue here to avoid pushing the instruction again below.
+                continue;
+            }
+
+            // For array index updates, the array remains a pointer and does not need to be loaded, but we must
+            // update the index and value operands, immediately add the updated instruction, and store the result.
+            Instruction::StoreIndex(op1, op2, var) => {
+                let new_op1 = map_or_load_operand(
+                    op1,
+                    &mut var_map,
+                    &mut block.0,
+                    next_var_id,
+                    should_load_operand(op1, vars_to_alloca),
+                );
+                let new_op2 = map_or_load_operand(
+                    op2,
+                    &mut var_map,
+                    &mut block.0,
+                    next_var_id,
+                    should_load_operand(op2, vars_to_alloca),
+                );
+                let array_operand = Operand::Variable(*var);
+                let new_ptr_var = Variable {
+                    variable_id: *next_var_id,
+                    ty: new_op1.get_type(),
+                };
+                *next_var_id = next_var_id.successor();
+                block
+                    .0
+                    .push(Instruction::Index(array_operand, new_op2, new_ptr_var));
+                block.0.push(Instruction::Store(new_op1, new_ptr_var));
                 // Continue here to avoid pushing the instruction again below.
                 continue;
             }

--- a/source/compiler/qsc_rir/src/passes/prune_unneeded_stores.rs
+++ b/source/compiler/qsc_rir/src/passes/prune_unneeded_stores.rs
@@ -33,20 +33,20 @@ fn process_callable(program: &mut Program, callable_id: CallableId) {
     while let Some(block_id) = blocks_to_visit.pop() {
         visited_blocks.insert(block_id);
         let mut used_vars_in_block = FxHashSet::default();
-        let mut index_vars_in_block = FxHashSet::default();
+        let mut must_keep_vars_in_block = FxHashSet::default();
         let stored_vars_before_block = stored_vars.clone();
         check_var_usage(
             program,
             block_id,
             &mut stored_vars,
             &mut used_vars_in_block,
-            &mut index_vars_in_block,
+            &mut must_keep_vars_in_block,
         );
 
         for var in used_vars_in_block {
             if !used_vars.insert(var)
                 || stored_vars_before_block.contains(&var)
-                || index_vars_in_block.contains(&var)
+                || must_keep_vars_in_block.contains(&var)
             {
                 // This variable was already marked as used, which means it is used cross-block.
                 // Alternatively, the variable was stored before this block and is used here.
@@ -105,7 +105,7 @@ fn check_var_usage(
     block_id: crate::rir::BlockId,
     stored_vars: &mut FxHashSet<VariableId>,
     used_vars: &mut FxHashSet<VariableId>,
-    index_vars: &mut FxHashSet<VariableId>,
+    must_keep_vars: &mut FxHashSet<VariableId>,
 ) {
     let block = program.get_block(block_id);
     for instr in &block.0 {
@@ -123,6 +123,21 @@ fn check_var_usage(
                     }
                 }
                 stored_vars.insert(variable.variable_id);
+            }
+            Instruction::StoreIndex(value, index, variable) => {
+                if let crate::rir::Operand::Variable(var) = value {
+                    used_vars.insert(var.variable_id);
+                }
+                if let crate::rir::Operand::Variable(var) = index {
+                    used_vars.insert(var.variable_id);
+                    must_keep_vars.insert(var.variable_id);
+                }
+                stored_vars.insert(variable.variable_id);
+            }
+            Instruction::CopyArray(src, dest) | Instruction::SliceArray(src, _, _, _, dest) => {
+                used_vars.insert(src.variable_id);
+                must_keep_vars.insert(src.variable_id);
+                stored_vars.insert(dest.variable_id);
             }
 
             Instruction::Call(_, operands, variable, _) => {
@@ -188,7 +203,7 @@ fn check_var_usage(
                 }
                 if let crate::rir::Operand::Variable(var) = index_operand {
                     used_vars.insert(var.variable_id);
-                    index_vars.insert(var.variable_id);
+                    must_keep_vars.insert(var.variable_id);
                 }
                 assert!(
                     !stored_vars.contains(&variable2.variable_id),

--- a/source/compiler/qsc_rir/src/passes/ssa_check.rs
+++ b/source/compiler/qsc_rir/src/passes/ssa_check.rs
@@ -253,9 +253,12 @@ fn get_variable_uses(program: &Program) -> IndexMap<VariableId, Vec<(BlockId, us
                 }
 
                 Instruction::StoreArray(..)
+                | Instruction::StoreIndex(..)
                 | Instruction::Alloca(..)
                 | Instruction::Load(..)
-                | Instruction::Index(..) => {
+                | Instruction::Index(..)
+                | Instruction::CopyArray(..)
+                | Instruction::SliceArray(..) => {
                     panic!("Unexpected advanced instruction at {block_id:?}, instruction {idx}")
                 }
             }

--- a/source/compiler/qsc_rir/src/passes/type_check.rs
+++ b/source/compiler/qsc_rir/src/passes/type_check.rs
@@ -14,6 +14,7 @@ pub fn check_types(program: &Program) {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn check_instr_types(program: &Program, instr: &Instruction) {
     match instr {
         Instruction::Call(id, args, var, _) => {
@@ -97,6 +98,35 @@ fn check_instr_types(program: &Program, instr: &Instruction) {
                     "expected operand type to match array element type"
                 );
             }
+        }
+        Instruction::StoreIndex(value, index, var) => {
+            let Ty::Array(_, elem_ty) = &var.ty else {
+                panic!("expected variable to be of array type");
+            };
+            assert_eq!(index.get_type(), Ty::Prim(Prim::Integer));
+            assert_eq!(value.get_type(), Ty::Prim(*elem_ty));
+        }
+        Instruction::CopyArray(src, dest) => {
+            assert_eq!(
+                src.ty, dest.ty,
+                "expected source and destination arrays to have the same type"
+            );
+        }
+        Instruction::SliceArray(array, start, step, end, var) => {
+            let Ty::Array(slice_size, elem_ty) = &var.ty else {
+                panic!("expected variable to be of array type");
+            };
+            let Ty::Array(_, array_elem_ty) = &array.ty else {
+                panic!("expected array to be of array type");
+            };
+            assert_eq!(array_elem_ty, elem_ty);
+            assert_eq!(
+                *slice_size,
+                ((end - start + step) / step)
+                    .max(0)
+                    .try_into()
+                    .expect("computed slice size should fit into i64")
+            );
         }
 
         Instruction::Convert(_, _)

--- a/source/compiler/qsc_rir/src/rir.rs
+++ b/source/compiler/qsc_rir/src/rir.rs
@@ -377,6 +377,7 @@ impl Display for FcmpConditionCode {
 pub enum Instruction {
     Store(Operand, Variable),
     StoreArray(Vec<Operand>, Variable),
+    StoreIndex(Operand, Operand, Variable),
     Call(
         CallableId,
         Vec<Operand>,
@@ -416,6 +417,8 @@ pub enum Instruction {
     Load(Variable, Variable),
     Alloca(Variable),
     Index(Operand, Operand, Variable),
+    CopyArray(Variable, Variable),
+    SliceArray(Variable, i64, i64, i64, Variable),
     Return(Option<Operand>),
 }
 
@@ -430,11 +433,16 @@ impl Instruction {
 }
 
 impl Display for Instruction {
+    #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self {
             Self::Store(value, variable) => write_unary_instruction(f, "Store", value, *variable)?,
             Self::StoreArray(value, variable) => {
                 write_store_array_instruction(f, value, *variable)?;
+            }
+            Self::StoreIndex(value, index, array_var) => {
+                let mut indent = set_indentation(indented(f), 0);
+                write!(indent, "StoreIndex {value}, {index}, {array_var}")?;
             }
             Self::Jump(block_id) => write!(f, "Jump({})", block_id.0)?,
             Self::Call(callable_id, args, variable, metadata) => {
@@ -523,6 +531,17 @@ impl Display for Instruction {
             Self::Index(array_var, index_opr, result_var) => {
                 let mut indent = set_indentation(indented(f), 0);
                 write!(indent, "{result_var} = Index {array_var}, {index_opr}")?;
+            }
+            Self::CopyArray(source_array, dest_array) => {
+                let mut indent = set_indentation(indented(f), 0);
+                write!(indent, "{dest_array} = CopyArray {source_array}")?;
+            }
+            Self::SliceArray(array_var, start, step, end, result_var) => {
+                let mut indent = set_indentation(indented(f), 0);
+                write!(
+                    indent,
+                    "{result_var} = SliceArray {array_var}, {start}, {step}, {end}"
+                )?;
             }
             Self::Return(None) => write!(f, "Return")?,
             Self::Return(Some(operand)) => write!(f, "Return {operand}")?,

--- a/source/compiler/qsc_rir/src/utils.rs
+++ b/source/compiler/qsc_rir/src/utils.rs
@@ -111,9 +111,12 @@ pub fn get_variable_assignments(program: &Program) -> IndexMap<VariableId, (Bloc
                 }
                 Instruction::Store(_, var)
                 | Instruction::StoreArray(_, var)
+                | Instruction::StoreIndex(_, _, var)
                 | Instruction::Alloca(var)
                 | Instruction::Load(_, var)
-                | Instruction::Index(_, _, var) => {
+                | Instruction::Index(_, _, var)
+                | Instruction::CopyArray(_, var)
+                | Instruction::SliceArray(_, _, _, _, var) => {
                     has_store = true;
                     assignments.insert(var.variable_id, (block_id, idx));
                 }
@@ -165,6 +168,24 @@ pub(crate) fn map_variable_use_in_block(
                         .collect::<Vec<_>>();
                 } else {
                     // Otherwise drop the store array by continuing the loop.
+                    continue;
+                }
+            }
+            Instruction::StoreIndex(value, index, var) => {
+                if var_stor_to_keep.contains(&var.variable_id) {
+                    // Only keep stores to variables that are in the set to keep.
+                    *value = value.mapped(var_map);
+                    *index = index.mapped(var_map);
+                } else {
+                    // Otherwise drop the store index by continuing the loop.
+                    continue;
+                }
+            }
+            Instruction::CopyArray(src, dest) | Instruction::SliceArray(src, _, _, _, dest) => {
+                if var_stor_to_keep.contains(&dest.variable_id) {
+                    *src = src.map_to_variable(var_map);
+                } else {
+                    // Otherwise drop the copy array by continuing the loop.
                     continue;
                 }
             }

--- a/source/qdk_package/tests-integration/resources/adaptive/input/MutableArrays.qs
+++ b/source/qdk_package/tests-integration/resources/adaptive/input/MutableArrays.qs
@@ -1,0 +1,13 @@
+namespace Test {
+    import Std.Convert.ResultArrayAsBoolArray;
+    operation Main() : Bool[] {
+        use qs = Qubit[3];
+        ApplyToEach(X, qs);
+        mutable arr = [false, size = Length(qs) + 1];
+        let res = ResultArrayAsBoolArray(MResetEachZ(qs));
+        for i in 0..Length(res)-1 {
+            arr[i + 1] = res[i];
+        }
+        arr[1..2...]
+    }
+}

--- a/source/qdk_package/tests-integration/resources/adaptive/output/MutableArrays.ll
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/MutableArrays.ll
@@ -1,0 +1,142 @@
+@0 = internal constant [4 x i8] c"0_a\00"
+@1 = internal constant [6 x i8] c"1_a0b\00"
+@2 = internal constant [6 x i8] c"2_a1b\00"
+@array0 = internal constant [3 x ptr] [ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 2 to ptr)]
+
+define i64 @ENTRYPOINT__main() #0 {
+block_0:
+  %var_1 = alloca i64
+  %var_7 = alloca [4 x i1]
+  %var_16 = alloca [3 x i1]
+  %var_17 = alloca i64
+  %var_19 = alloca i1
+  %var_21 = alloca i64
+  %var_24 = alloca [2 x i1]
+  %var_25 = alloca [2 x i1]
+  call void @__quantum__rt__initialize(ptr null)
+  store i64 0, ptr %var_1
+  br label %block_1
+block_1:
+  %var_29 = load i64, ptr %var_1
+  %var_2 = icmp slt i64 %var_29, 3
+  br i1 %var_2, label %block_2, label %block_3
+block_2:
+  %var_48 = load i64, ptr %var_1
+  %var_3_offset_chk = icmp slt i64 %var_48, 0
+  %var_3_offset = select i1 %var_3_offset_chk, i64 1, i64 0
+  %var_3 = getelementptr [3 x ptr], ptr @array0, i64 %var_3_offset, i64 %var_48
+  %var_49 = load ptr, ptr %var_3
+  call void @X(ptr %var_49)
+  %var_6 = add i64 %var_48, 1
+  store i64 %var_6, ptr %var_1
+  br label %block_1
+block_3:
+  %var_7_0 = getelementptr [4 x i1], ptr %var_7, i64 0, i64 0
+  store i1 false, ptr %var_7_0
+  %var_7_1 = getelementptr [4 x i1], ptr %var_7, i64 0, i64 1
+  store i1 false, ptr %var_7_1
+  %var_7_2 = getelementptr [4 x i1], ptr %var_7, i64 0, i64 2
+  store i1 false, ptr %var_7_2
+  %var_7_3 = getelementptr [4 x i1], ptr %var_7, i64 0, i64 3
+  store i1 false, ptr %var_7_3
+  call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 0 to ptr), ptr inttoptr (i64 0 to ptr))
+  call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__qis__mresetz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
+  %var_10 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 0 to ptr))
+  %var_12 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 1 to ptr))
+  %var_14 = call i1 @__quantum__rt__read_result(ptr inttoptr (i64 2 to ptr))
+  %var_16_0 = getelementptr [3 x i1], ptr %var_16, i64 0, i64 0
+  store i1 %var_10, ptr %var_16_0
+  %var_16_1 = getelementptr [3 x i1], ptr %var_16, i64 0, i64 1
+  store i1 %var_12, ptr %var_16_1
+  %var_16_2 = getelementptr [3 x i1], ptr %var_16, i64 0, i64 2
+  store i1 %var_14, ptr %var_16_2
+  store i64 0, ptr %var_17
+  br label %block_4
+block_4:
+  %var_33 = load i64, ptr %var_17
+  %var_18 = icmp sle i64 %var_33, 2
+  store i1 true, ptr %var_19
+  br i1 %var_18, label %block_5, label %block_6
+block_5:
+  %var_36 = load i1, ptr %var_19
+  br i1 %var_36, label %block_7, label %block_8
+block_6:
+  store i1 false, ptr %var_19
+  br label %block_5
+block_7:
+  %var_42 = load i64, ptr %var_17
+  %var_20 = add i64 %var_42, 1
+  store i64 %var_20, ptr %var_21
+  %var_22_offset_chk = icmp slt i64 %var_42, 0
+  %var_22_offset = select i1 %var_22_offset_chk, i64 1, i64 0
+  %var_22 = getelementptr [3 x i1], ptr %var_16, i64 %var_22_offset, i64 %var_42
+  %var_44 = load i1, ptr %var_22
+  %var_45 = load i64, ptr %var_21
+  %var_46_offset_chk = icmp slt i64 %var_45, 0
+  %var_46_offset = select i1 %var_46_offset_chk, i64 1, i64 0
+  %var_46 = getelementptr [4 x i1], ptr %var_7, i64 %var_46_offset, i64 %var_45
+  store i1 %var_44, ptr %var_46
+  %var_23 = add i64 %var_42, 1
+  store i64 %var_23, ptr %var_17
+  br label %block_4
+block_8:
+  %var_24_0_src = getelementptr [4 x i1], ptr %var_7, i64 0, i64 1
+  %var_24_0 = load i1, ptr %var_24_0_src
+  %var_24_0_dst = getelementptr [2 x i1], ptr %var_24, i64 0, i64 0
+  store i1 %var_24_0, ptr %var_24_0_dst
+  %var_24_1_src = getelementptr [4 x i1], ptr %var_7, i64 0, i64 3
+  %var_24_1 = load i1, ptr %var_24_1_src
+  %var_24_1_dst = getelementptr [2 x i1], ptr %var_24, i64 0, i64 1
+  store i1 %var_24_1, ptr %var_24_1_dst
+  %var_38 = load [2 x i1], ptr %var_24
+  store [2 x i1] %var_38, ptr %var_25
+  %var_26_offset_chk = icmp slt i64 0, 0
+  %var_26_offset = select i1 %var_26_offset_chk, i64 1, i64 0
+  %var_26 = getelementptr [2 x i1], ptr %var_25, i64 %var_26_offset, i64 0
+  %var_40 = load i1, ptr %var_26
+  %var_27_offset_chk = icmp slt i64 1, 0
+  %var_27_offset = select i1 %var_27_offset_chk, i64 1, i64 0
+  %var_27 = getelementptr [2 x i1], ptr %var_25, i64 %var_27_offset, i64 1
+  %var_41 = load i1, ptr %var_27
+  call void @__quantum__rt__array_record_output(i64 2, ptr @0)
+  call void @__quantum__rt__bool_record_output(i1 %var_40, ptr @1)
+  call void @__quantum__rt__bool_record_output(i1 %var_41, ptr @2)
+  ret i64 0
+}
+
+declare void @__quantum__rt__initialize(ptr)
+
+define internal void @X(ptr %var_5) {
+block_9:
+  call void @__quantum__qis__x__body(ptr %var_5)
+  ret void
+}
+
+declare void @__quantum__qis__x__body(ptr)
+
+declare void @__quantum__qis__mresetz__body(ptr, ptr) #1
+
+declare i1 @__quantum__rt__read_result(ptr) #2
+
+declare void @__quantum__rt__array_record_output(i64, ptr)
+
+declare void @__quantum__rt__bool_record_output(i1, ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
+attributes #1 = { "irreversible" }
+attributes #2 = { nofree nosync nounwind willreturn memory(argmem: read) }
+
+; module flags
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8}
+
+!0 = !{i32 1, !"qir_major_version", i32 2}
+!1 = !{i32 7, !"qir_minor_version", i32 1}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+!4 = !{i32 5, !"int_computations", !{!"i64"}}
+!5 = !{i32 5, !"float_computations", !{!"double"}}
+!6 = !{i32 7, !"backwards_branching", i2 3}
+!7 = !{i32 1, !"arrays", i1 true}
+!8 = !{i32 1, !"ir_functions", i1 true}

--- a/source/qdk_package/tests-integration/resources/adaptive/output/MutableArrays.out
+++ b/source/qdk_package/tests-integration/resources/adaptive/output/MutableArrays.out
@@ -1,0 +1,10 @@
+START
+METADATA	entry_point
+METADATA	output_labeling_schema
+METADATA	qir_profiles	adaptive_profile
+METADATA	required_num_qubits	3
+METADATA	required_num_results	3
+OUTPUT	ARRAY	2	0_a
+OUTPUT	BOOL	true	1_a0b
+OUTPUT	BOOL	true	2_a1b
+END	0


### PR DESCRIPTION
This change adds support for mutable fixed size arrays in Adaptive Profile. It adds new RIR instructions to correspond to array copy, slice, and store index instructions and updates Partial Evaluation to emit these instructions when needed. To minimize extraneous propagation of variables and only emit the new instructions when required by the program, the implementation carefully tracks the usage of mutable fixed size arrays throughout the program, the change also updates Runtime Capabilities Analysis to mark those arrays who are dynamically updated and propagate those results as part of analysis. This allows Partial Eval to identify these arrays when they are initialized and emit the expected store instructions, tracking the resulting variable rather than the array contents (since emitting at first array update is too late). The new instructions generate multiple lines of QIR each, rather than emitting to a loop, to preserve block linearity and avoid introducing new control flow where it is unexpected. Changes are validated in Partial Eval and Codegen unit tests, as well as Python integration testing.